### PR TITLE
Update Kangal cluster role and additionalPrinterColumns

### DIFF
--- a/charts/kangal/Chart.yaml
+++ b/charts/kangal/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - performance tests
   - tests runner
 name: kangal
-version: 1.0.2
+version: 1.0.3
 home: https://github.com/hellofresh/kangal
 icon: https://raw.githubusercontent.com/hellofresh/kangal/master/kangal_logo.svg
 maintainers:

--- a/charts/kangal/crd.yaml
+++ b/charts/kangal/crd.yaml
@@ -24,6 +24,9 @@ spec:
           type: string
           description: The current phase of the loadtest
           jsonPath: .status.phase
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
       # subresources describes the subresources for custom resources.
       subresources:
         # status enables the status subresource.

--- a/charts/kangal/templates/clusterrole.yaml
+++ b/charts/kangal/templates/clusterrole.yaml
@@ -21,6 +21,7 @@ rules:
     resources:
       - loadtests
     verbs:
+      - update
       - create
       - get
       - watch


### PR DESCRIPTION
**Description:**
ES - 4110
Current CRD configuration misses `Age` attribute to show how long the load test resource exists. It also misses a cluster role 
to update LoadTest resource.

```
k get lt
NAME                   TYPE     PHASE      AGE
loadtest-funky-bison   JMeter   finished   8d
```