### PR TITLE
Build only on Linux and Darwin

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,15 +11,9 @@ builds:
     goos:
       - linux
       - darwin
-      - windows
     goarch:
       - amd64
-      - arm
       - arm64
-      - 386
-    ignore:
-      - goos: darwin
-        goarch: 386
 
 dockers:
   - goos: linux


### PR DESCRIPTION
**Description:**
This PR updates gorealaser file to build Kangal only for Linux and Darwin (amd, arm) platforms.