### PR TITLE
Conflict object catch

### DIFF
--- a/pkg/controller/loadtest.go
+++ b/pkg/controller/loadtest.go
@@ -289,10 +289,10 @@ func (c *Controller) syncHandler(key string) error {
 			return nil
 		}
 
-		// The LoadTest resource may be invalid, in which case we stop
+		// The LoadTest resource may be conflicted, in which case we stop
 		// processing.
-		if errors.IsInvalid(err) {
-			utilRuntime.HandleError(fmt.Errorf("loadtest '%s' is an ivalid object.It might be deleted.", key))
+		if errors.IsConflict(err) {
+			utilRuntime.HandleError(fmt.Errorf("There is a conflict with loadtest '%s'. It might be because object has been removed or modified in the datastore.", key))
 			return nil
 		}
 		return err

--- a/pkg/controller/loadtest.go
+++ b/pkg/controller/loadtest.go
@@ -288,6 +288,13 @@ func (c *Controller) syncHandler(key string) error {
 			utilRuntime.HandleError(fmt.Errorf("loadtest '%s' in work queue no longer exists", key))
 			return nil
 		}
+
+		// The LoadTest resource may be invalid, in which case we stop
+		// processing.
+		if errors.IsInvalid(err) {
+			utilRuntime.HandleError(fmt.Errorf("loadtest '%s' is an ivalid object.It might be deleted.", key))
+			return nil
+		}
 		return err
 	}
 	// copy object before mutate it

--- a/pkg/controller/loadtest.go
+++ b/pkg/controller/loadtest.go
@@ -292,7 +292,7 @@ func (c *Controller) syncHandler(key string) error {
 		// The LoadTest resource may be conflicted, in which case we stop
 		// processing.
 		if errors.IsConflict(err) {
-			utilRuntime.HandleError(fmt.Errorf("There is a conflict with loadtest '%s'. It might be because object has been removed or modified in the datastore", key))
+			utilRuntime.HandleError(fmt.Errorf("there is a conflict with loadtest '%s' between datastore and cache. it might be because object has been removed or modified in the datastore", key))
 			return nil
 		}
 		return err
@@ -336,10 +336,9 @@ func (c *Controller) syncHandler(key string) error {
 		// The LoadTest resource may be conflicted, in which case we stop
 		// processing.
 		if errors.IsConflict(err) {
-			utilRuntime.HandleError(fmt.Errorf("There is a conflict with loadtest '%s'. It might be because object has been removed or modified in the datastore", key))
+			utilRuntime.HandleError(fmt.Errorf("there is a conflict with loadtest '%s' between datastore and cache. it might be because object has been removed or modified in the datastore", key))
 			return nil
 		}
-
 		return err
 	}
 
@@ -349,10 +348,9 @@ func (c *Controller) syncHandler(key string) error {
 		// The LoadTest resource may be conflicted, in which case we stop
 		// processing.
 		if errors.IsConflict(err) {
-			utilRuntime.HandleError(fmt.Errorf("There is a conflict with loadtest '%s'. It might be because object has been removed or modified in the datastore", key))
+			utilRuntime.HandleError(fmt.Errorf("the loadtest '%s'has been modified; please apply your changes to the latest version and try again", key))
 			return nil
 		}
-
 		return err
 	}
 

--- a/pkg/controller/loadtest.go
+++ b/pkg/controller/loadtest.go
@@ -292,7 +292,7 @@ func (c *Controller) syncHandler(key string) error {
 		// The LoadTest resource may be conflicted, in which case we stop
 		// processing.
 		if errors.IsConflict(err) {
-			utilRuntime.HandleError(fmt.Errorf("There is a conflict with loadtest '%s'. It might be because object has been removed or modified in the datastore.", key))
+			utilRuntime.HandleError(fmt.Errorf("There is a conflict with loadtest '%s'. It might be because object has been removed or modified in the datastore", key))
 			return nil
 		}
 		return err
@@ -333,12 +333,26 @@ func (c *Controller) syncHandler(key string) error {
 	// check or clean LoadTest
 	err = c.checkOrDeleteLoadTest(ctx, loadTest)
 	if err != nil {
+		// The LoadTest resource may be conflicted, in which case we stop
+		// processing.
+		if errors.IsConflict(err) {
+			utilRuntime.HandleError(fmt.Errorf("There is a conflict with loadtest '%s'. It might be because object has been removed or modified in the datastore", key))
+			return nil
+		}
+
 		return err
 	}
 
 	// Finally, we send updated loadtest resource back
 	_, err = c.kangalClientSet.KangalV1().LoadTests().Update(ctx, loadTest, metaV1.UpdateOptions{})
 	if err != nil {
+		// The LoadTest resource may be conflicted, in which case we stop
+		// processing.
+		if errors.IsConflict(err) {
+			utilRuntime.HandleError(fmt.Errorf("There is a conflict with loadtest '%s'. It might be because object has been removed or modified in the datastore", key))
+			return nil
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
When controller deletes load test it tries to send object back to Kubernetes but obviously if fails:

```
{"level":"info","ts":"2020-09-21T09:49:22.581Z","caller":"controller/loadtest.go:408","msg":"Deleting loadtest","type":"kangal","loadtest":"loadtest-wintering-camel","phase":"finished"}{"level":"error","ts":"2020-09-21T09:49:22.606Z","caller":"controller/loadtest.go:252","msg":"error syncing loadtest, re-queuing","type":"kangal","loadtest":"loadtest-wintering-camel","error":"Operation cannot be fulfilled on loadtests.kangal.hellofresh.com "loadtest-wintering-camel": StorageError: invalid object, Code: 4, Key: /registry/kangal.hellofresh.com/loadtests/loadtest-wintering-camel, ResourceVersion: 0, AdditionalErrorMsg: Precondition failed: UID in precondition: dec01d29-24ad-4e51-8606-5dd99f314cc1, UID in object meta: ","stacktrace":"github.com/hellofresh/kangal/pkg/controller.(*Controller).processNextWorkItem.func1\n\t/home/runner/work/kangal/kangal/pkg/controller/loadtest.go:252\ngithub.com/hellofresh/kangal/pkg/controller.(*Controller).processNextWorkItem\n\t/home/runner/work/kangal/kangal/pkg/controller/loadtest.go:260\ngithub.com/hellofresh/kangal/pkg/controller.(*Controller).runWorker\n\t/home/runner/work/kangal/kangal/pkg/controller/loadtest.go:195\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/runner/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/runner/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/runner/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/runner/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:90"}
```

This error happens because of the workerqueue cache. Sometimes a CR has been deleted by proxy but it might be in the workerqueue cache. And for this reason, controller throws `Operation cannot be fulfilled on...` error to indicate the item can't be updated as provided. That might because item has been updated or deleted and cache is different than the object store.

This PR blocks to throwing an error but simply skipping.