### PR TITLE
Configurable jmeter backend master and worker images

### DIFF
--- a/docs/jmeter/README.md
+++ b/docs/jmeter/README.md
@@ -4,6 +4,7 @@
 - [Installing JMeter for local test development](#installing-jmeter-for-local-test-development)
 - [Required JMeter plugins](#required-jmeter-plugins)
 - [Configuring JMeter resource requirements](#configuring-jmeter-resource-requirements)
+- [Configuring Master and Worker image](#configuring-master-and-worker-image)
 - [Writing tests](writing-tests.md)
 - [Reporting](reporting.md)
 
@@ -66,6 +67,15 @@ JMETER_WORKER_MEMORY_REQUESTS
 More information regarding resource limits and requests can be found in the following page(s):
 - https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 - https://cloud.google.com/blog/products/gcp/kubernetes-best-practices-resource-requests-and-limits
+
+## Configuring Master and Worker image
+You can use the following environment variables to use a specific docker images used for the jmeter master and worker:
+```
+JMETER_MASTER_IMAGE
+JMETER_MASTER_IMAGE_TAG
+JMETER_WORKER_IMAGE
+JMETER_WORKER_IMAGE_TAG
+```
 
 ## Writing tests
 Read more at [docs/jmeter/writing-tests.md](writing-tests.md).

--- a/pkg/backends/jmeter/config.go
+++ b/pkg/backends/jmeter/config.go
@@ -2,10 +2,14 @@ package jmeter
 
 // Config specific to JMeter backend
 type Config struct {
+	MasterImage          string `envconfig:"JMETER_MASTER_IMAGE" default:"hellofreshtech/kangal-jmeter-master"`
+	MasterImageTag       string `envconfig:"JMETER_MASTER_IMAGE_TAG" default:"latest"`
 	MasterCPULimits      string `envconfig:"JMETER_MASTER_CPU_LIMITS"`
 	MasterCPURequests    string `envconfig:"JMETER_MASTER_CPU_REQUESTS"`
 	MasterMemoryLimits   string `envconfig:"JMETER_MASTER_MEMORY_LIMITS"`
 	MasterMemoryRequests string `envconfig:"JMETER_MASTER_MEMORY_REQUESTS"`
+	WorkerImage          string `envconfig:"JMETER_WORKER_IMAGE" default:"hellofreshtech/kangal-jmeter-worker"`
+	WorkerImageTag       string `envconfig:"JMETER_WORKER_IMAGE_TAG" default:"latest"`
 	WorkerCPULimits      string `envconfig:"JMETER_WORKER_CPU_LIMITS"`
 	WorkerCPURequests    string `envconfig:"JMETER_WORKER_CPU_REQUESTS"`
 	WorkerMemoryLimits   string `envconfig:"JMETER_WORKER_MEMORY_LIMITS"`

--- a/pkg/backends/jmeter/jmeter.go
+++ b/pkg/backends/jmeter/jmeter.go
@@ -24,9 +24,6 @@ var (
 	MaxWaitTimeForPods = time.Minute * 10
 	//loadTestWorkerLabelSelector is the selector used for selecting jmeter worker resources
 	loadTestWorkerLabelSelector = fmt.Sprintf("%s=%s", loadTestWorkerPodLabelKey, loadTestWorkerPodLabelValue)
-	masterImage                 = "hellofreshtech/kangal-jmeter-master"
-	workerImage                 = "hellofreshtech/kangal-jmeter-worker"
-	imageTag                    = "latest"
 )
 
 // JMeter enables the controller to run a loadtest using JMeter
@@ -37,7 +34,11 @@ type JMeter struct {
 	logger             *zap.Logger
 	namespacesLister   coreListersV1.NamespaceLister
 	reportPreSignedURL *url.URL
+	masterImage        string
+	masterImageTag     string
 	masterResources    helper.Resources
+	workerImage        string
+	workerImageTag     string
 	workerResources    helper.Resources
 
 	podAnnotations, namespaceAnnotations map[string]string
@@ -54,12 +55,16 @@ func New(kubeClientSet kubernetes.Interface, kangalClientSet clientSetV.Interfac
 		reportPreSignedURL:   reportPreSignedURL,
 		podAnnotations:       podAnnotations,
 		namespaceAnnotations: namespaceAnnotations,
+		masterImage:          config.MasterImage,
+		masterImageTag:       config.MasterImageTag,
 		masterResources: helper.Resources{
 			CPULimits:      config.MasterCPULimits,
 			CPURequests:    config.MasterCPURequests,
 			MemoryLimits:   config.MasterMemoryLimits,
 			MemoryRequests: config.MasterMemoryRequests,
 		},
+		workerImage:    config.WorkerImage,
+		workerImageTag: config.WorkerImageTag,
 		workerResources: helper.Resources{
 			CPULimits:      config.WorkerCPULimits,
 			CPURequests:    config.WorkerCPURequests,
@@ -76,19 +81,19 @@ func (c *JMeter) SetDefaults() error {
 	}
 
 	if c.loadTest.Spec.MasterConfig.Image == "" {
-		c.loadTest.Spec.MasterConfig.Image = masterImage
+		c.loadTest.Spec.MasterConfig.Image = c.masterImage
 	}
 
 	if c.loadTest.Spec.MasterConfig.Tag == "" {
-		c.loadTest.Spec.MasterConfig.Tag = imageTag
+		c.loadTest.Spec.MasterConfig.Tag = c.masterImageTag
 	}
 
 	if c.loadTest.Spec.WorkerConfig.Image == "" {
-		c.loadTest.Spec.WorkerConfig.Image = workerImage
+		c.loadTest.Spec.WorkerConfig.Image = c.workerImage
 	}
 
 	if c.loadTest.Spec.WorkerConfig.Tag == "" {
-		c.loadTest.Spec.WorkerConfig.Tag = imageTag
+		c.loadTest.Spec.WorkerConfig.Tag = c.workerImageTag
 	}
 
 	return nil

--- a/pkg/backends/jmeter/spec.go
+++ b/pkg/backends/jmeter/spec.go
@@ -24,5 +24,5 @@ func BuildLoadTestSpec(overwrite bool, distributedPods int32, testFileStr, testD
 	if testFileStr == "" {
 		return lt, ErrRequireTestFile
 	}
-	return loadTestV1.NewSpec(loadTestV1.LoadTestTypeJMeter, overwrite, distributedPods, testFileStr, testDataStr, envVarsStr, loadTestV1.ImageDetails{Image: masterImage, Tag: imageTag}, loadTestV1.ImageDetails{Image: workerImage, Tag: imageTag}, "", time.Duration(0)), nil
+	return loadTestV1.NewSpec(loadTestV1.LoadTestTypeJMeter, overwrite, distributedPods, testFileStr, testDataStr, envVarsStr, loadTestV1.ImageDetails{}, loadTestV1.ImageDetails{}, "", time.Duration(0)), nil
 }

--- a/pkg/backends/jmeter/spec_test.go
+++ b/pkg/backends/jmeter/spec_test.go
@@ -35,8 +35,8 @@ func TestBuildJMeterLoadTestSpec(t *testing.T) {
 			want: v1.LoadTestSpec{
 				Type:            "JMeter",
 				Overwrite:       true,
-				MasterConfig:    v1.ImageDetails{Image: masterImage, Tag: imageTag},
-				WorkerConfig:    v1.ImageDetails{Image: workerImage, Tag: imageTag},
+				MasterConfig:    v1.ImageDetails{},
+				WorkerConfig:    v1.ImageDetails{},
 				DistributedPods: &distributedPods,
 				TestFile:        "something in the file",
 				TestData:        "some test data",


### PR DESCRIPTION
This PR:
- Makes master and worker image configurable
- Keeps the current defaults when unspecified: `hellofreshtech/kangal-jmeter-master:latest` and `hellofresh/kangal-jmeter-worker:master` when they are not specified

This allows automated testing of [`kangal-jmeter`](https://github.com/hellofresh/kangal-jmeter) images before they are released live.