### PR TITLE
Add tags to load tests

### DIFF
--- a/charts/kangal/Chart.yaml
+++ b/charts/kangal/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - performance tests
   - tests runner
 name: kangal
-version: 1.1.0
+version: 1.2.0
 home: https://github.com/hellofresh/kangal
 icon: https://raw.githubusercontent.com/hellofresh/kangal/master/kangal_logo.svg
 maintainers:

--- a/charts/kangal/crd.yaml
+++ b/charts/kangal/crd.yaml
@@ -44,6 +44,11 @@ spec:
                 distributedPods:
                   minimum: 1
                   type: integer
+                tags:
+                  type: object
+                  nullable: true
+                  additionalProperties:
+                    type: string
                 testFile:
                   type: string
                 testData:

--- a/docs/user-flow.md
+++ b/docs/user-flow.md
@@ -35,6 +35,20 @@ curl -X POST http://${KANGAL_PROXY_ADDRESS}/load-test \
   -F overwrite=true
 ```
 
+You can also tag the load test so that you can find them later, the format is `tag1:value1,tag2:value2`
+
+```bash
+curl -X POST http://${KANGAL_PROXY_ADDRESS}/load-test \
+  -H 'Content-Type: multipart/form-data' \
+  -F distributedPods=1 \
+  -F testFile=@examples/constant_load.jmx \
+  -F testData=@artifacts/loadtests/testData.csv \
+  -F envVars=@artifacts/loadtests/envVars.csv \
+  -F type=JMeter \
+  -F tags=tag1:value1,tag2:value2 \
+  -F overwrite=true
+```
+
 ## Check 
 Check the status of the load test.
 
@@ -66,4 +80,24 @@ Delete your finished load test.
 
 ```
 curl -X DELETE http://${KANGAL_PROXY_ADDRESS}/load-test/loadtest-name
