### PR TITLE
Add config to adjust JMeter pod resource limits and requests

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -54,14 +54,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
 
-      - name: Run Unit tests
-        run: |
-          make test-unit
-
       - name: Setup Golang
         uses: actions/setup-go@v2
         with:
           go-version: '^1.15'
+
+      - name: Run Unit tests
+        run: |
+          make test-unit
 
       - name: Setup Kind
         uses: engineerd/setup-kind@v0.4.0

--- a/ci/integration-tests.sh
+++ b/ci/integration-tests.sh
@@ -4,6 +4,16 @@ set -e
 export AWS_ACCESS_KEY_ID=""
 export AWS_SECRET_ACCESS_KEY=""
 
+# Adjust resource requests and limits
+#export JMETER_MASTER_CPU_LIMITS="2000m"
+export JMETER_MASTER_CPU_REQUESTS="150m"
+#export JMETER_MASTER_MEMORY_LIMITS="4Gi"
+export JMETER_MASTER_MEMORY_REQUESTS="500Mi"
+#export JMETER_WORKER_CPU_LIMITS="2000m"
+export JMETER_WORKER_CPU_REQUESTS="150m"
+#export JMETER_WORKER_MEMORY_LIMITS="4Gi"
+export JMETER_WORKER_MEMORY_REQUESTS="500Mi"
+
 echo "Starting kangal proxy"
 ./bin/kangal proxy --kubeconfig="$HOME/.kube/config" --max-load-tests 1 > /tmp/kangal_proxy.log 2>&1 &
 PID_PROXY=$!

--- a/ci/integration-tests.sh
+++ b/ci/integration-tests.sh
@@ -4,16 +4,6 @@ set -e
 export AWS_ACCESS_KEY_ID=""
 export AWS_SECRET_ACCESS_KEY=""
 
-# Adjust resource requests and limits
-#export JMETER_MASTER_CPU_LIMITS="2000m"
-export JMETER_MASTER_CPU_REQUESTS="150m"
-#export JMETER_MASTER_MEMORY_LIMITS="4Gi"
-export JMETER_MASTER_MEMORY_REQUESTS="500Mi"
-#export JMETER_WORKER_CPU_LIMITS="2000m"
-export JMETER_WORKER_CPU_REQUESTS="150m"
-#export JMETER_WORKER_MEMORY_LIMITS="4Gi"
-export JMETER_WORKER_MEMORY_REQUESTS="500Mi"
-
 echo "Starting kangal proxy"
 ./bin/kangal proxy --kubeconfig="$HOME/.kube/config" --max-load-tests 1 > /tmp/kangal_proxy.log 2>&1 &
 PID_PROXY=$!

