### PR TITLE
Add new Proxy endpoint for report persistance

### DIFF
--- a/charts/kangal/Chart.yaml
+++ b/charts/kangal/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - performance tests
   - tests runner
 name: kangal
-version: 1.1.0
+version: 1.1.1
 home: https://github.com/hellofresh/kangal
 icon: https://raw.githubusercontent.com/hellofresh/kangal/master/kangal_logo.svg
 maintainers:

--- a/charts/kangal/Chart.yaml
+++ b/charts/kangal/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - performance tests
   - tests runner
 name: kangal
-version: 1.1.1
+version: 1.2.1
 home: https://github.com/hellofresh/kangal
 icon: https://raw.githubusercontent.com/hellofresh/kangal/master/kangal_logo.svg
 maintainers:

--- a/charts/kangal/README.md
+++ b/charts/kangal/README.md
@@ -134,17 +134,18 @@ Deployment specific configurations:
 | `openapi-ui.env.VALIDATOR_URL`        | The URL to spec validator                       | `null`                                 |
 
 ### Kangal Controller
-| Parameter                             | Description                                | Default                 |
-|---------------------------------------|--------------------------------------------|-------------------------|
-| `controller.image.repository`         | Repository of the image                    | `hellofreshtech/kangal` |
-| `controller.image.tag`                | Tag of the image                           | `latest`                |
-| `controller.image.pullPolicy`         | Pull policy of the image                   | `Always`                |
-| `controller.args`                     | Argument for `kangal` command              | `["controller"]`        |
-| `controller.replicaCount`             | Number of pod replicas                     | `1`                     |
-| `controller.service.enabled`          | Service enabled flag                       | `true`                  |
-| `controller.service.enablePrometheus` | ServiceMonitor for Prometheus enabled flag | `false`                 |
-| `controller.service.type`             | Service type                               | `ClusterIP`             |
-| `controller.service.ports.http`       | Service port                               | `80`                    |
+| Parameter                             | Description                                | Default                      |
+|---------------------------------------|--------------------------------------------|------------------------------|
+| `controller.image.repository`         | Repository of the image                    | `hellofreshtech/kangal`      |
+| `controller.image.tag`                | Tag of the image                           | `latest`                     |
+| `controller.image.pullPolicy`         | Pull policy of the image                   | `Always`                     |
+| `controller.args`                     | Argument for `kangal` command              | `["controller"]`             |
+| `controller.replicaCount`             | Number of pod replicas                     | `1`                          |
+| `controller.service.enabled`          | Service enabled flag                       | `true`                       |
+| `controller.service.enablePrometheus` | ServiceMonitor for Prometheus enabled flag | `false`                      |
+| `controller.service.type`             | Service type                               | `ClusterIP`                  |
+| `controller.service.ports.http`       | Service port                               | `80`                         |
+| `controller.env.KANGAL_PROXY_URL`     | Kangal Proxy URL used to persist reports   | `https://kangal-proxy.local` |
 
 ### Kangal Controller (Locust specific)
 | Parameter                                      | Description                 | Default           |

--- a/charts/kangal/values.yaml
+++ b/charts/kangal/values.yaml
@@ -124,6 +124,7 @@ controller:
 
   # Environmental variables to set
   env:
+    KANGAL_PROXY_URL: "https://kangal-proxy.local"
     LOCUST_IMAGE: "locustio/locust"
     LOCUST_IMAGE_TAG: "1.3.0"
 

--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hellofresh/kangal/pkg/core/observability"
 	clientSet "github.com/hellofresh/kangal/pkg/kubernetes/generated/clientset/versioned"
 	informers "github.com/hellofresh/kangal/pkg/kubernetes/generated/informers/externalversions"
