### PR TITLE
Update Kangal chart readme and fix chart path

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,4 +29,4 @@ dockers:
 
 release:
   extra_files:
-  - glob: kangal/crd.yaml
+  - glob: charts/kangal/crd.yaml

--- a/charts/kangal/README.md
+++ b/charts/kangal/README.md
@@ -3,9 +3,8 @@
 [Kangal](https://github.com/hellofresh/kangal) is a tool to spin up an isolated environment in a Kubernetes cluster to run performance tests using JMeter
 
 ## TL;DR;
-!!! **TODO:** change repo after migration to hub.helm.sh
 ```console
-$ helm repo add hf-charts https://
+$ helm repo add kangal https://hellofresh.github.io/kangal/
 $ helm install kangal
 ```
 


### PR DESCRIPTION
**Description**
EES - 132
This PR updates README on Kangal chart by adding instructions on how to fetch Kangal helm package. I also found that we missed one chart path update on goreleaser.