### PR TITLE
Remove SetDefaults method

### DIFF
--- a/pkg/backends/backend.go
+++ b/pkg/backends/backend.go
@@ -20,9 +20,6 @@ import (
 // LoadTestType defines the methods that a loadtest type needs to implement
 // for the controller to be able to run it
 type LoadTestType interface {
-	// SetDefaults mutates the LoadTest object to add default values to empty fields
-	SetDefaults() error
-
 	// CheckOrCreateResources check for resources or create the needed resources for the loadtest type
 	CheckOrCreateResources(ctx context.Context) error
 

--- a/pkg/backends/fake/fake.go
+++ b/pkg/backends/fake/fake.go
@@ -33,23 +33,6 @@ func New(kubeClientSet kubernetes.Interface, lt *loadTestV1.LoadTest, logger *za
 	}
 }
 
-// SetDefaults set default values for creating a Fake LoadTest pods
-func (c *Fake) SetDefaults() error {
-	if c.loadTest.Status.Phase == "" {
-		c.loadTest.Status.Phase = loadTestV1.LoadTestCreating
-	}
-
-	if c.loadTest.Spec.MasterConfig.Image == "" {
-		c.loadTest.Spec.MasterConfig.Image = sleepImage
-	}
-
-	if c.loadTest.Spec.MasterConfig.Tag == "" {
-		c.loadTest.Spec.MasterConfig.Tag = imageTag
-	}
-
-	return nil
-}
-
 // CheckOrCreateResources check if Fake kubernetes resources have been create, if they have not been create them
 func (c *Fake) CheckOrCreateResources(ctx context.Context) error {
 	// Get the Namespace resource

--- a/pkg/backends/fake/fake_test.go
+++ b/pkg/backends/fake/fake_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	batchV1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,17 +29,6 @@ func (e *StatusError) Error() string {
 
 func (e *StatusError) Status() metav1.Status {
 	return metav1.Status{Reason: metav1.StatusReasonNotFound}
-}
-
-func TestSetLoadTestDefaults(t *testing.T) {
-	lt := createFake()
-
-	err := lt.SetDefaults()
-	require.NoError(t, err)
-	assert.Equal(t, loadtestV1.LoadTestCreating, lt.loadTest.Status.Phase)
-	assert.Equal(t, sleepImage, lt.loadTest.Spec.MasterConfig.Image)
-	assert.Equal(t, imageTag, lt.loadTest.Spec.MasterConfig.Tag)
-	assert.Equal(t, imageTag, lt.loadTest.Spec.MasterConfig.Tag)
 }
 
 func TestCheckOrCreateResources(t *testing.T) {

--- a/pkg/backends/jmeter/jmeter.go
+++ b/pkg/backends/jmeter/jmeter.go
@@ -69,31 +69,6 @@ func New(kubeClientSet kubernetes.Interface, kangalClientSet clientSetV.Interfac
 	}
 }
 
-// SetDefaults set default values for creating a JMeter loadtest
-func (c *JMeter) SetDefaults() error {
-	if c.loadTest.Status.Phase == "" {
-		c.loadTest.Status.Phase = loadTestV1.LoadTestCreating
-	}
-
-	if c.loadTest.Spec.MasterConfig.Image == "" {
-		c.loadTest.Spec.MasterConfig.Image = masterImage
-	}
-
-	if c.loadTest.Spec.MasterConfig.Tag == "" {
-		c.loadTest.Spec.MasterConfig.Tag = imageTag
-	}
-
-	if c.loadTest.Spec.WorkerConfig.Image == "" {
-		c.loadTest.Spec.WorkerConfig.Image = workerImage
-	}
-
-	if c.loadTest.Spec.WorkerConfig.Tag == "" {
-		c.loadTest.Spec.WorkerConfig.Tag = imageTag
-	}
-
-	return nil
-}
-
 // CheckOrCreateResources check if JMeter kubernetes resources have been create,
 // if they have not been create them
 func (c *JMeter) CheckOrCreateResources(ctx context.Context) error {

--- a/pkg/backends/jmeter/jmeter_test.go
+++ b/pkg/backends/jmeter/jmeter_test.go
@@ -68,16 +68,6 @@ func TestCheckForTimeout(t *testing.T) {
 	}
 }
 
-func TestSetLoadTestDefaults(t *testing.T) {
-	jm := &JMeter{
-		loadTest: &loadtestV1.LoadTest{},
-	}
-
-	err := jm.SetDefaults()
-	require.NoError(t, err)
-	assert.Equal(t, loadtestV1.LoadTestCreating, jm.loadTest.Status.Phase)
-}
-
 func TestGetLoadTestPhaseFromJob(t *testing.T) {
 	var testPhases = []struct {
 		ExpectedPhase loadtestV1.LoadTestPhase

--- a/pkg/backends/locust/locust.go
+++ b/pkg/backends/locust/locust.go
@@ -35,29 +35,6 @@ type Locust struct {
 	podAnnotations     map[string]string
 }
 
-// SetDefaults mutates the LoadTest object to add default values to empty fields
-func (c *Locust) SetDefaults() error {
-	if c.loadTest.Status.Phase == "" {
-		c.loadTest.Status.Phase = loadTestV1.LoadTestCreating
-	}
-
-	if c.loadTest.Spec.MasterConfig.Image == "" {
-		c.loadTest.Spec.MasterConfig.Image = c.image
-	}
-	if c.loadTest.Spec.MasterConfig.Tag == "" {
-		c.loadTest.Spec.MasterConfig.Tag = c.imageTag
-	}
-
-	if c.loadTest.Spec.WorkerConfig.Image == "" {
-		c.loadTest.Spec.WorkerConfig.Image = c.image
-	}
-	if c.loadTest.Spec.WorkerConfig.Tag == "" {
-		c.loadTest.Spec.WorkerConfig.Tag = c.imageTag
-	}
-
-	return nil
-}
-
 // CheckOrCreateResources check for resources or create the needed resources for the loadtest type
 func (c *Locust) CheckOrCreateResources(ctx context.Context) error {
 	workerJobs, err := c.kubeClientSet.

--- a/pkg/backends/locust/spec.go
+++ b/pkg/backends/locust/spec.go
@@ -23,5 +23,5 @@ func BuildLoadTestSpec(overwrite bool, distributedPods int32, tags loadTestV1.Lo
 	if testFileStr == "" {
 		return lt, ErrRequireTestFile
 	}
-	return loadTestV1.NewSpec(loadTestV1.LoadTestTypeLocust, overwrite, distributedPods, tags, testFileStr, "", envVarsStr, loadTestV1.ImageDetails{}, loadTestV1.ImageDetails{}, targetURL, duration), nil
+	return loadTestV1.NewSpec(loadTestV1.LoadTestTypeLocust, overwrite, distributedPods, tags, testFileStr, "", envVarsStr, loadTestV1.ImageDetails{Image: defaultImage, Tag: defaultImageTag}, loadTestV1.ImageDetails{Image: defaultImage, Tag: defaultImageTag}, targetURL, duration), nil
 }

--- a/pkg/backends/locust/spec_test.go
+++ b/pkg/backends/locust/spec_test.go
@@ -40,8 +40,8 @@ func TestBuildLoadTestSpec(t *testing.T) {
 			want: v1.LoadTestSpec{
 				Type:            "Locust",
 				Overwrite:       true,
-				MasterConfig:    v1.ImageDetails{},
-				WorkerConfig:    v1.ImageDetails{},
+				MasterConfig:    v1.ImageDetails{Image: defaultImage, Tag: defaultImageTag},
+				WorkerConfig:    v1.ImageDetails{Image: defaultImage, Tag: defaultImageTag},
 				DistributedPods: &distributedPods,
 				Tags:            v1.LoadTestTags{"team": "kangal"},
 				TestFile:        "something in the file",

--- a/pkg/controller/loadtest.go
+++ b/pkg/controller/loadtest.go
@@ -312,12 +312,6 @@ func (c *Controller) syncHandler(key string) error {
 		return err
 	}
 
-	// mutates the LoadTest object to add default values to empty fields
-	err = backend.SetDefaults()
-	if err != nil {
-		return err
-	}
-
 	// check or create loadtest resources
 	err = backend.CheckOrCreateResources(ctx)
 	if err != nil {


### PR DESCRIPTION
**Description:**
EES-4280

SetDefaults method was a previous hack because of an invalid spec of [crd.yaml](https://github.com/hellofresh/kangal/blob/master/charts/kangal/crd.yaml) 
This is not an issue anymore and Kangal Proxy is now able to prepare all specs for LoadTest so Kangal controller doesn't need to mutate resource specs anymore.