### PR TITLE
Refactor unit tests in proxy pkg

### DIFF
--- a/pkg/proxy/jmeter.go
+++ b/pkg/proxy/jmeter.go
@@ -1,10 +1,12 @@
 package proxy
 
 import (
+	"bytes"
 	"crypto/sha1"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -182,6 +184,23 @@ func getDistributedPods(r *http.Request) (int32, error) {
 	}
 
 	return int32(dn), nil
+}
+
+//fileToString converts file to string
+func fileToString(f io.ReadCloser) (string, error) {
+	buf := new(bytes.Buffer)
+	if _, err := buf.ReadFrom(f); err != nil {
+		return "", err
+	}
+
+	defer f.Close()
+	s := buf.String()
+
+	if len(s) == 0 {
+		return "", ErrFileToStringEmpty
+	}
+
+	return s, nil
 }
 
 // ToLoadTest converts cr structure to LoadTest

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"strings"
 
 	"github.com/go-chi/chi"
 	"github.com/go-chi/render"
@@ -221,38 +220,6 @@ func (p *Proxy) GetLogs(w http.ResponseWriter, r *http.Request) {
 
 	io.WriteString(w, string(logs))
 	return
-}
-
-//fileToString converts file to string
-func fileToString(f io.ReadCloser) (string, error) {
-	buf := new(bytes.Buffer)
-	if _, err := buf.ReadFrom(f); err != nil {
-		return "", err
-	}
-
-	defer f.Close()
-	s := buf.String()
-
-	if len(s) == 0 {
-		return "", ErrFileToStringEmpty
-	}
-
-	return s, nil
-}
-
-//convertTestName converts testfile name to valid LoadTest object name
-//example: my_load_test.jmx to my-load-test
-func convertTestName(n string) string {
-	noSuffix := strings.TrimSuffix(n, ".jmx")
-
-	tf := strings.ToLower(noSuffix)
-
-	if strings.Contains(tf, "_") {
-		nu := strings.ReplaceAll(tf, "_", "-")
-		return nu
-	}
-
-	return tf
 }
 
 func doRequest(req *restClient.Request) ([]byte, error) {


### PR DESCRIPTION
1 - removed unused func `convertTestName` from proxy.go
2 - moved `fileToString` from proxy.go to jmeter.go where it's actually used
3 - moved test related to `loadTest.validate()` from proxy_test.go to jmeter_test.go
4 - restructured and extended existing unit tests for proxy.go and jmeter.go 