-	"github.com/hellofresh/kangal/pkg/report"
 )
 
 type controllerCmdOptions struct {
@@ -78,11 +77,6 @@ func NewControllerCmd(ctx context.Context) *cobra.Command {
 
 			kubeInformerFactory := kubeInformers.NewSharedInformerFactory(kubeClient, time.Second*30)
 			kangalInformerFactory := informers.NewSharedInformerFactory(kangalClient, time.Second*30)
-
-			err = report.InitObjectStorageClient(cfg.Report)
-			if err != nil {
-				return fmt.Errorf("building reportingClient client: %w", err)
-			}
 
 			return controller.Run(ctx, cfg, controller.Runner{
 				Logger:         logger,

--- a/docs/README.md
+++ b/docs/README.md
@@ -111,9 +111,10 @@ make build
 5. Set the environment variables
 
 ``` bash
-export AWS_BUCKET_NAME=YOUR_BUCKET_NAME      # name of the bucket for saving reports
-export AWS_ENDPOINT_URL=YOUR_BUCKET_ENDPOINT # storage connection parameter
-export AWS_DEFAULT_REGION=YOUR_AWS_REGION    # storage connection parameter
+export AWS_BUCKET_NAME=YOUR_BUCKET_NAME       # name of the bucket for saving reports
+export AWS_ENDPOINT_URL=YOUR_BUCKET_ENDPOINT  # storage connection parameter
+export AWS_DEFAULT_REGION=YOUR_AWS_REGION     # storage connection parameter
+export KANGAL_PROXY_URL=http://localhost:8080 # used to persist reports
 ```
 
 6. Run both Kangal proxy and controller

--- a/openapi.json
+++ b/openapi.json
@@ -171,6 +171,45 @@
 						}
 					}
 				}
+			},
+			"put": {
+				"tags": ["load-tests"],
+				"summary": "Persist report for a specific loadTest",
+				"operationId": "persistLoadTestReport",
+				"parameters": [{
+					"name": "loadTestName",
+					"in": "path",
+					"description": "The name of the load test to upload the report",
+					"required": true,
+					"style": "simple",
+					"explode": false,
+					"schema": {
+						"type": "string"
+					}
+				}],
+				"responses": {
+					"200": {
+						"description": "Report persisted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "string",
+									"example": "Report persisted"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "unexpected error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Error"
+								}
+							}
+						}
+					}
+				}
 			}
 		},
 		"/load-test/{loadTestName}/logs": {

--- a/pkg/backends/backend.go
+++ b/pkg/backends/backend.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hellofresh/kangal/pkg/backends/locust"
 	loadTestV1 "github.com/hellofresh/kangal/pkg/kubernetes/apis/loadtest/v1"
 	clientSetV "github.com/hellofresh/kangal/pkg/kubernetes/generated/clientset/versioned"
-	"github.com/hellofresh/kangal/pkg/report"
 )
 
 // LoadTestType defines the methods that a loadtest type needs to implement
@@ -37,15 +36,14 @@ type Config struct {
 }
 
 // NewLoadTest returns a new LoadTestType