--- a/docs/jmeter-in-kangal/JMeter-load-generator-in-kangal.md
+++ b/docs/jmeter-in-kangal/JMeter-load-generator-in-kangal.md
@@ -52,3 +52,25 @@ List of external JMeter plugins used in Kangal setup:
 * jpgc-functions [Custom JMeter Functions](https://jmeter-plugins.org/wiki/Functions/)
 
 You can also use and modify example test files from Kangal repo, described [here](How-to-write-tests.md) and [Load generator in Kangal](JMeter-load-generator-in-kangal.md). But we strongly recommend you to read the [offical docs](https://jmeter.apache.org/usermanual/test_plan.html) to understand major concepts.
+
+### Configuring JMeter Resource Requirements
+By default, Kangal does not specify resource requirements for loadtests run with JMeter as a backend.
+
+You can specify resource limits and requests for JMeter master and worker containers to ensure that when the load generator runs, it has sufficient resources and will not fail before the service does.
+
+The following environment variables can be specified to configure this parameter:
+
+```
+JMETER_MASTER_CPU_LIMITS
+JMETER_MASTER_CPU_REQUESTS
+JMETER_MASTER_MEMORY_LIMITS
+JMETER_MASTER_MEMORY_REQUESTS
+JMETER_WORKER_CPU_LIMITS
+JMETER_WORKER_CPU_REQUESTS
+JMETER_WORKER_MEMORY_LIMITS
+JMETER_WORKER_MEMORY_REQUESTS
+```
+
+More information regarding resource limits and requests can be found in the following page(s):
+- https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+- https://cloud.google.com/blog/products/gcp/kubernetes-best-practices-resource-requests-and-limits

--- a/pkg/backends/backend.go
+++ b/pkg/backends/backend.go
@@ -28,12 +28,17 @@ type LoadTestType interface {
 	CheckOrUpdateStatus(ctx context.Context) error
 }
 
+// Config contains all configurations related to kangal backends
+type Config struct {
+	JMeter jmeter.Config
+}
+
 // NewLoadTest returns a new LoadTestType
-func NewLoadTest(loadTest *loadTestV1.LoadTest, kubeClientSet kubernetes.Interface, kangalClientSet clientSetV.Interface, logger *zap.Logger, namespacesLister coreListersV1.NamespaceLister, reportConfig report.Config, podAnnotations, namespaceAnnotations map[string]string) (LoadTestType, error) {
+func NewLoadTest(loadTest *loadTestV1.LoadTest, kubeClientSet kubernetes.Interface, kangalClientSet clientSetV.Interface, logger *zap.Logger, namespacesLister coreListersV1.NamespaceLister, reportConfig report.Config, podAnnotations, namespaceAnnotations map[string]string, backendsConfig Config) (LoadTestType, error) {
 	switch loadTest.Spec.Type {
 	case loadTestV1.LoadTestTypeJMeter:
 		presignedURL := report.NewPreSignedPutURL(loadTest.GetName())
-		return jmeter.New(kubeClientSet, kangalClientSet, loadTest, logger, namespacesLister, presignedURL, podAnnotations, namespaceAnnotations), nil
+		return jmeter.New(kubeClientSet, kangalClientSet, loadTest, logger, namespacesLister, presignedURL, podAnnotations, namespaceAnnotations, backendsConfig.JMeter), nil
 	case loadTestV1.LoadTestTypeFake:
 		return fake.New(kubeClientSet, loadTest, logger), nil
 	}

--- a/pkg/backends/jmeter/config.go
+++ b/pkg/backends/jmeter/config.go
@@ -2,12 +2,12 @@ package jmeter
 
 // Config specific to JMeter backend
 type Config struct {
-	MasterCPULimits      string `envconfig:"JMETER_MASTER_CPU_LIMITS" default:"2000m"`
-	MasterCPURequests    string `envconfig:"JMETER_MASTER_CPU_REQUESTS" default:"1000m"`
-	MasterMemoryLimits   string `envconfig:"JMETER_MASTER_MEMORY_LIMITS" default:"4Gi"`
-	MasterMemoryRequests string `envconfig:"JMETER_MASTER_MEMORY_REQUESTS" default:"4Gi"`
-	WorkerCPULimits      string `envconfig:"JMETER_WORKER_CPU_LIMITS" default:"2000m"`
-	WorkerCPURequests    string `envconfig:"JMETER_WORKER_CPU_REQUESTS" default:"1000m"`
-	WorkerMemoryLimits   string `envconfig:"JMETER_WORKER_MEMORY_LIMITS" default:"4Gi"`
-	WorkerMemoryRequests string `envconfig:"JMETER_WORKER_MEMORY_REQUESTS" default:"4Gi"`
+	MasterCPULimits      string `envconfig:"JMETER_MASTER_CPU_LIMITS"`
+	MasterCPURequests    string `envconfig:"JMETER_MASTER_CPU_REQUESTS"`
+	MasterMemoryLimits   string `envconfig:"JMETER_MASTER_MEMORY_LIMITS"`
+	MasterMemoryRequests string `envconfig:"JMETER_MASTER_MEMORY_REQUESTS"`
+	WorkerCPULimits      string `envconfig:"JMETER_WORKER_CPU_LIMITS"`
+	WorkerCPURequests    string `envconfig:"JMETER_WORKER_CPU_REQUESTS"`
+	WorkerMemoryLimits   string `envconfig:"JMETER_WORKER_MEMORY_LIMITS"`
+	WorkerMemoryRequests string `envconfig:"JMETER_WORKER_MEMORY_REQUESTS"`
 }

--- a/pkg/backends/jmeter/config.go
+++ b/pkg/backends/jmeter/config.go
@@ -1,0 +1,13 @@
+package jmeter
+
+// Config specific to JMeter backend
+type Config struct {
+	MasterCPULimits      string `envconfig:"JMETER_MASTER_CPU_LIMITS" default:"2000m"`
+	MasterCPURequests    string `envconfig:"JMETER_MASTER_CPU_REQUESTS" default:"1000m"`
+	MasterMemoryLimits   string `envconfig:"JMETER_MASTER_MEMORY_LIMITS" default:"4Gi"`
+	MasterMemoryRequests string `envconfig:"JMETER_MASTER_MEMORY_REQUESTS" default:"4Gi"`
+	WorkerCPULimits      string `envconfig:"JMETER_WORKER_CPU_LIMITS" default:"2000m"`
+	WorkerCPURequests    string `envconfig:"JMETER_WORKER_CPU_REQUESTS" default:"1000m"`
+	WorkerMemoryLimits   string `envconfig:"JMETER_WORKER_MEMORY_LIMITS" default:"4Gi"`
+	WorkerMemoryRequests string `envconfig:"JMETER_WORKER_MEMORY_REQUESTS" default:"4Gi"`
+}

--- a/pkg/backends/jmeter/jmeter.go
+++ b/pkg/backends/jmeter/jmeter.go
@@ -36,12 +36,13 @@ type JMeter struct {
 	logger             *zap.Logger
 	namespacesLister   coreListersV1.NamespaceLister
 	reportPreSignedURL *url.URL
+	config             Config
 
 	podAnnotations, namespaceAnnotations map[string]string
 }
 
 //New initializes new JMeter provider handler to manage load test resources with Kangal Controller
-func New(kubeClientSet kubernetes.Interface, kangalClientSet clientSetV.Interface, lt *loadTestV1.LoadTest, logger *zap.Logger, namespacesLister coreListersV1.NamespaceLister, reportPreSignedURL *url.URL, podAnnotations, namespaceAnnotations map[string]string) *JMeter {
+func New(kubeClientSet kubernetes.Interface, kangalClientSet clientSetV.Interface, lt *loadTestV1.LoadTest, logger *zap.Logger, namespacesLister coreListersV1.NamespaceLister, reportPreSignedURL *url.URL, podAnnotations, namespaceAnnotations map[string]string, jMeterConfig Config) *JMeter {
 	return &JMeter{
 		kubeClientSet:        kubeClientSet,
 		kangalClientSet:      kangalClientSet,
@@ -51,6 +52,7 @@ func New(kubeClientSet kubernetes.Interface, kangalClientSet clientSetV.Interfac
 		reportPreSignedURL:   reportPreSignedURL,
 		podAnnotations:       podAnnotations,
 		namespaceAnnotations: namespaceAnnotations,
+		config:               jMeterConfig,
 	}
 }
 

--- a/pkg/backends/jmeter/jmeter_test.go
+++ b/pkg/backends/jmeter/jmeter_test.go
@@ -162,16 +162,7 @@ func TestJMeter_CheckOrCreateResources(t *testing.T) {
 		&url.URL{},
 		map[string]string{"": ""},
 		map[string]string{"": ""},
-		Config{
-			MasterCPULimits:      "100m",
-			MasterCPURequests:    "200m",
-			MasterMemoryLimits:   "100Mi",
-			MasterMemoryRequests: "200Mi",
-			WorkerCPULimits:      "300m",
-			WorkerCPURequests:    "400m",
-			WorkerMemoryLimits:   "300Mi",
-			WorkerMemoryRequests: "400Mi",
-		},
+		Config{},
 	)
 
 	c.CheckOrCreateResources(ctx)

--- a/pkg/backends/jmeter/resources.go
+++ b/pkg/backends/jmeter/resources.go
@@ -203,16 +203,12 @@ func (c *JMeter) NewPod(i int, configMap *coreV1.ConfigMap, podAnnotations map[s
 							MountPath: "/testdata",
 						},
 					},
-					Resources: coreV1.ResourceRequirements{
-						Requests: map[coreV1.ResourceName]resource.Quantity{
-							coreV1.ResourceMemory: resource.MustParse(c.config.WorkerMemoryRequests),
-							coreV1.ResourceCPU:    resource.MustParse(c.config.WorkerCPURequests),
-						},
-						Limits: map[coreV1.ResourceName]resource.Quantity{
-							coreV1.ResourceMemory: resource.MustParse(c.config.WorkerMemoryLimits),
-							coreV1.ResourceCPU:    resource.MustParse(c.config.WorkerCPULimits),
-						},
-					},
+					Resources: buildResourceRequirements(
+						c.config.WorkerCPULimits,
+						c.config.WorkerCPURequests,
+						c.config.WorkerMemoryLimits,
+						c.config.WorkerMemoryRequests,
+					),
 					EnvFrom: []coreV1.EnvFromSource{
 						{
 							SecretRef: &coreV1.SecretEnvSource{
@@ -305,16 +301,12 @@ func (c *JMeter) NewJMeterMasterJob(preSignedURL *url.URL, podAnnotations map[st
 									SubPath:   "jmeter.properties",
 								},
 							},
-							Resources: coreV1.ResourceRequirements{
-								Requests: map[coreV1.ResourceName]resource.Quantity{
-									coreV1.ResourceMemory: resource.MustParse(c.config.MasterMemoryRequests),
-									coreV1.ResourceCPU:    resource.MustParse(c.config.MasterCPURequests),
-								},
-								Limits: map[coreV1.ResourceName]resource.Quantity{
-									coreV1.ResourceMemory: resource.MustParse(c.config.MasterMemoryLimits),
-									coreV1.ResourceCPU:    resource.MustParse(c.config.MasterCPULimits),
-								},
-							},
+							Resources: buildResourceRequirements(
+								c.config.MasterCPULimits,
+								c.config.MasterCPURequests,
+								c.config.MasterMemoryLimits,
+								c.config.MasterMemoryRequests,
+							),
 						},
 					},
 					Volumes: []coreV1.Volume{
@@ -456,4 +448,32 @@ func getNamespaceFromLoadTestName(loadTestName string, logger *zap.Logger) (newN
 	}
 	newNamespaceName = nsName[loadTestNameLength-2] + "-" + nsName[loadTestNameLength-1]
 	return newNamespaceName, nil
+}
+
+// buildResourceRequirements creates ResourceRequirements that allows not all values to be specified
+// This is necessary because setting a resource requirement with value 0 produces a different behavior
+func buildResourceRequirements(cpuLimit, cpuRequest, memLimit, memRequest string) coreV1.ResourceRequirements {
+	limits := make(map[coreV1.ResourceName]resource.Quantity)
+	requests := make(map[coreV1.ResourceName]resource.Quantity)
+
+	if quantity, err := resource.ParseQuantity(cpuLimit); err == nil {
+		limits[coreV1.ResourceCPU] = quantity
+	}
+
+	if quantity, err := resource.ParseQuantity(cpuRequest); err == nil {
+		requests[coreV1.ResourceCPU] = quantity
+	}
+
+	if quantity, err := resource.ParseQuantity(memLimit); err == nil {
+		limits[coreV1.ResourceMemory] = quantity
+	}
+
+	if quantity, err := resource.ParseQuantity(memRequest); err == nil {
+		requests[coreV1.ResourceMemory] = quantity
+	}
+
+	return coreV1.ResourceRequirements{
+		Limits:   limits,
+		Requests: requests,
+	}
 }

--- a/pkg/backends/jmeter/resources.go
+++ b/pkg/backends/jmeter/resources.go
@@ -205,12 +205,12 @@ func (c *JMeter) NewPod(i int, configMap *coreV1.ConfigMap, podAnnotations map[s
 					},
 					Resources: coreV1.ResourceRequirements{
 						Requests: map[coreV1.ResourceName]resource.Quantity{
-							coreV1.ResourceMemory: resource.MustParse("4Gi"),
-							coreV1.ResourceCPU:    resource.MustParse("1000m"),
+							coreV1.ResourceMemory: resource.MustParse(c.config.WorkerMemoryRequests),
+							coreV1.ResourceCPU:    resource.MustParse(c.config.WorkerCPURequests),
 						},
 						Limits: map[coreV1.ResourceName]resource.Quantity{
-							coreV1.ResourceMemory: resource.MustParse("4Gi"),
-							coreV1.ResourceCPU:    resource.MustParse("2000m"),
+							coreV1.ResourceMemory: resource.MustParse(c.config.WorkerMemoryLimits),
+							coreV1.ResourceCPU:    resource.MustParse(c.config.WorkerCPULimits),
 						},
 					},
 					EnvFrom: []coreV1.EnvFromSource{
@@ -307,12 +307,12 @@ func (c *JMeter) NewJMeterMasterJob(preSignedURL *url.URL, podAnnotations map[st
 							},
 							Resources: coreV1.ResourceRequirements{
 								Requests: map[coreV1.ResourceName]resource.Quantity{
-									coreV1.ResourceMemory: resource.MustParse("4Gi"),
-									coreV1.ResourceCPU:    resource.MustParse("1000m"),
+									coreV1.ResourceMemory: resource.MustParse(c.config.MasterMemoryRequests),
+									coreV1.ResourceCPU:    resource.MustParse(c.config.MasterCPURequests),
 								},
 								Limits: map[coreV1.ResourceName]resource.Quantity{
-									coreV1.ResourceMemory: resource.MustParse("4Gi"),
-									coreV1.ResourceCPU:    resource.MustParse("2000m"),
+									coreV1.ResourceMemory: resource.MustParse(c.config.MasterMemoryLimits),
+									coreV1.ResourceCPU:    resource.MustParse(c.config.MasterCPULimits),
 								},
 							},
 						},

--- a/pkg/backends/jmeter/resources_test.go
+++ b/pkg/backends/jmeter/resources_test.go
@@ -140,14 +140,14 @@ func TestPodResourceConfiguration(t *testing.T) {
 	}
 
 	masterJob := c.NewJMeterMasterJob(&url.URL{}, map[string]string{"": ""})
-	assert.Equal(t, masterJob.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String(), c.config.MasterCPULimits)
-	assert.Equal(t, masterJob.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String(), c.config.MasterCPURequests)
-	assert.Equal(t, masterJob.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String(), c.config.MasterMemoryLimits)
-	assert.Equal(t, masterJob.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String(), c.config.MasterMemoryRequests)
+	assert.Equal(t, c.config.MasterCPULimits, masterJob.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String())
+	assert.Equal(t, c.config.MasterCPURequests, masterJob.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String())
+	assert.Equal(t, c.config.MasterMemoryLimits, masterJob.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String())
+	assert.Equal(t, c.config.MasterMemoryRequests, masterJob.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String())
 
 	workerPod := c.NewPod(0, &v1.ConfigMap{}, map[string]string{"": ""})
-	assert.Equal(t, workerPod.Spec.Containers[0].Resources.Limits.Cpu().String(), c.config.WorkerCPULimits)
-	assert.Equal(t, workerPod.Spec.Containers[0].Resources.Requests.Cpu().String(), c.config.WorkerCPURequests)
-	assert.Equal(t, workerPod.Spec.Containers[0].Resources.Limits.Memory().String(), c.config.WorkerMemoryLimits)
-	assert.Equal(t, workerPod.Spec.Containers[0].Resources.Requests.Memory().String(), c.config.WorkerMemoryRequests)
+	assert.Equal(t, c.config.WorkerCPULimits, workerPod.Spec.Containers[0].Resources.Limits.Cpu().String())
+	assert.Equal(t, c.config.WorkerCPURequests, workerPod.Spec.Containers[0].Resources.Requests.Cpu().String())
+	assert.Equal(t, c.config.WorkerMemoryLimits, workerPod.Spec.Containers[0].Resources.Limits.Memory().String())
+	assert.Equal(t, c.config.WorkerMemoryRequests, workerPod.Spec.Containers[0].Resources.Requests.Memory().String())
 }

--- a/pkg/backends/jmeter/resources_test.go
+++ b/pkg/backends/jmeter/resources_test.go
@@ -1,11 +1,14 @@
 package jmeter
 
 import (
+	"net/url"
 	"os"
 	"testing"
 
+	loadtestv1 "github.com/hellofresh/kangal/pkg/kubernetes/apis/loadtest/v1"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
+	v1 "k8s.io/api/core/v1"
 )
 
 var logger = zap.NewNop()
@@ -114,4 +117,37 @@ func TestGetNamespaceFromInvalidName(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, expectedError, err.Error())
 	assert.Equal(t, "", res)
+}
+
+func TestPodResourceConfiguration(t *testing.T) {
+	c := &JMeter{
+		loadTest: &loadtestv1.LoadTest{
+			Spec: loadtestv1.LoadTestSpec{
+				MasterConfig: loadtestv1.ImageDetails{},
+				WorkerConfig: loadtestv1.ImageDetails{},
+			},
+		},
+		config: Config{
+			MasterCPULimits:      "100m",
+			MasterCPURequests:    "200m",
+			MasterMemoryLimits:   "100Mi",
+			MasterMemoryRequests: "200Mi",
+			WorkerCPULimits:      "300m",
+			WorkerCPURequests:    "400m",
+			WorkerMemoryLimits:   "300Mi",
+			WorkerMemoryRequests: "400Mi",
+		},
+	}
+
+	masterJob := c.NewJMeterMasterJob(&url.URL{}, map[string]string{"": ""})
+	assert.Equal(t, masterJob.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String(), c.config.MasterCPULimits)
+	assert.Equal(t, masterJob.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String(), c.config.MasterCPURequests)
+	assert.Equal(t, masterJob.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String(), c.config.MasterMemoryLimits)
+	assert.Equal(t, masterJob.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String(), c.config.MasterMemoryRequests)
+
+	workerPod := c.NewPod(0, &v1.ConfigMap{}, map[string]string{"": ""})
+	assert.Equal(t, workerPod.Spec.Containers[0].Resources.Limits.Cpu().String(), c.config.WorkerCPULimits)
+	assert.Equal(t, workerPod.Spec.Containers[0].Resources.Requests.Cpu().String(), c.config.WorkerCPURequests)
+	assert.Equal(t, workerPod.Spec.Containers[0].Resources.Limits.Memory().String(), c.config.WorkerMemoryLimits)
+	assert.Equal(t, workerPod.Spec.Containers[0].Resources.Requests.Memory().String(), c.config.WorkerMemoryRequests)
 }

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"time"
 
+	"github.com/hellofresh/kangal/pkg/backends"
 	"github.com/hellofresh/kangal/pkg/core/observability"
 	"github.com/hellofresh/kangal/pkg/report"
 )
@@ -16,7 +17,8 @@ type Config struct {
 	// load test lives for, the default is 1 hour. (ex. 5h)
 	CleanUpThreshold time.Duration `envconfig:"CLEANUP_THRESHOLD" default:"1h"`
 	// S3 compatible configuration access keys and endpoints needed to store load test reports
-	Report report.Config
+	Report   report.Config
+	Backends backends.Config
 
 	MasterURL            string
 	KubeConfig           string

--- a/pkg/controller/jmeter_integration_test.go
+++ b/pkg/controller/jmeter_integration_test.go
@@ -34,7 +34,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationJMeter(t *testing.T) {
-	t.Skip("Skipping JMeter integration tests")
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
@@ -123,9 +122,12 @@ func TestIntegrationJMeter(t *testing.T) {
 
 	t.Run("Checking master pod is created", func(t *testing.T) {
 		var master coreV1.PodList
-		for i := 0; i < 5; i++ {
+		for i := 0; i < 60; i++ {
 			WaitForResource(ShortWaitSec)
 			master, _ = GetMasterPod(client.CoreV1(), expectedLoadtestName)
+			if len(master.Items) < 1 {
+				continue
+			}
 			if master.Items[0].Status.Phase == "Running" {
 				break
 			}

--- a/pkg/controller/loadtest.go
+++ b/pkg/controller/loadtest.go
@@ -301,7 +301,7 @@ func (c *Controller) syncHandler(key string) error {
 	loadTest := loadTestFromCache.DeepCopy()
 	defer c.updateLoadTestStatus(ctx, loadTest)
 
-	backend, err := backends.NewLoadTest(loadTest, c.kubeClientSet, c.kangalClientSet, c.logger, c.namespacesLister, c.cfg.Report, c.cfg.PodAnnotations, c.cfg.NamespaceAnnotations)
+	backend, err := backends.NewLoadTest(loadTest, c.kubeClientSet, c.kangalClientSet, c.logger, c.namespacesLister, c.cfg.Report, c.cfg.PodAnnotations, c.cfg.NamespaceAnnotations, c.cfg.Backends)
 	if err != nil {
 		return fmt.Errorf("failed to create new backend: %w", err)
 	}

--- a/pkg/controller/test_helper.go
+++ b/pkg/controller/test_helper.go
@@ -273,6 +273,11 @@ func WaitResource(obj watch.Interface, condFunc watchtools.ConditionFunc) (*watc
 	return watchtools.UntilWithoutRetry(ctx, obj, condFunc)
 }
 
+// WaitResourceWithContext is WaitResource with custom context when the default context is not suitable
+func WaitResourceWithContext(ctx context.Context, obj watch.Interface, condFunc watchtools.ConditionFunc) (*watch.Event, error) {
+	return watchtools.UntilWithoutRetry(ctx, obj, condFunc)
+}
+
 // WaitForResource sleeps to wait kubernetes resources to be created
 func WaitForResource(d time.Duration) {
 	time.Sleep(d * time.Second)


### PR DESCRIPTION
This PR:
- Adds environment variables to adjust JMeter master and worker pod resource (memory and cpu) limits and request
- Lowers cpu and memory resource requests for both master and worker in integration test
- (Re-)enables jmeter integration-test