+```
+
+## List
+
+You can find out all the load tests
+
+```bash
+curl http://${KANGAL_PROXY_ADDRESS}/load-test
+```
+
+You can filter by `tags`
+
+```bash
+curl 'http://${KANGAL_PROXY_ADDRESS}/load-test?tags=tag1:value1'
+```
+
+And limit your search
+
+```bash
+curl 'http://${KANGAL_PROXY_ADDRESS}/load-test?tags=tag1:value1&limit=10'
 ```

--- a/openapi.json
+++ b/openapi.json
@@ -14,6 +14,62 @@
 	}],
 	"paths": {
 		"/load-test": {
+			"get": {
+				"tags": ["load-tests"],
+				"summary": "List all the load tests",
+				"operationId": "listLoadTest",
+				"parameters": [
+					{
+						"name": "tags",
+						"in": "query",
+						"description": "Filter the result by tags, value is in format: tag1:value1,tag2:value2",
+						"schema": {
+							"type": "string"
+						},
+						"example": "department:platform,team:kangal"
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "Limit the result when querying on a large cluster",
+						"schema": {
+							"type": "integer"
+						},
+						"example": "500"
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "Continue the next page when querying on a large cluster",
+						"schema": {
+							"type": "integer"
+						},
+						"example": "ENCODED_CONTINUE_TOKEN"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Expected response to a valid request",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/LoadTestStatusPage"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "unexpected error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Error"
+								}
+							}
+						}
+					}
+				}
+			},
 			"post": {
 				"tags": ["load-tests"],
 				"summary": "Create a new loadTest",
@@ -290,6 +346,27 @@
 					}
 				}
 			},
+			"LoadTestStatusPage": {
+				"type": "object",
+				"properties": {
+					"limit": {
+						"type": "integer"
+					},
+					"continue": {
+						"type": "string"
+					},
+					"remain": {
+						"type": "integer",
+						"nullable": true
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/LoadTestStatus"
+						}
+					}
+				}
+			},
 			"LoadTestStatus": {
 				"type": "object",
 				"properties": {
@@ -303,6 +380,12 @@
 					"phase": {
 						"type": "string",
 						"enum": ["creating", "starting", "running", "finished", "errored"]
+					},
+					"tags": {
+						"type": "object",
+						"additionalProperties": {
+							"type": "string"
+						}
 					},
 					"hasEnvVars": {
 						"type": "boolean"

--- a/pkg/backends/backend.go
+++ b/pkg/backends/backend.go
@@ -51,14 +51,14 @@ func NewLoadTest(loadTest *loadTestV1.LoadTest, kubeClientSet kubernetes.Interfa
 }
 
 // BuildLoadTestSpecByBackend returns a valid LoadTestSpec based on backend rules
-func BuildLoadTestSpecByBackend(loadTestType loadTestV1.LoadTestType, overwrite bool, distributedPods int32, testFileStr, testDataStr, envVarsStr, targetURL string, duration time.Duration) (loadTestV1.LoadTestSpec, error) {
+func BuildLoadTestSpecByBackend(loadTestType loadTestV1.LoadTestType, overwrite bool, distributedPods int32, tags loadTestV1.LoadTestTags, testFileStr, testDataStr, envVarsStr, targetURL string, duration time.Duration) (loadTestV1.LoadTestSpec, error) {
 	switch loadTestType {
 	case loadTestV1.LoadTestTypeJMeter:
-		return jmeter.BuildLoadTestSpec(overwrite, distributedPods, testFileStr, testDataStr, envVarsStr)
+		return jmeter.BuildLoadTestSpec(overwrite, distributedPods, tags, testFileStr, testDataStr, envVarsStr)
 	case loadTestV1.LoadTestTypeFake:
-		return fake.BuildLoadTestSpec(overwrite)
+		return fake.BuildLoadTestSpec(tags, overwrite)
 	case loadTestV1.LoadTestTypeLocust:
-		return locust.BuildLoadTestSpec(overwrite, distributedPods, testFileStr, envVarsStr, targetURL, duration)
+		return locust.BuildLoadTestSpec(overwrite, distributedPods, tags, testFileStr, envVarsStr, targetURL, duration)
 	}
 	return loadTestV1.LoadTestSpec{}, fmt.Errorf("load test provider not found to build specs: %s", loadTestType)
 }

--- a/pkg/backends/fake/spec.go
+++ b/pkg/backends/fake/spec.go
@@ -7,7 +7,7 @@ import (
 )
 
 //BuildLoadTestSpec returns LoadTestSpec for Fake backend provider
-func BuildLoadTestSpec(overwrite bool) (loadTestV1.LoadTestSpec, error) {
+func BuildLoadTestSpec(tags loadTestV1.LoadTestTags, overwrite bool) (loadTestV1.LoadTestSpec, error) {
 	// in general Fake backend provider doesn't need any fields except overwrite flag
-	return loadTestV1.NewSpec(loadTestV1.LoadTestTypeFake, overwrite, 1, "", "", "", loadTestV1.ImageDetails{Image: sleepImage, Tag: imageTag}, loadTestV1.ImageDetails{}, "", time.Duration(0)), nil
+	return loadTestV1.NewSpec(loadTestV1.LoadTestTypeFake, overwrite, 1, tags, "", "", "", loadTestV1.ImageDetails{Image: sleepImage, Tag: imageTag}, loadTestV1.ImageDetails{}, "", time.Duration(0)), nil
 }

--- a/pkg/backends/fake/spec_test.go
+++ b/pkg/backends/fake/spec_test.go
@@ -12,6 +12,7 @@ func TestBuildFakeLoadTestSpec(t *testing.T) {
 	var distributedPods int32 = 1
 
 	type args struct {
+		tags      loadtestv1.LoadTestTags
 		overwrite bool
 	}
 	tests := []struct {
@@ -23,6 +24,7 @@ func TestBuildFakeLoadTestSpec(t *testing.T) {
 		{
 			name: "Spec is valid",
 			args: args{
+				tags:      loadtestv1.LoadTestTags{"team": "kangal"},
 				overwrite: true,
 			},
 			want: loadtestv1.LoadTestSpec{
@@ -34,6 +36,7 @@ func TestBuildFakeLoadTestSpec(t *testing.T) {
 				},
 				WorkerConfig:    loadtestv1.ImageDetails{},
 				DistributedPods: &distributedPods,
+				Tags:            loadtestv1.LoadTestTags{"team": "kangal"},
 				TestFile:        "",
 				TestData:        "",
 				EnvVars:         "",
@@ -43,7 +46,7 @@ func TestBuildFakeLoadTestSpec(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := BuildLoadTestSpec(tt.args.overwrite)
+			got, err := BuildLoadTestSpec(tt.args.tags, tt.args.overwrite)
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/pkg/backends/jmeter/spec.go
+++ b/pkg/backends/jmeter/spec.go
@@ -15,7 +15,7 @@ var (
 )
 
 //BuildLoadTestSpec validates input and returns valid LoadTestSpec for JMeter backend provider
-func BuildLoadTestSpec(overwrite bool, distributedPods int32, testFileStr, testDataStr, envVarsStr string) (loadTestV1.LoadTestSpec, error) {
+func BuildLoadTestSpec(overwrite bool, distributedPods int32, tags loadTestV1.LoadTestTags, testFileStr, testDataStr, envVarsStr string) (loadTestV1.LoadTestSpec, error) {
 	lt := loadTestV1.LoadTestSpec{}
 	// JMeter backend provider needs full spec: from number of distributed pods to envVars
 	if distributedPods <= int32(0) {
@@ -24,5 +24,5 @@ func BuildLoadTestSpec(overwrite bool, distributedPods int32, testFileStr, testD
 	if testFileStr == "" {
 		return lt, ErrRequireTestFile
 	}
-	return loadTestV1.NewSpec(loadTestV1.LoadTestTypeJMeter, overwrite, distributedPods, testFileStr, testDataStr, envVarsStr, loadTestV1.ImageDetails{Image: masterImage, Tag: imageTag}, loadTestV1.ImageDetails{Image: workerImage, Tag: imageTag}, "", time.Duration(0)), nil
+	return loadTestV1.NewSpec(loadTestV1.LoadTestTypeJMeter, overwrite, distributedPods, tags, testFileStr, testDataStr, envVarsStr, loadTestV1.ImageDetails{Image: masterImage, Tag: imageTag}, loadTestV1.ImageDetails{Image: workerImage, Tag: imageTag}, "", time.Duration(0)), nil
 }

--- a/pkg/backends/jmeter/spec_test.go
+++ b/pkg/backends/jmeter/spec_test.go
@@ -14,6 +14,7 @@ func TestBuildJMeterLoadTestSpec(t *testing.T) {
 	type args struct {
 		overwrite       bool
 		distributedPods int32
+		tags            v1.LoadTestTags
 		testFileStr     string
 		testDataStr     string
 		envVarsStr      string
@@ -29,6 +30,7 @@ func TestBuildJMeterLoadTestSpec(t *testing.T) {
 			args: args{
 				overwrite:       true,
 				distributedPods: 3,
+				tags:            v1.LoadTestTags{"team": "kangal"},
 				testFileStr:     "something in the file",
 				testDataStr:     "some test data",
 			},
@@ -38,6 +40,7 @@ func TestBuildJMeterLoadTestSpec(t *testing.T) {
 				MasterConfig:    v1.ImageDetails{Image: masterImage, Tag: imageTag},
 				WorkerConfig:    v1.ImageDetails{Image: workerImage, Tag: imageTag},
 				DistributedPods: &distributedPods,
+				Tags:            v1.LoadTestTags{"team": "kangal"},
 				TestFile:        "something in the file",
 				TestData:        "some test data",
 				EnvVars:         "",
@@ -65,7 +68,7 @@ func TestBuildJMeterLoadTestSpec(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := BuildLoadTestSpec(tt.args.overwrite, tt.args.distributedPods, tt.args.testFileStr, tt.args.testDataStr, tt.args.envVarsStr)
+			got, err := BuildLoadTestSpec(tt.args.overwrite, tt.args.distributedPods, tt.args.tags, tt.args.testFileStr, tt.args.testDataStr, tt.args.envVarsStr)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -77,6 +80,7 @@ func TestBuildJMeterLoadTestSpec(t *testing.T) {
 			assert.Equal(t, tt.want.MasterConfig, got.MasterConfig)
 			assert.Equal(t, tt.want.WorkerConfig, got.WorkerConfig)
 			assert.Equal(t, &tt.want.DistributedPods, &got.DistributedPods)
+			assert.Equal(t, tt.want.Tags, got.Tags)
 			assert.Equal(t, tt.want.TestFile, got.TestFile)
 			assert.Equal(t, tt.want.TestData, got.TestData)
 		})

--- a/pkg/backends/locust/spec.go
+++ b/pkg/backends/locust/spec.go
@@ -15,7 +15,7 @@ var (
 )
 
 //BuildLoadTestSpec validates input and returns valid LoadTestSpec
-func BuildLoadTestSpec(overwrite bool, distributedPods int32, testFileStr, envVarsStr, targetURL string, duration time.Duration) (loadTestV1.LoadTestSpec, error) {
+func BuildLoadTestSpec(overwrite bool, distributedPods int32, tags loadTestV1.LoadTestTags, testFileStr, envVarsStr, targetURL string, duration time.Duration) (loadTestV1.LoadTestSpec, error) {
 	lt := loadTestV1.LoadTestSpec{}
 	if distributedPods <= int32(0) {
 		return lt, ErrRequireMinOneDistributedPod
@@ -23,5 +23,5 @@ func BuildLoadTestSpec(overwrite bool, distributedPods int32, testFileStr, envVa
 	if testFileStr == "" {
 		return lt, ErrRequireTestFile
 	}
-	return loadTestV1.NewSpec(loadTestV1.LoadTestTypeLocust, overwrite, distributedPods, testFileStr, "", envVarsStr, loadTestV1.ImageDetails{}, loadTestV1.ImageDetails{}, targetURL, duration), nil
+	return loadTestV1.NewSpec(loadTestV1.LoadTestTypeLocust, overwrite, distributedPods, tags, testFileStr, "", envVarsStr, loadTestV1.ImageDetails{}, loadTestV1.ImageDetails{}, targetURL, duration), nil
 }

--- a/pkg/backends/locust/spec_test.go
+++ b/pkg/backends/locust/spec_test.go
@@ -15,6 +15,7 @@ func TestBuildLoadTestSpec(t *testing.T) {
 	type args struct {
 		overwrite       bool
 		distributedPods int32
+		tags            v1.LoadTestTags
 		testFileStr     string
 		envVarsStr      string
 		targetURL       string
@@ -31,6 +32,7 @@ func TestBuildLoadTestSpec(t *testing.T) {
 			args: args{
 				overwrite:       true,
 				distributedPods: 3,
+				tags:            v1.LoadTestTags{"team": "kangal"},
 				testFileStr:     "something in the file",
 				envVarsStr:      "my-key,my-value",
 				targetURL:       "http://my-app.my-domain.com",
@@ -41,6 +43,7 @@ func TestBuildLoadTestSpec(t *testing.T) {
 				MasterConfig:    v1.ImageDetails{},
 				WorkerConfig:    v1.ImageDetails{},
 				DistributedPods: &distributedPods,
+				Tags:            v1.LoadTestTags{"team": "kangal"},
 				TestFile:        "something in the file",
 				EnvVars:         "my-key,my-value",
 				TargetURL:       "http://my-app.my-domain.com",
@@ -68,7 +71,7 @@ func TestBuildLoadTestSpec(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := BuildLoadTestSpec(tt.args.overwrite, tt.args.distributedPods, tt.args.testFileStr, tt.args.envVarsStr, tt.args.targetURL, tt.args.duration)
+			got, err := BuildLoadTestSpec(tt.args.overwrite, tt.args.distributedPods, tt.args.tags, tt.args.testFileStr, tt.args.envVarsStr, tt.args.targetURL, tt.args.duration)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -81,6 +84,7 @@ func TestBuildLoadTestSpec(t *testing.T) {
 			assert.Equal(t, tt.want.MasterConfig, got.MasterConfig)
 			assert.Equal(t, tt.want.WorkerConfig, got.WorkerConfig)
 			assert.Equal(t, &tt.want.DistributedPods, &got.DistributedPods)
+			assert.Equal(t, tt.want.Tags, got.Tags)
 			assert.Equal(t, tt.want.TestFile, got.TestFile)
 			assert.Equal(t, tt.want.EnvVars, got.EnvVars)
 			assert.Equal(t, tt.want.TargetURL, got.TargetURL)

--- a/pkg/controller/test_helper.go
+++ b/pkg/controller/test_helper.go
@@ -117,6 +117,18 @@ func GetLoadtestTestdata(clientSet clientSetV.Clientset, loadtestName string) (s
 	return result.Spec.TestData, nil
 }
 
+// GetLoadtestLabels returns load test labels.
+func GetLoadtestLabels(clientSet clientSetV.Clientset, loadtestName string) (map[string]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
+	defer cancel()
+
+	result, err := clientSet.KangalV1().LoadTests().Get(ctx, loadtestName, metaV1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return result.Labels, nil
+}
+
 // GetLoadtests returns a list of load tests
 func GetLoadtests(clientSet clientSetV.Clientset) ([]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)

--- a/pkg/kubernetes/apis/loadtest/v1/spec.go
+++ b/pkg/kubernetes/apis/loadtest/v1/spec.go
@@ -12,16 +12,23 @@ var (
 	ErrRequireMinOneDistributedPod = errors.New("LoadTest must specify 1 or more DistributedPods")
 	// ErrRequireTestFile the TestFile filed is required to not be an empty string
 	ErrRequireTestFile = errors.New("LoadTest TestFile is required")
+	// ErrTagMissingLabel indicates that tag label is missing.
+	ErrTagMissingLabel = errors.New("missing tag label")
+	// ErrTagMissingValue indicates that tag value is missing.
+	ErrTagMissingValue = errors.New("missing tag value")
+	// ErrTagValueMaxLengthExceeded indicates that tag value is too long.
+	ErrTagValueMaxLengthExceeded = errors.New("tag value is too long")
 )
 
 //NewSpec initialize spec for LoadTest custom resource
-func NewSpec(loadTestType LoadTestType, overwrite bool, distributedPods int32, testFileStr, testDataStr, envVarsStr string, masterConfig, workerConfig ImageDetails, targetURL string, duration time.Duration) LoadTestSpec {
+func NewSpec(loadTestType LoadTestType, overwrite bool, distributedPods int32, tags LoadTestTags, testFileStr, testDataStr, envVarsStr string, masterConfig, workerConfig ImageDetails, targetURL string, duration time.Duration) LoadTestSpec {
 	return LoadTestSpec{
 		Type:            loadTestType,
 		Overwrite:       overwrite,
 		MasterConfig:    masterConfig,
 		WorkerConfig:    workerConfig,
 		DistributedPods: &distributedPods,
+		Tags:            tags,
 		TestFile:        testFileStr,
 		TestData:        testDataStr,
 		EnvVars:         envVarsStr,

--- a/pkg/kubernetes/apis/loadtest/v1/spec_test.go
+++ b/pkg/kubernetes/apis/loadtest/v1/spec_test.go
@@ -14,6 +14,7 @@ func TestBuildLoadTestSpec(t *testing.T) {
 		loadTestType    LoadTestType
 		overwrite       bool
 		distributedPods int32
+		tags            LoadTestTags
 		testFileStr     string
 		testDataStr     string
 		envVarsStr      string
@@ -34,6 +35,7 @@ func TestBuildLoadTestSpec(t *testing.T) {
 				loadTestType:    "Fake",
 				overwrite:       true,
 				distributedPods: 3,
+				tags:            LoadTestTags{"team": "kangal"},
 				testFileStr:     "something in the file",
 				masterConfig: ImageDetails{
 					Image: "image",
@@ -49,6 +51,7 @@ func TestBuildLoadTestSpec(t *testing.T) {
 				},
 				WorkerConfig:    ImageDetails{},
 				DistributedPods: &distributedPods,
+				Tags:            LoadTestTags{"team": "kangal"},
 				TestFile:        "something in the file",
 				TestData:        "",
 				EnvVars:         "",
@@ -58,7 +61,7 @@ func TestBuildLoadTestSpec(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := NewSpec(tt.args.loadTestType, tt.args.overwrite, tt.args.distributedPods, tt.args.testFileStr, tt.args.testDataStr, tt.args.envVarsStr, tt.args.masterConfig, tt.args.workerConfig, tt.args.targetURL, tt.args.duration)
+			got := NewSpec(tt.args.loadTestType, tt.args.overwrite, tt.args.distributedPods, tt.args.tags, tt.args.testFileStr, tt.args.testDataStr, tt.args.envVarsStr, tt.args.masterConfig, tt.args.workerConfig, tt.args.targetURL, tt.args.duration)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/kubernetes/apis/loadtest/v1/types.go
+++ b/pkg/kubernetes/apis/loadtest/v1/types.go
@@ -49,12 +49,16 @@ type LoadTestSpec struct {
 	MasterConfig    ImageDetails  `json:"masterConfig"`
 	WorkerConfig    ImageDetails  `json:"workerConfig"`
 	DistributedPods *int32        `json:"distributedPods"`
+	Tags            LoadTestTags  `json:"tags"`
 	TestFile        string        `json:"testFile"`
 	TestData        string        `json:"testData,omitempty"`
 	EnvVars         string        `json:"envVars,omitempty"`
 	TargetURL       string        `json:"targetURL,omitempty"`
 	Duration        time.Duration `json:"duration,omitempty"`
 }
+
+// LoadTestTags is a list of tags of a LoadTest resource.
+type LoadTestTags map[string]string
 
 // MasterConfig is the configuration information for each resource type
 type MasterConfig struct {

--- a/pkg/proxy/proxy_integration_test.go
+++ b/pkg/proxy/proxy_integration_test.go
@@ -38,6 +38,7 @@ func TestIntegrationCreateLoadtestFormPostAllFiles(t *testing.T) {
 	}
 
 	distributedPods := "2"
+	tagsString := "department:platform,team:kangal"
 	loadtestType := apisLoadTestV1.LoadTestTypeFake
 
 	requestFiles := map[string]string{
@@ -49,7 +50,7 @@ func TestIntegrationCreateLoadtestFormPostAllFiles(t *testing.T) {
 	var createdLoadTestName string
 
 	t.Run("Creates the loadtest", func(t *testing.T) {
-		request, err := createRequestWrapper(requestFiles, distributedPods, string(loadtestType))
+		request, err := createRequestWrapper(requestFiles, distributedPods, string(loadtestType), tagsString)
 		require.NoError(t, err)
 
 		resp, err := http.Post(fmt.Sprintf("http://localhost:%d/load-test", HTTPPort), request.contentType, request.body)
@@ -67,6 +68,18 @@ func TestIntegrationCreateLoadtestFormPostAllFiles(t *testing.T) {
 	t.Run("Checking the loadtest is created", func(t *testing.T) {
 		err := testhelper.WaitLoadtest(clientSet, createdLoadTestName)
 		require.NoError(t, err)
+	})
+
+	t.Run("Checking if the loadtest labels are correct", func(t *testing.T) {
+		labels, err := testhelper.GetLoadtestLabels(clientSet, createdLoadTestName)
+		require.NoError(t, err)
+
+		expected := map[string]string{
+			"test-file-hash":      "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+			"test-tag-department": "platform",
+			"test-tag-team":       "kangal",
+		}
+		assert.Equal(t, expected, labels)
 	})
 }
 
@@ -87,7 +100,7 @@ func TestIntegrationCreateLoadtestDuplicates(t *testing.T) {
 	var createdLoadTestName string
 
 	t.Run("Creates first loadtest, must succeed", func(t *testing.T) {
-		request, err := createRequestWrapper(requestFiles, distributedPods, string(loadtestType))
+		request, err := createRequestWrapper(requestFiles, distributedPods, string(loadtestType), "")
 		require.NoError(t, err)
 
 		resp, err := http.Post(fmt.Sprintf("http://localhost:%d/load-test", HTTPPort), request.contentType, request.body)
@@ -103,7 +116,7 @@ func TestIntegrationCreateLoadtestDuplicates(t *testing.T) {
 	})
 
 	t.Run("Creates second loadtest, must fail", func(t *testing.T) {
-		request, err := createRequestWrapper(requestFiles, distributedPods, string(loadtestType))
+		request, err := createRequestWrapper(requestFiles, distributedPods, string(loadtestType), "")
 		require.NoError(t, err)
 
 		resp, err := http.Post(fmt.Sprintf("http://localhost:%d/load-test", HTTPPort), request.contentType, request.body)
@@ -135,7 +148,7 @@ func TestIntegrationCreateLoadtestReachMaxLimit(t *testing.T) {
 	var createdLoadTestName string
 
 	t.Run("Creates first loadtest, must succeed", func(t *testing.T) {
-		request, err := createRequestWrapper(requestFiles, distributedPods, string(loadtestType))
+		request, err := createRequestWrapper(requestFiles, distributedPods, string(loadtestType), "")
 		require.NoError(t, err)
 
 		resp, err := http.Post(fmt.Sprintf("http://localhost:%d/load-test", HTTPPort), request.contentType, request.body)
@@ -154,7 +167,7 @@ func TestIntegrationCreateLoadtestReachMaxLimit(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Creates second loadtest, must fail", func(t *testing.T) {
-		request, err := createRequestWrapper(requestFilesSecond, distributedPods, string(loadtestType))
+		request, err := createRequestWrapper(requestFilesSecond, distributedPods, string(loadtestType), "")
 		require.NoError(t, err)
 
 		resp, err := http.Post(fmt.Sprintf("http://localhost:%d/load-test", HTTPPort), request.contentType, request.body)
@@ -180,7 +193,7 @@ func TestIntegrationCreateLoadtestFormPostOneFile(t *testing.T) {
 	var createdLoadTestName string
 
 	t.Run("Creates the loadtest", func(t *testing.T) {
-		request, err := createRequestWrapper(requestFiles, distributedPods, string(loadtestType))
+		request, err := createRequestWrapper(requestFiles, distributedPods, string(loadtestType), "")
 		require.NoError(t, err)
 
 		resp, err := http.Post(fmt.Sprintf("http://localhost:%d/load-test", HTTPPort), request.contentType, request.body)
@@ -228,7 +241,7 @@ func TestIntegrationCreateLoadtestEmptyTestFile(t *testing.T) {
 	var body io.ReadCloser
 
 	t.Run("Creates the loadtest with empty testFile", func(t *testing.T) {
-		request, err := createRequestWrapper(requestFiles, distributedPods, string(loadtestType))
+		request, err := createRequestWrapper(requestFiles, distributedPods, string(loadtestType), "")
 		require.NoError(t, err)
 
 		resp, err := http.Post(fmt.Sprintf("http://localhost:%d/load-test", HTTPPort), request.contentType, request.body)
@@ -272,7 +285,7 @@ func TestIntegrationCreateLoadtestEmptyTestDataFile(t *testing.T) {
 	var body io.ReadCloser
 
 	t.Run("Creates the loadtest", func(t *testing.T) {
-		request, err := createRequestWrapper(requestFiles, distributedPods, string(loadtestType))
+		request, err := createRequestWrapper(requestFiles, distributedPods, string(loadtestType), "")
 		require.NoError(t, err)
 
 		resp, err := http.Post(fmt.Sprintf("http://localhost:%d/load-test", HTTPPort), request.contentType, request.body)

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -48,6 +48,11 @@ func RunServer(ctx context.Context, cfg Config, rr Runner) error {
 	loadtestRoute := "/load-test"
 	loadtestRouteWithID := fmt.Sprintf("%s/{id}", loadtestRoute)
 
+	r.Method(http.MethodGet,
+		loadtestRoute,
+		ochttp.WithRouteTag(http.HandlerFunc(proxyHandler.List), loadtestRoute),
+	)
+
 	r.Method(http.MethodPost,
 		loadtestRoute,
 		ochttp.WithRouteTag(http.HandlerFunc(proxyHandler.Create), loadtestRoute),

--- a/pkg/proxy/test_helper_test.go
+++ b/pkg/proxy/test_helper_test.go
@@ -26,13 +26,17 @@ type Request struct {
 	contentType string
 }
 
-func createRequestWrapper(requestFiles map[string]string, distributedPods string, loadtestType string) (*Request, error) {
+func createRequestWrapper(requestFiles map[string]string, distributedPods string, loadtestType string, tagsString string) (*Request, error) {
 	request := &Request{}
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 
 	if err := writer.WriteField("distributedPods", distributedPods); err != nil {
 		return request, fmt.Errorf("error adding pod nr: %w", err)
+	}
+
+	if err := writer.WriteField("tags", tagsString); err != nil {
+		return request, fmt.Errorf("error adding tags: %w", err)
 	}
 
 	if err := writer.WriteField("type", loadtestType); err != nil {


### PR DESCRIPTION
## Motivation

As an end user, I have a need of tagging my load tests and be able to retrieve the list of my tests. There are a couple of use cases:

- I could tag the test with my team name and other team members could easily find out what tests we have
- I could list out all the finished or running tests of my team.

## Changes

In the `ObjectMeta` we will inject the labels so that we can use `labelSelector` to retrieve them back. The label will in format `test-tag-[LABEL]: [VALUE]`

_Creation_

There will be one more param `tags`. For example: `tags=department:platform,team=kangal`

We will create an object with labels

```
test-file-hash: <hash>
test-tag-department: platform
test-tag-team: kangal
```

_List_

The request will be like `/load-test?phase=running&tags=department:platform,team:kangal`

We will use `labelSelector` to find all matched objects, then filter again with `phase`

## Further Benefits

We can integrate with other automation system with list request for
- Download and post report to s3
- Scheduled to delete finished tests.