### PR TITLE
Adjust jmeter resource requests

### DIFF
--- a/pkg/backends/jmeter/resources.go
+++ b/pkg/backends/jmeter/resources.go
@@ -204,8 +204,8 @@ func (c *JMeter) NewPod(i int, configMap *coreV1.ConfigMap, podAnnotations map[s
 					},
 					Resources: coreV1.ResourceRequirements{
 						Requests: map[coreV1.ResourceName]resource.Quantity{
-							coreV1.ResourceMemory: resource.MustParse("4Gi"),
-							coreV1.ResourceCPU:    resource.MustParse("1000m"),
+							coreV1.ResourceMemory: resource.MustParse("500Mi"),
+							coreV1.ResourceCPU:    resource.MustParse("250m"),
 						},
 						Limits: map[coreV1.ResourceName]resource.Quantity{
 							coreV1.ResourceMemory: resource.MustParse("4Gi"),
@@ -325,8 +325,8 @@ func (c *JMeter) NewJMeterMasterJob(awsAccessKeyID, awsSecretAccessKey, awsRegio
 							},
 							Resources: coreV1.ResourceRequirements{
 								Requests: map[coreV1.ResourceName]resource.Quantity{
-									coreV1.ResourceMemory: resource.MustParse("4Gi"),
-									coreV1.ResourceCPU:    resource.MustParse("1000m"),
+									coreV1.ResourceMemory: resource.MustParse("500Mi"),
+									coreV1.ResourceCPU:    resource.MustParse("250m"),
 								},
 								Limits: map[coreV1.ResourceName]resource.Quantity{
 									coreV1.ResourceMemory: resource.MustParse("4Gi"),

--- a/pkg/controller/jmeter_integration_test.go
+++ b/pkg/controller/jmeter_integration_test.go
@@ -122,9 +122,12 @@ func TestIntegrationJMeter(t *testing.T) {
 
 	t.Run("Checking master pod is created", func(t *testing.T) {
 		var master coreV1.PodList
-		for i := 0; i < 5; i++ {
+		for i := 0; i < 60; i++ {
 			WaitForResource(ShortWaitSec)
 			master, _ = GetMasterPod(client.CoreV1(), expectedLoadtestName)
+			if len(master.Items) < 1 {
+				continue
+			}
 			if master.Items[0].Status.Phase == "Running" {
 				break
 			}

--- a/pkg/controller/jmeter_integration_test.go
+++ b/pkg/controller/jmeter_integration_test.go
@@ -34,7 +34,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationJMeter(t *testing.T) {
-	t.Skip("Skipping JMeter integration tests")
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}


### PR DESCRIPTION
This PR re-enables jmeter integration test and adjusts memory request on each container to allow integration test with Github Actions (as there is a 7GB memory limit).