### PR TITLE
update charts README.md with crd installation instructions

### DIFF
--- a/charts/kangal/Chart.yaml
+++ b/charts/kangal/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - performance tests
   - tests runner
 name: kangal
-version: 1.0.3
+version: 1.0.4
 home: https://github.com/hellofresh/kangal
 icon: https://raw.githubusercontent.com/hellofresh/kangal/master/kangal_logo.svg
 maintainers:

--- a/charts/kangal/README.md
+++ b/charts/kangal/README.md
@@ -6,6 +6,7 @@
 ```console
 $ helm repo add kangal https://hellofresh.github.io/kangal
 $ helm install kangal/kangal --name kangal
+$ kubectl apply -f  https://raw.githubusercontent.com/hellofresh/kangal/master/charts/kangal/crd.yaml
 ```
 
 ## Introduction
@@ -23,9 +24,11 @@ To install the chart with the release name `kangal` and specific [Kangal version
 ```console
 $ helm repo add kangal https://hellofresh.github.io/kangal
 $ helm install --name kangal --set proxy.image.tag=1.0.0 --set controller.image.tag=1.0.0 kangal/kangal
+$ kubectl apply -f  https://raw.githubusercontent.com/hellofresh/kangal/master/charts/kangal/crd.yaml
 ```
 
 The command deploys Kangal on the Kubernetes cluster in the default configuration.
+It also applies the latest version of Custom Resource Definition (CRD) to the cluster.
 
 > **Tip**: List all releases using `helm list`
 
@@ -34,6 +37,7 @@ To uninstall/delete the `kangal` deployment:
 
 ```console
 $ helm delete kangal
+$ kubectl delete crd loadtests.kangal.hellofresh.com
 ```
 
 ## Configuration


### PR DESCRIPTION
EES-4125
Since we're using Helm v2 and it doesn't support an elegant way of managing CRDs, we update the README with recommendations to apply CRD in the Kubernetes cluster manually.