-func NewLoadTest(loadTest *loadTestV1.LoadTest, kubeClientSet kubernetes.Interface, kangalClientSet clientSetV.Interface, logger *zap.Logger, namespacesLister coreListersV1.NamespaceLister, reportConfig report.Config, podAnnotations, namespaceAnnotations map[string]string, backendsConfig Config) (LoadTestType, error) {
-	presignedURL := report.NewPreSignedPutURL(loadTest.GetName())
+func NewLoadTest(loadTest *loadTestV1.LoadTest, kubeClientSet kubernetes.Interface, kangalClientSet clientSetV.Interface, logger *zap.Logger, namespacesLister coreListersV1.NamespaceLister, reportURL string, podAnnotations, namespaceAnnotations map[string]string, backendsConfig Config) (LoadTestType, error) {
 	switch loadTest.Spec.Type {
 	case loadTestV1.LoadTestTypeJMeter:
-		return jmeter.New(kubeClientSet, kangalClientSet, loadTest, logger, namespacesLister, presignedURL, podAnnotations, namespaceAnnotations, backendsConfig.JMeter), nil
+		return jmeter.New(kubeClientSet, kangalClientSet, loadTest, logger, namespacesLister, reportURL, podAnnotations, namespaceAnnotations, backendsConfig.JMeter), nil
 	case loadTestV1.LoadTestTypeFake:
 		return fake.New(kubeClientSet, loadTest, logger), nil
 	case loadTestV1.LoadTestTypeLocust:
-		return locust.New(kubeClientSet, kangalClientSet, loadTest, logger, presignedURL, backendsConfig.Locust, podAnnotations), nil
+		return locust.New(kubeClientSet, kangalClientSet, loadTest, logger, reportURL, backendsConfig.Locust, podAnnotations), nil
 	}
 	return nil, fmt.Errorf("load test provider not found: %s", loadTest.Spec.Type)
 }

--- a/pkg/backends/jmeter/jmeter_test.go
+++ b/pkg/backends/jmeter/jmeter_test.go
@@ -2,7 +2,6 @@ package jmeter
 
 import (
 	"context"
-	"net/url"
 	"testing"
 
 	"github.com/hellofresh/kangal/pkg/kubernetes/generated/clientset/versioned/fake"
@@ -159,7 +158,7 @@ func TestJMeter_CheckOrCreateResources(t *testing.T) {
 		},
 		logger,
 		namespaceLister,
-		&url.URL{},
+		"",
 		map[string]string{"": ""},
 		map[string]string{"": ""},
 		Config{},

--- a/pkg/backends/jmeter/jmeter_test.go
+++ b/pkg/backends/jmeter/jmeter_test.go
@@ -158,7 +158,7 @@ func TestJMeter_CheckOrCreateResources(t *testing.T) {
 		},
 		logger,
 		namespaceLister,
-		"",
+		"http://kangal-proxy.local/load-test/loadtest-name/report",
 		map[string]string{"": ""},
 		map[string]string{"": ""},
 		Config{},

--- a/pkg/backends/jmeter/resources.go
+++ b/pkg/backends/jmeter/resources.go
@@ -4,7 +4,6 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"strings"
 
@@ -233,7 +232,7 @@ func (c *JMeter) NewPod(i int, configMap *coreV1.ConfigMap, podAnnotations map[s
 }
 
 // NewJMeterMasterJob creates a new job which runs the jmeter master pod
-func (c *JMeter) NewJMeterMasterJob(preSignedURL *url.URL, podAnnotations map[string]string) *batchV1.Job {
+func (c *JMeter) NewJMeterMasterJob(reportURL string, podAnnotations map[string]string) *batchV1.Job {
 	loadtest := c.loadTest
 	var one int32 = 1
 	MasterConfig := loadtest.Spec.MasterConfig
@@ -249,10 +248,10 @@ func (c *JMeter) NewJMeterMasterJob(preSignedURL *url.URL, podAnnotations map[st
 		},
 	}
 
-	if nil != preSignedURL {
+	if "" != reportURL {
 		jMeterEnvVars = append(jMeterEnvVars, coreV1.EnvVar{
 			Name:  "REPORT_PRESIGNED_URL",
-			Value: preSignedURL.String(),
+			Value: reportURL,
 		})
 	}
 

--- a/pkg/backends/jmeter/resources_test.go
+++ b/pkg/backends/jmeter/resources_test.go
@@ -1,7 +1,6 @@
 package jmeter
 
 import (
-	"net/url"
 	"testing"
 
 	"github.com/hellofresh/kangal/pkg/core/helper"
@@ -115,7 +114,7 @@ func TestPodResourceConfiguration(t *testing.T) {
 		},
 	}
 
-	masterJob := c.NewJMeterMasterJob(&url.URL{}, map[string]string{"": ""})
+	masterJob := c.NewJMeterMasterJob("", map[string]string{"": ""})
 	assert.Equal(t, c.masterResources.CPULimits, masterJob.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String())
 	assert.Equal(t, c.masterResources.CPURequests, masterJob.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String())
 	assert.Equal(t, c.masterResources.MemoryLimits, masterJob.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String())

--- a/pkg/backends/jmeter/resources_test.go
+++ b/pkg/backends/jmeter/resources_test.go
@@ -114,7 +114,7 @@ func TestPodResourceConfiguration(t *testing.T) {
 		},
 	}
 
-	masterJob := c.NewJMeterMasterJob("", map[string]string{"": ""})
+	masterJob := c.NewJMeterMasterJob("http://kangal-proxy.local/load-test/loadtest-name/report", map[string]string{"": ""})
 	assert.Equal(t, c.masterResources.CPULimits, masterJob.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String())
 	assert.Equal(t, c.masterResources.CPURequests, masterJob.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String())
 	assert.Equal(t, c.masterResources.MemoryLimits, masterJob.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String())

--- a/pkg/backends/locust/locust.go
+++ b/pkg/backends/locust/locust.go
@@ -3,7 +3,6 @@ package locust
 import (
 	"context"
 	"fmt"
-	"net/url"
 
 	coreV1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -23,16 +22,16 @@ var (
 
 // Locust enables the controller to run a loadtest using locust.io
 type Locust struct {
-	kubeClientSet      kubernetes.Interface
-	kangalClientSet    clientSetV.Interface
-	loadTest           *loadTestV1.LoadTest
-	logger             *zap.Logger
-	reportPreSignedURL *url.URL
-	image              string
-	imageTag           string
-	masterResources    helper.Resources
-	workerResources    helper.Resources
-	podAnnotations     map[string]string
+	kubeClientSet   kubernetes.Interface
+	kangalClientSet clientSetV.Interface
+	loadTest        *loadTestV1.LoadTest
+	logger          *zap.Logger
+	reportURL       string
+	image           string
+	imageTag        string
+	masterResources helper.Resources
+	workerResources helper.Resources
+	podAnnotations  map[string]string
 }
 
 // SetDefaults mutates the LoadTest object to add default values to empty fields
@@ -110,7 +109,7 @@ func (c *Locust) CheckOrCreateResources(ctx context.Context) error {
 		}
 	}
 
-	masterJob := newMasterJob(c.loadTest, configMap, secret, c.reportPreSignedURL, c.masterResources, c.podAnnotations)
+	masterJob := newMasterJob(c.loadTest, configMap, secret, c.reportURL, c.masterResources, c.podAnnotations)
 	_, err = c.kubeClientSet.
 		BatchV1().
 		Jobs(c.loadTest.Status.Namespace).
@@ -186,7 +185,7 @@ func New(
 	kangalClientSet clientSetV.Interface,
 	loadTest *loadTestV1.LoadTest,
 	logger *zap.Logger,
-	reportPreSignedURL *url.URL,
+	reportURL string,
 	config Config,
 	podAnnotations map[string]string,
 ) *Locust {
@@ -201,13 +200,13 @@ func New(
 	}
 
 	return &Locust{
-		kubeClientSet:      kubeClientSet,
-		kangalClientSet:    kangalClientSet,
-		loadTest:           loadTest,
-		logger:             logger,
-		reportPreSignedURL: reportPreSignedURL,
-		image:              image,
-		imageTag:           imageTag,
+		kubeClientSet:   kubeClientSet,
+		kangalClientSet: kangalClientSet,
+		loadTest:        loadTest,
+		logger:          logger,
+		reportURL:       reportURL,
+		image:           image,
+		imageTag:        imageTag,
 		masterResources: helper.Resources{
 			CPULimits:      config.MasterCPULimits,
 			CPURequests:    config.MasterCPURequests,

--- a/pkg/backends/locust/locust_test.go
+++ b/pkg/backends/locust/locust_test.go
@@ -46,7 +46,7 @@ func TestLocustCheckOrCreateResources(t *testing.T) {
 			},
 		},
 		logger,
-		"",
+		"http://kangal-proxy.local/load-test/loadtest-name/report",
 		Config{},
 		map[string]string{},
 	)
@@ -93,7 +93,7 @@ func TestLocustCheckOrUpdateStatus(t *testing.T) {
 			},
 		},
 		logger,
-		"",
+		"http://kangal-proxy.local/load-test/loadtest-name/report",
 		Config{},
 		map[string]string{"": ""},
 	)

--- a/pkg/backends/locust/locust_test.go
+++ b/pkg/backends/locust/locust_test.go
@@ -2,7 +2,6 @@ package locust
 
 import (
 	"context"
-	"net/url"
 	"testing"
 
 	batchV1 "k8s.io/api/batch/v1"
@@ -47,7 +46,7 @@ func TestLocustCheckOrCreateResources(t *testing.T) {
 			},
 		},
 		logger,
-		&url.URL{},
+		"",
 		Config{},
 		map[string]string{},
 	)
@@ -94,7 +93,7 @@ func TestLocustCheckOrUpdateStatus(t *testing.T) {
 			},
 		},
 		logger,
-		&url.URL{},
+		"",
 		Config{},
 		map[string]string{"": ""},
 	)

--- a/pkg/backends/locust/resources.go
+++ b/pkg/backends/locust/resources.go
@@ -2,7 +2,6 @@ package locust
 
 import (
 	"fmt"
-	"net/url"
 
 	batchV1 "k8s.io/api/batch/v1"
 	coreV1 "k8s.io/api/core/v1"
@@ -64,7 +63,7 @@ func newMasterJobName(loadTest *loadtestV1.LoadTest) string {
 	return fmt.Sprintf("%s-master", loadTest.ObjectMeta.Name)
 }
 
-func newMasterJob(loadTest *loadtestV1.LoadTest, testfileConfigMap *coreV1.ConfigMap, envvarSecret *coreV1.Secret, preSignedURL *url.URL, masterResources helper.Resources, podAnnotations map[string]string) *batchV1.Job {
+func newMasterJob(loadTest *loadtestV1.LoadTest, testfileConfigMap *coreV1.ConfigMap, envvarSecret *coreV1.Secret, reportURL string, masterResources helper.Resources, podAnnotations map[string]string) *batchV1.Job {
 	name := newMasterJobName(loadTest)
 
 	ownerRef := metaV1.NewControllerRef(loadTest, loadtestV1.SchemeGroupVersion.WithKind("LoadTest"))
@@ -81,10 +80,10 @@ func newMasterJob(loadTest *loadtestV1.LoadTest, testfileConfigMap *coreV1.Confi
 		{Name: "LOCUST_RUN_TIME", Value: loadTest.Spec.Duration.String()},
 	}
 
-	if nil != preSignedURL {
+	if "" != reportURL {
 		envVars = append(envVars, coreV1.EnvVar{
 			Name:  "REPORT_PRESIGNED_URL",
-			Value: preSignedURL.String(),
+			Value: reportURL,
 		})
 	}
 

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hellofresh/kangal/pkg/backends"
 	"github.com/hellofresh/kangal/pkg/core/observability"
-	"github.com/hellofresh/kangal/pkg/report"
 )
 
 // Config is the possible Kangal Controller configurations
@@ -17,8 +16,8 @@ type Config struct {
 	// load test lives for, the default is 1 hour. (ex. 5h)
 	CleanUpThreshold time.Duration `envconfig:"CLEANUP_THRESHOLD" default:"1h"`
 	// S3 compatible configuration access keys and endpoints needed to store load test reports
-	Report   report.Config
-	Backends backends.Config
+	KangalProxyURL string `envconfig:"KANGAL_PROXY_URL" default:""`
+	Backends       backends.Config
 
 	MasterURL            string
 	KubeConfig           string

--- a/pkg/controller/loadtest.go
+++ b/pkg/controller/loadtest.go
@@ -301,7 +301,12 @@ func (c *Controller) syncHandler(key string) error {
 	loadTest := loadTestFromCache.DeepCopy()
 	defer c.updateLoadTestStatus(ctx, loadTest)
 
-	backend, err := backends.NewLoadTest(loadTest, c.kubeClientSet, c.kangalClientSet, c.logger, c.namespacesLister, c.cfg.Report, c.cfg.PodAnnotations, c.cfg.NamespaceAnnotations, c.cfg.Backends)
+	var reportURL string
+	if c.cfg.KangalProxyURL != "" {
+		reportURL = fmt.Sprintf("%s/load-test/%s/report", c.cfg.KangalProxyURL, loadTest.GetName())
+	}
+
+	backend, err := backends.NewLoadTest(loadTest, c.kubeClientSet, c.kangalClientSet, c.logger, c.namespacesLister, reportURL, c.cfg.PodAnnotations, c.cfg.NamespaceAnnotations, c.cfg.Backends)
 	if err != nil {
 		return fmt.Errorf("failed to create new backend: %w", err)
 	}

--- a/pkg/core/helper/helper_test.go
+++ b/pkg/core/helper/helper_test.go
@@ -7,6 +7,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestBuildResourceRequirements(t *testing.T) {
+	req := helper.BuildResourceRequirements(helper.Resources{
+		CPULimits:      "500m",
+		CPURequests:    "250m",
+		MemoryLimits:   "128Mi",
+		MemoryRequests: "64Mi",
+	})
+	assert.Equal(t, int(2), len(req.Limits))
+	assert.Equal(t, int(2), len(req.Requests))
+}
+
 func TestReadSecret(t *testing.T) {
 	teststring := "aaa,1\nbbb,2\nccc,3\n"
 

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -84,7 +84,7 @@ func RunServer(ctx context.Context, cfg Config, rr Runner) error {
 		http.Redirect(w, r, url, http.StatusMovedPermanently)
 	})
 	r.Get("/load-test/{id}/report/*", report.ShowHandler())
-	r.Put("/load-test/{id}/report", report.PersistHandler(rr.KubeClient))
+	r.Put("/load-test/{id}/report", report.PersistHandler(rr.KubeClient, rr.Logger))
 
 	address := fmt.Sprintf(":%d", cfg.HTTPPort)
 	rr.Logger.Info("Running HTTP server...", zap.String("address", address))

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -79,6 +79,7 @@ func RunServer(ctx context.Context, cfg Config, rr Runner) error {
 		http.Redirect(w, r, url, http.StatusMovedPermanently)
 	})
 	r.Get("/load-test/{id}/report/*", report.ShowHandler())
+	r.Put("/load-test/{id}/report", report.PersistHandler(rr.KubeClient))
 
 	address := fmt.Sprintf(":%d", cfg.HTTPPort)
 	rr.Logger.Info("Running HTTP server...", zap.String("address", address))

--- a/pkg/report/handler.go
+++ b/pkg/report/handler.go
@@ -2,10 +2,15 @@ package report
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 
 	"github.com/go-chi/chi"
+
+	kube "github.com/hellofresh/kangal/pkg/kubernetes"
 )
+
+var httpClient = &http.Client{}
 
 //ShowHandler method returns response from file bucket in defined object storage
 func ShowHandler() func(w http.ResponseWriter, r *http.Request) {
@@ -26,5 +31,55 @@ func ShowHandler() func(w http.ResponseWriter, r *http.Request) {
 		}
 
 		http.FileServer(fs).ServeHTTP(w, r)
+	}
+}
+
+//PersistHandler method streams request to storage presigned URL
+func PersistHandler(kubeClient *kube.Client) func(w http.ResponseWriter, r *http.Request) {
+	if minioClient == nil {
+		panic("client was not initialized, please initialize object storage client")
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		loadTestName := chi.URLParam(r, "id")
+
+		_, err := kubeClient.GetLoadTest(r.Context(), loadTestName)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		url, err := newPreSignedPutURL(loadTestName)
+		if nil != err {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		proxyReq, err := http.NewRequest(r.Method, url.String(), r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		for header, values := range r.Header {
+			for _, value := range values {
+				proxyReq.Header.Add(header, value)
+			}
+		}
+		proxyReq.ContentLength = r.ContentLength
+
+		proxyResp, err := httpClient.Do(proxyReq)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		proxyRespBody, err := ioutil.ReadAll(proxyResp.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(proxyResp.StatusCode)
+		w.Write(proxyRespBody)
 	}
 }

--- a/pkg/report/handler.go
+++ b/pkg/report/handler.go
@@ -61,32 +61,15 @@ func PersistHandler(kubeClient *kk8s.Client) func(w http.ResponseWriter, r *http
 			return
 		}
 
-		proxyReq, err := http.NewRequest(r.Method, url.String(), r.Body)
-		if err != nil {
-			render.Render(w, r, khttp.ErrResponse(http.StatusInternalServerError, err.Error()))
-			return
-		}
-		for header, values := range r.Header {
-			for _, value := range values {
-				proxyReq.Header.Add(header, value)
-			}
-		}
+		proxyReq, _ := http.NewRequest(r.Method, url.String(), r.Body)
 		proxyReq.ContentLength = r.ContentLength
 
-		proxyResp, err := httpClient.Do(proxyReq)
-		if err != nil {
-			render.Render(w, r, khttp.ErrResponse(http.StatusInternalServerError, err.Error()))
-			return
-		}
+		proxyResp, _ := httpClient.Do(proxyReq)
 
 		body := "Report persisted"
 
 		if http.StatusOK != proxyResp.StatusCode {
-			b, err := ioutil.ReadAll(proxyResp.Body)
-			if err != nil {
-				render.Render(w, r, khttp.ErrResponse(http.StatusInternalServerError, err.Error()))
-				return
-			}
+			b, _ := ioutil.ReadAll(proxyResp.Body)
 			body = string(b)
 		}
 

--- a/pkg/report/handler.go
+++ b/pkg/report/handler.go
@@ -62,8 +62,12 @@ func PersistHandler(kubeClient *kk8s.Client) func(w http.ResponseWriter, r *http
 			return
 		}
 
-		proxyReq, _ := http.NewRequest(r.Method, url.String(), r.Body)
+		proxyReq, err := http.NewRequestWithContext(r.Context(), r.Method, url.String(), r.Body)
 		proxyReq.ContentLength = r.ContentLength
+		if nil != err {
+			render.Render(w, r, khttp.ErrResponse(http.StatusInternalServerError, err.Error()))
+			return
+		}
 
 		proxyResp, _ := httpClient.Do(proxyReq)
 

--- a/pkg/report/handler.go
+++ b/pkg/report/handler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	khttp "github.com/hellofresh/kangal/pkg/core/http"
 	kk8s "github.com/hellofresh/kangal/pkg/kubernetes"
@@ -14,7 +15,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 )
 
-var httpClient = &http.Client{}
+var httpClient = &http.Client{
+	Timeout: 30 * time.Second,
+}
 
 //ShowHandler method returns response from file bucket in defined object storage
 func ShowHandler() func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/report/handler.go
+++ b/pkg/report/handler.go
@@ -63,12 +63,12 @@ func PersistHandler(kubeClient *kk8s.Client) func(w http.ResponseWriter, r *http
 		}
 
 		proxyReq, err := http.NewRequestWithContext(r.Context(), r.Method, url.String(), r.Body)
-		proxyReq.ContentLength = r.ContentLength
-		proxyReq.Header = r.Header
 		if nil != err {
 			render.Render(w, r, khttp.ErrResponse(http.StatusInternalServerError, err.Error()))
 			return
 		}
+		proxyReq.ContentLength = r.ContentLength
+		proxyReq.Header = r.Header
 
 		proxyResp, err := httpClient.Do(proxyReq)
 		if nil != err {

--- a/pkg/report/handler.go
+++ b/pkg/report/handler.go
@@ -2,6 +2,7 @@ package report
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 
 	"github.com/go-chi/chi"
@@ -78,7 +79,18 @@ func PersistHandler(kubeClient *kk8s.Client) func(w http.ResponseWriter, r *http
 			return
 		}
 
+		body := "Report persisted"
+
+		if http.StatusOK != proxyResp.StatusCode {
+			b, err := ioutil.ReadAll(proxyResp.Body)
+			if err != nil {
+				render.Render(w, r, khttp.ErrResponse(http.StatusInternalServerError, err.Error()))
+				return
+			}
+			body = string(b)
+		}
+
 		render.Status(r, proxyResp.StatusCode)
-		render.JSON(w, r, "Report persisted")
+		render.JSON(w, r, body)
 	}
 }

--- a/pkg/report/handler.go
+++ b/pkg/report/handler.go
@@ -75,6 +75,7 @@ func PersistHandler(kubeClient *kk8s.Client) func(w http.ResponseWriter, r *http
 			render.Render(w, r, khttp.ErrResponse(http.StatusInternalServerError, err.Error()))
 			return
 		}
+		defer proxyResp.Body.Close()
 
 		body := "Report persisted"
 

--- a/pkg/report/handler.go
+++ b/pkg/report/handler.go
@@ -5,10 +5,11 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/go-chi/chi"
-	"github.com/go-chi/render"
 	khttp "github.com/hellofresh/kangal/pkg/core/http"
 	kk8s "github.com/hellofresh/kangal/pkg/kubernetes"
+
+	"github.com/go-chi/chi"
+	"github.com/go-chi/render"
 	"k8s.io/apimachinery/pkg/api/errors"
 )
 

--- a/pkg/report/handler.go
+++ b/pkg/report/handler.go
@@ -70,7 +70,11 @@ func PersistHandler(kubeClient *kk8s.Client) func(w http.ResponseWriter, r *http
 			return
 		}
 
-		proxyResp, _ := httpClient.Do(proxyReq)
+		proxyResp, err := httpClient.Do(proxyReq)
+		if nil != err {
+			render.Render(w, r, khttp.ErrResponse(http.StatusInternalServerError, err.Error()))
+			return
+		}
 
 		body := "Report persisted"
 

--- a/pkg/report/handler.go
+++ b/pkg/report/handler.go
@@ -64,6 +64,7 @@ func PersistHandler(kubeClient *kk8s.Client) func(w http.ResponseWriter, r *http
 
 		proxyReq, err := http.NewRequestWithContext(r.Context(), r.Method, url.String(), r.Body)
 		proxyReq.ContentLength = r.ContentLength
+		proxyReq.Header = r.Header
 		if nil != err {
 			render.Render(w, r, khttp.ErrResponse(http.StatusInternalServerError, err.Error()))
 			return

--- a/pkg/report/handler.go
+++ b/pkg/report/handler.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-chi/chi"
 	"github.com/go-chi/render"
+	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/errors"
 )
 
@@ -38,7 +39,7 @@ func ShowHandler() func(w http.ResponseWriter, r *http.Request) {
 }
 
 //PersistHandler method streams request to storage presigned URL
-func PersistHandler(kubeClient *kk8s.Client) func(w http.ResponseWriter, r *http.Request) {
+func PersistHandler(kubeClient *kk8s.Client, logger *zap.Logger) func(w http.ResponseWriter, r *http.Request) {
 	if minioClient == nil {
 		panic("client was not initialized, please initialize object storage client")
 	}
@@ -72,6 +73,7 @@ func PersistHandler(kubeClient *kk8s.Client) func(w http.ResponseWriter, r *http
 
 		proxyResp, err := httpClient.Do(proxyReq)
 		if nil != err {
+			logger.Error("Failed to persist report", zap.Error(err), zap.String("loadtest", loadTestName))
 			render.Render(w, r, khttp.ErrResponse(http.StatusInternalServerError, err.Error()))
 			return
 		}

--- a/pkg/report/handler_test.go
+++ b/pkg/report/handler_test.go
@@ -95,6 +95,14 @@ func TestPersistHandler(t *testing.T) {
 			},
 			expectedStatusCode: http.StatusUnauthorized,
 		},
+		{
+			name:                   "Request timed out",
+			fakeResponseStatusCode: http.StatusRequestTimeout,
+			getLoadTestsFn: func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+				return true, &loadtestV1.LoadTest{}, nil
+			},
+			expectedStatusCode: http.StatusRequestTimeout,
+		},
 	}
 
 	req, err := http.NewRequest("PUT", "/load-test/loadtest-name/report", nil)

--- a/pkg/report/handler_test.go
+++ b/pkg/report/handler_test.go
@@ -106,6 +106,7 @@ func TestPersistHandler(t *testing.T) {
 	minioClient, _ = minio.NewWithRegion("localhost:80", "access-key", "secret-access-key", false, "us-east1")
 	bucketName = "bucket-name"
 	expires = time.Second
+	logger := zap.NewNop()
 
 	for _, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {
@@ -128,7 +129,7 @@ func TestPersistHandler(t *testing.T) {
 
 			rr := httptest.NewRecorder()
 			handler := chi.NewRouter()
-			handler.Put("/load-test/{id}/report", PersistHandler(kangalKubeClient))
+			handler.Put("/load-test/{id}/report", PersistHandler(kangalKubeClient, logger))
 			handler.ServeHTTP(rr, req)
 
 			assert.Equal(t, rr.Code, scenario.expectedStatusCode)

--- a/pkg/report/handler_test.go
+++ b/pkg/report/handler_test.go
@@ -8,17 +8,19 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-chi/chi"
-	kk8s "github.com/hellofresh/kangal/pkg/kubernetes"
-	loadtestV1 "github.com/hellofresh/kangal/pkg/kubernetes/apis/loadtest/v1"
-	"github.com/hellofresh/kangal/pkg/kubernetes/generated/clientset/versioned/fake"
-	"github.com/minio/minio-go/v6"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
+
+	kk8s "github.com/hellofresh/kangal/pkg/kubernetes"
+	loadtestV1 "github.com/hellofresh/kangal/pkg/kubernetes/apis/loadtest/v1"
+	"github.com/hellofresh/kangal/pkg/kubernetes/generated/clientset/versioned/fake"
+
+	"github.com/go-chi/chi"
+	"github.com/minio/minio-go/v6"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 )
 
 // fakeFS mocks http.FileSystem

--- a/pkg/report/presigned.go
+++ b/pkg/report/presigned.go
@@ -1,16 +1,17 @@
 package report
 
 import (
+	"errors"
 	"net/url"
 )
 
-// NewPreSignedPutURL returns a signed URL that allows to upload a single file
-func NewPreSignedPutURL(loadTestName string) *url.URL {
+var ErrNoMinioClient = errors.New("Minio client not initialized")
+
+// newPreSignedPutURL returns a signed URL that allows to upload a single file
+func newPreSignedPutURL(loadTestName string) (*url.URL, error) {
 	if nil == minioClient {
-		return nil
+		return nil, ErrNoMinioClient
 	}
 
-	presignedURL, _ := minioClient.PresignedPutObject(bucketName, loadTestName, expires)
-
-	return presignedURL
+	return minioClient.PresignedPutObject(bucketName, loadTestName, expires)
 }

--- a/pkg/report/presigned.go
+++ b/pkg/report/presigned.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 )
 
+// ErrNoMinioClient is returned when the package was not initialized with `InitObjectStorageClient`
 var ErrNoMinioClient = errors.New("Minio client not initialized")
 
 // newPreSignedPutURL returns a signed URL that allows to upload a single file

--- a/pkg/report/presigned_test.go
+++ b/pkg/report/presigned_test.go
@@ -17,8 +17,9 @@ func TestNewPreSignedPutURL(t *testing.T) {
 	assert.Nil(t, err)
 
 	loadTestName := "fake-loadtest"
-	url := NewPreSignedPutURL(loadTestName)
+	url, err := newPreSignedPutURL(loadTestName)
 
+	assert.NoError(t, err)
 	assert.NotNil(t, url)
 	assert.Contains(t, url.String(), loadTestName)
 }
@@ -26,6 +27,7 @@ func TestNewPreSignedPutURL(t *testing.T) {
 func TestNilClientNewPreSignedPutURL(t *testing.T) {
 	minioClient = nil
 	loadTestName := "fake-loadtest"
-	url := NewPreSignedPutURL(loadTestName)
+	url, err := newPreSignedPutURL(loadTestName)
+	assert.EqualError(t, err, ErrNoMinioClient.Error())
 	assert.Nil(t, url)
 }


### PR DESCRIPTION
EES-4260

Using Presigned URL's to persist reports does not works well when using IAM roles to obtain credentials.
That's because even if you issue a URL for a long period, you still limited to the credentials expire time, which is 15 minutes, and no way to control that.

This PR adds a new endpoint to Kangal Controller (PUT /load-test/{id}/report) which generates a fresh Presigned URL and stream the request content to it.