### PR TITLE
Set MasterConfig and WorkerConfig spec via proxy

### DIFF
--- a/charts/kangal/Chart.yaml
+++ b/charts/kangal/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - performance tests
   - tests runner
 name: kangal
-version: 1.2.1
+version: 1.3.0
 home: https://github.com/hellofresh/kangal
 icon: https://raw.githubusercontent.com/hellofresh/kangal/master/kangal_logo.svg
 maintainers:

--- a/charts/kangal/README.md
+++ b/charts/kangal/README.md
@@ -69,15 +69,21 @@ To install Kangal to your infrastructure you need 3 deployments: Kangal-Proxy, K
 
 The following table lists the common configurable parameters for `Kangal` chart:
 
-| Parameter                         | Description                                                                                         | Default                      |
-|-----------------------------------|-----------------------------------------------------------------------------------------------------|------------------------------|
-| `fullnameOverride`                | String to fully override kangal.fullname template with a string                                     | `nil`                        |
-| `nameOverride`                    | String to partially override kangal.fullname template with a string (will prepend the release name) | `nil`                        |
-| `configmap.AWS_ACCESS_KEY_ID`     | AWS access key ID. If not defined report will not be stored                                         | ``                           |
-| `configmap.AWS_SECRET_ACCESS_KEY` | AWS secret access key                                                                               | ``                           |
-| `configmap.AWS_BUCKET_NAME`       | The name of the bucket for saving reports                                                           | `my-bucket`                  |
-| `configmap.AWS_ENDPOINT_URL`      | Storage connection parameter                                                                        | `s3.us-east-1.amazonaws.com` |
-| `configmap.AWS_DEFAULT_REGION`    | Storage connection parameter                                                                        | `us-east-1`                  |
+| Parameter                           | Description                                                                                         | Default                               |
+|-------------------------------------|-----------------------------------------------------------------------------------------------------|---------------------------------------|
+| `fullnameOverride`                  | String to fully override kangal.fullname template with a string                                     | `nil`                                 |
+| `nameOverride`                      | String to partially override kangal.fullname template with a string (will prepend the release name) | `nil`                                 |
+| `configmap.AWS_ACCESS_KEY_ID`       | AWS access key ID. If not defined report will not be stored                                         | ``                                    |
+| `configmap.AWS_SECRET_ACCESS_KEY`   | AWS secret access key                                                                               | ``                                    |
+| `configmap.AWS_BUCKET_NAME`         | The name of the bucket for saving reports                                                           | `my-bucket`                           |
+| `configmap.AWS_ENDPOINT_URL`        | Storage connection parameter                                                                        | `s3.us-east-1.amazonaws.com`          |
+| `configmap.AWS_DEFAULT_REGION`      | Storage connection parameter                                                                        | `us-east-1`                           |
+| `configmap.JMETER_MASTER_IMAGE_NAME | Default JMeter master image name/repository if none is provided when creating a new loadtest        | "hellofreshtech/kangal-jmeter-master" |
+| `configmap.JMETER_MASTER_IMAGE_TAG  | Tag of the JMeter master image above                                                                | "latest"                              |
+| `configmap.JMETER_WORKER_IMAGE_NAME | Default JMeter worker image name/repository if none is provided when creating a new loadtest        | "hellofreshtech/kangal-jmeter-worker" |
+| `configmap.JMETER_WORKER_IMAGE_TAG  | Tag of the JMeter worker image above                                                                | "latest"                              |
+| `configmap.LOCUST_IMAGE             | Default Locust image name/repository if none is provided when creating a new loadtest               | "locustio/locust"                     |
+| `configmap.LOCUST_IMAGE_TAG         | Tag of the Locust image above                                                                       | "1.3.0"                               |
 
 Deployment specific configurations:
 
@@ -147,11 +153,21 @@ Deployment specific configurations:
 | `controller.service.ports.http`       | Service port                               | `80`                         |
 | `controller.env.KANGAL_PROXY_URL`     | Kangal Proxy URL used to persist reports   | `https://kangal-proxy.local` |
 
+### Kangal Controller (JMeter specific)
+| Parameter                                      | Description                 | Default           |
+|------------------------------------------------|-----------------------------|-------------------|
+| `controller.env.JMETER_MASTER_CPU_LIMITS`      | Master container CPU limits | ``                |
+| `controller.env.JMETER_MASTER_CPU_REQUESTS`    | Master CPU requests         | ``                |
+| `controller.env.JMETER_MASTER_MEMORY_LIMITS`   | Master memory limits        | ``                |
+| `controller.env.JMETER_MASTER_MEMORY_REQUESTS` | Master memory requests      | ``                |
+| `controller.env.JMETER_WORKER_CPU_LIMITS`      | Master container CPU limits | ``                |
+| `controller.env.JMETER_WORKER_CPU_REQUESTS`    | Master CPU requests         | ``                |
+| `controller.env.JMETER_WORKER_MEMORY_LIMITS`   | Master memory limits        | ``                |
+| `controller.env.JMETER_WORKER_MEMORY_REQUESTS` | Master memory requests      | ``                |
+
 ### Kangal Controller (Locust specific)
 | Parameter                                      | Description                 | Default           |
 |------------------------------------------------|-----------------------------|-------------------|
-| `controller.env.LOCUST_IMAGE`                  | Locust image                | `locustio/locust` |
-| `controller.env.LOCUST_IMAGE_TAG`              | Locust image tag            | `1.3.0`           |
 | `controller.env.LOCUST_MASTER_CPU_LIMITS`      | Master container CPU limits | ``                |
 | `controller.env.LOCUST_MASTER_CPU_REQUESTS`    | Master CPU requests         | ``                |
 | `controller.env.LOCUST_MASTER_MEMORY_LIMITS`   | Master memory limits        | ``                |

--- a/charts/kangal/values.yaml
+++ b/charts/kangal/values.yaml
@@ -125,8 +125,6 @@ controller:
   # Environmental variables to set
   env:
     KANGAL_PROXY_URL: "https://kangal-proxy.local"
-    LOCUST_IMAGE: "locustio/locust"
-    LOCUST_IMAGE_TAG: "1.3.0"
 
 openapi-ui:
   enabled: true
@@ -174,3 +172,9 @@ configMap:
   AWS_ENDPOINT_URL: "s3.us-east-1.amazonaws.com"
   AWS_BUCKET_NAME: "my-bucket"
   AWS_DEFAULT_REGION: "us-east-1"
+  JMETER_MASTER_IMAGE_NAME: "hellofreshtech/kangal-jmeter-master"
+  JMETER_MASTER_IMAGE_TAG: "latest"
+  JMETER_WORKER_IMAGE_NAME: "hellofreshtech/kangal-jmeter-worker"
+  JMETER_WORKER_IMAGE_TAG: "latest"
+  LOCUST_IMAGE: "locustio/locust"
+  LOCUST_IMAGE_TAG: "1.3.0"

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.2.0
+	github.com/docker/distribution v2.7.1+incompatible
 	github.com/felixge/httpsnoop v1.0.1
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/go-chi/render v1.0.1
@@ -13,6 +14,7 @@ require (
 	github.com/json-iterator/go v1.1.10 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/minio/minio-go/v6 v6.0.57
+	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rs/cors v1.7.0
 	github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304 // indirect

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
+github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 h1:cenwrSVm+Z7QLSV/BsnenAOcDXdX4cMv4wP0B/5QbPg=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
@@ -225,6 +227,8 @@ github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/backends/backend.go
+++ b/pkg/backends/backend.go
@@ -48,14 +48,14 @@ func NewLoadTest(loadTest *loadTestV1.LoadTest, kubeClientSet kubernetes.Interfa
 }
 
 // BuildLoadTestSpecByBackend returns a valid LoadTestSpec based on backend rules
-func BuildLoadTestSpecByBackend(loadTestType loadTestV1.LoadTestType, overwrite bool, distributedPods int32, tags loadTestV1.LoadTestTags, testFileStr, testDataStr, envVarsStr, targetURL string, duration time.Duration, masterImageRef, workerImageRef reference.NamedTagged) (loadTestV1.LoadTestSpec, error) {
+func BuildLoadTestSpecByBackend(loadTestType loadTestV1.LoadTestType, config Config, overwrite bool, distributedPods int32, tags loadTestV1.LoadTestTags, testFileStr, testDataStr, envVarsStr, targetURL string, duration time.Duration, masterImageRef, workerImageRef reference.NamedTagged) (loadTestV1.LoadTestSpec, error) {
 	switch loadTestType {
 	case loadTestV1.LoadTestTypeJMeter:
-		return jmeter.BuildLoadTestSpec(overwrite, distributedPods, tags, testFileStr, testDataStr, envVarsStr, masterImageRef, workerImageRef)
+		return jmeter.BuildLoadTestSpec(config.JMeter, overwrite, distributedPods, tags, testFileStr, testDataStr, envVarsStr, masterImageRef, workerImageRef)
 	case loadTestV1.LoadTestTypeFake:
 		return fake.BuildLoadTestSpec(tags, overwrite)
 	case loadTestV1.LoadTestTypeLocust:
-		return locust.BuildLoadTestSpec(overwrite, distributedPods, tags, testFileStr, envVarsStr, targetURL, duration, masterImageRef, workerImageRef)
+		return locust.BuildLoadTestSpec(config.Locust, overwrite, distributedPods, tags, testFileStr, envVarsStr, targetURL, duration, masterImageRef)
 	}
 	return loadTestV1.LoadTestSpec{}, fmt.Errorf("load test provider not found to build specs: %s", loadTestType)
 }

--- a/pkg/backends/backend.go
+++ b/pkg/backends/backend.go
@@ -35,7 +35,16 @@ type Config struct {
 }
 
 // NewLoadTest returns a new LoadTestType
-func NewLoadTest(loadTest *loadTestV1.LoadTest, kubeClientSet kubernetes.Interface, kangalClientSet clientSetV.Interface, logger *zap.Logger, namespacesLister coreListersV1.NamespaceLister, reportURL string, podAnnotations, namespaceAnnotations map[string]string, backendsConfig Config) (LoadTestType, error) {
+func NewLoadTest(
+	loadTest *loadTestV1.LoadTest,
+	kubeClientSet kubernetes.Interface,
+	kangalClientSet clientSetV.Interface,
+	logger *zap.Logger,
+	namespacesLister coreListersV1.NamespaceLister,
+	reportURL string,
+	podAnnotations, namespaceAnnotations map[string]string,
+	backendsConfig Config,
+) (LoadTestType, error) {
 	switch loadTest.Spec.Type {
 	case loadTestV1.LoadTestTypeJMeter:
 		return jmeter.New(kubeClientSet, kangalClientSet, loadTest, logger, namespacesLister, reportURL, podAnnotations, namespaceAnnotations, backendsConfig.JMeter), nil
@@ -48,7 +57,16 @@ func NewLoadTest(loadTest *loadTestV1.LoadTest, kubeClientSet kubernetes.Interfa
 }
 
 // BuildLoadTestSpecByBackend returns a valid LoadTestSpec based on backend rules
-func BuildLoadTestSpecByBackend(loadTestType loadTestV1.LoadTestType, config Config, overwrite bool, distributedPods int32, tags loadTestV1.LoadTestTags, testFileStr, testDataStr, envVarsStr, targetURL string, duration time.Duration, masterImageRef, workerImageRef reference.NamedTagged) (loadTestV1.LoadTestSpec, error) {
+func BuildLoadTestSpecByBackend(
+	loadTestType loadTestV1.LoadTestType,
+	config Config,
+	overwrite bool,
+	distributedPods int32,
+	tags loadTestV1.LoadTestTags,
+	testFileStr, testDataStr, envVarsStr, targetURL string,
+	duration time.Duration,
+	masterImageRef, workerImageRef reference.NamedTagged,
+) (loadTestV1.LoadTestSpec, error) {
 	switch loadTestType {
 	case loadTestV1.LoadTestTypeJMeter:
 		return jmeter.BuildLoadTestSpec(config.JMeter, overwrite, distributedPods, tags, testFileStr, testDataStr, envVarsStr, masterImageRef, workerImageRef)

--- a/pkg/backends/backend.go
+++ b/pkg/backends/backend.go
@@ -55,7 +55,7 @@ func BuildLoadTestSpecByBackend(loadTestType loadTestV1.LoadTestType, overwrite 
 	case loadTestV1.LoadTestTypeFake:
 		return fake.BuildLoadTestSpec(tags, overwrite)
 	case loadTestV1.LoadTestTypeLocust:
-		return locust.BuildLoadTestSpec(overwrite, distributedPods, tags, testFileStr, envVarsStr, targetURL, duration, masterImageRef)
+		return locust.BuildLoadTestSpec(overwrite, distributedPods, tags, testFileStr, envVarsStr, targetURL, duration, masterImageRef, workerImageRef)
 	}
 	return loadTestV1.LoadTestSpec{}, fmt.Errorf("load test provider not found to build specs: %s", loadTestType)
 }

--- a/pkg/backends/backend.go
+++ b/pkg/backends/backend.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/docker/distribution/reference"
+
 	"go.uber.org/zap"
 	"k8s.io/client-go/kubernetes"
 	coreListersV1 "k8s.io/client-go/listers/core/v1"
@@ -49,14 +51,14 @@ func NewLoadTest(loadTest *loadTestV1.LoadTest, kubeClientSet kubernetes.Interfa
 }
 
 // BuildLoadTestSpecByBackend returns a valid LoadTestSpec based on backend rules
-func BuildLoadTestSpecByBackend(loadTestType loadTestV1.LoadTestType, overwrite bool, distributedPods int32, tags loadTestV1.LoadTestTags, testFileStr, testDataStr, envVarsStr, targetURL string, duration time.Duration) (loadTestV1.LoadTestSpec, error) {
+func BuildLoadTestSpecByBackend(loadTestType loadTestV1.LoadTestType, overwrite bool, distributedPods int32, tags loadTestV1.LoadTestTags, testFileStr, testDataStr, envVarsStr, targetURL string, duration time.Duration, masterImageRef, workerImageRef reference.NamedTagged) (loadTestV1.LoadTestSpec, error) {
 	switch loadTestType {
 	case loadTestV1.LoadTestTypeJMeter:
-		return jmeter.BuildLoadTestSpec(overwrite, distributedPods, tags, testFileStr, testDataStr, envVarsStr)
+		return jmeter.BuildLoadTestSpec(overwrite, distributedPods, tags, testFileStr, testDataStr, envVarsStr, masterImageRef, workerImageRef)
 	case loadTestV1.LoadTestTypeFake:
 		return fake.BuildLoadTestSpec(tags, overwrite)
 	case loadTestV1.LoadTestTypeLocust:
-		return locust.BuildLoadTestSpec(overwrite, distributedPods, tags, testFileStr, envVarsStr, targetURL, duration)
+		return locust.BuildLoadTestSpec(overwrite, distributedPods, tags, testFileStr, envVarsStr, targetURL, duration, masterImageRef)
 	}
 	return loadTestV1.LoadTestSpec{}, fmt.Errorf("load test provider not found to build specs: %s", loadTestType)
 }

--- a/pkg/backends/backend.go
+++ b/pkg/backends/backend.go
@@ -21,9 +21,6 @@ import (
 // LoadTestType defines the methods that a loadtest type needs to implement
 // for the controller to be able to run it
 type LoadTestType interface {
-	// SetDefaults mutates the LoadTest object to add default values to empty fields
-	SetDefaults() error
-
 	// CheckOrCreateResources check for resources or create the needed resources for the loadtest type
 	CheckOrCreateResources(ctx context.Context) error
 

--- a/pkg/backends/fake/fake.go
+++ b/pkg/backends/fake/fake.go
@@ -33,25 +33,12 @@ func New(kubeClientSet kubernetes.Interface, lt *loadTestV1.LoadTest, logger *za
 	}
 }
 
-// SetDefaults set default values for creating a Fake LoadTest pods
-func (c *Fake) SetDefaults() error {
+// CheckOrCreateResources check if Fake kubernetes resources have been create, if they have not been create them
+func (c *Fake) CheckOrCreateResources(ctx context.Context) error {
 	if c.loadTest.Status.Phase == "" {
 		c.loadTest.Status.Phase = loadTestV1.LoadTestCreating
 	}
 
-	if c.loadTest.Spec.MasterConfig.Image == "" {
-		c.loadTest.Spec.MasterConfig.Image = sleepImage
-	}
-
-	if c.loadTest.Spec.MasterConfig.Tag == "" {
-		c.loadTest.Spec.MasterConfig.Tag = imageTag
-	}
-
-	return nil
-}
-
-// CheckOrCreateResources check if Fake kubernetes resources have been create, if they have not been create them
-func (c *Fake) CheckOrCreateResources(ctx context.Context) error {
 	// Get the Namespace resource
 	namespace, err := c.kubeClient.CoreV1().Namespaces().Get(ctx, c.loadTest.Status.Namespace, metaV1.GetOptions{})
 	// The LoadTest resource may no longer exist, in which case we stop

--- a/pkg/backends/fake/fake.go
+++ b/pkg/backends/fake/fake.go
@@ -35,10 +35,6 @@ func New(kubeClientSet kubernetes.Interface, lt *loadTestV1.LoadTest, logger *za
 
 // CheckOrCreateResources check if Fake kubernetes resources have been create, if they have not been create them
 func (c *Fake) CheckOrCreateResources(ctx context.Context) error {
-	if c.loadTest.Status.Phase == "" {
-		c.loadTest.Status.Phase = loadTestV1.LoadTestCreating
-	}
-
 	// Get the Namespace resource
 	namespace, err := c.kubeClient.CoreV1().Namespaces().Get(ctx, c.loadTest.Status.Namespace, metaV1.GetOptions{})
 	// The LoadTest resource may no longer exist, in which case we stop
@@ -70,6 +66,10 @@ func (c *Fake) CheckOrUpdateStatus(ctx context.Context) error {
 	}
 	if err != nil {
 		return err
+	}
+
+	if c.loadTest.Status.Phase == "" {
+		c.loadTest.Status.Phase = loadTestV1.LoadTestCreating
 	}
 
 	if c.loadTest.Status.Phase == loadTestV1.LoadTestErrored {

--- a/pkg/backends/fake/fake_test.go
+++ b/pkg/backends/fake/fake_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	batchV1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,17 +29,6 @@ func (e *StatusError) Error() string {
 
 func (e *StatusError) Status() metav1.Status {
 	return metav1.Status{Reason: metav1.StatusReasonNotFound}
-}
-
-func TestSetLoadTestDefaults(t *testing.T) {
-	lt := createFake()
-
-	err := lt.SetDefaults()
-	require.NoError(t, err)
-	assert.Equal(t, loadtestV1.LoadTestCreating, lt.loadTest.Status.Phase)
-	assert.Equal(t, sleepImage, lt.loadTest.Spec.MasterConfig.Image)
-	assert.Equal(t, imageTag, lt.loadTest.Spec.MasterConfig.Tag)
-	assert.Equal(t, imageTag, lt.loadTest.Spec.MasterConfig.Tag)
 }
 
 func TestCheckOrCreateResources(t *testing.T) {

--- a/pkg/backends/fake/spec.go
+++ b/pkg/backends/fake/spec.go
@@ -9,5 +9,17 @@ import (
 //BuildLoadTestSpec returns LoadTestSpec for Fake backend provider
 func BuildLoadTestSpec(tags loadTestV1.LoadTestTags, overwrite bool) (loadTestV1.LoadTestSpec, error) {
 	// in general Fake backend provider doesn't need any fields except overwrite flag
-	return loadTestV1.NewSpec(loadTestV1.LoadTestTypeFake, overwrite, 1, tags, "", "", "", loadTestV1.ImageDetails{Image: sleepImage, Tag: imageTag}, loadTestV1.ImageDetails{}, "", time.Duration(0)), nil
+	return loadTestV1.NewSpec(
+		loadTestV1.LoadTestTypeFake,
+		overwrite,
+		1,
+		tags,
+		"",
+		"",
+		"",
+		loadTestV1.ImageDetails{Image: sleepImage, Tag: imageTag},
+		loadTestV1.ImageDetails{},
+		"",
+		time.Duration(0),
+	), nil
 }

--- a/pkg/backends/jmeter/config.go
+++ b/pkg/backends/jmeter/config.go
@@ -2,10 +2,14 @@ package jmeter
 
 // Config specific to JMeter backend
 type Config struct {
+	MasterImageName      string `envconfig:"JMETER_MASTER_IMAGE_NAME"`
+	MasterImageTag       string `envconfig:"JMETER_MASTER_IMAGE_TAG"`
 	MasterCPULimits      string `envconfig:"JMETER_MASTER_CPU_LIMITS"`
 	MasterCPURequests    string `envconfig:"JMETER_MASTER_CPU_REQUESTS"`
 	MasterMemoryLimits   string `envconfig:"JMETER_MASTER_MEMORY_LIMITS"`
 	MasterMemoryRequests string `envconfig:"JMETER_MASTER_MEMORY_REQUESTS"`
+	WorkerImageName      string `envconfig:"JMETER_WORKER_IMAGE_NAME"`
+	WorkerImageTag       string `envconfig:"JMETER_WORKER_IMAGE_TAG"`
 	WorkerCPULimits      string `envconfig:"JMETER_WORKER_CPU_LIMITS"`
 	WorkerCPURequests    string `envconfig:"JMETER_WORKER_CPU_REQUESTS"`
 	WorkerMemoryLimits   string `envconfig:"JMETER_WORKER_MEMORY_LIMITS"`

--- a/pkg/backends/jmeter/jmeter.go
+++ b/pkg/backends/jmeter/jmeter.go
@@ -72,10 +72,6 @@ func New(kubeClientSet kubernetes.Interface, kangalClientSet clientSetV.Interfac
 // CheckOrCreateResources check if JMeter kubernetes resources have been create,
 // if they have not been create them
 func (c *JMeter) CheckOrCreateResources(ctx context.Context) error {
-	if c.loadTest.Status.Phase == "" {
-		c.loadTest.Status.Phase = loadTestV1.LoadTestCreating
-	}
-
 	JMeterServices, err := c.kubeClientSet.CoreV1().Services(c.loadTest.Status.Namespace).List(ctx, metaV1.ListOptions{})
 	if err != nil {
 		return err
@@ -140,6 +136,10 @@ func (c *JMeter) CheckOrUpdateStatus(ctx context.Context) error {
 			c.loadTest.Status.Phase = loadTestV1.LoadTestFinished
 			return nil
 		}
+	}
+
+	if c.loadTest.Status.Phase == "" {
+		c.loadTest.Status.Phase = loadTestV1.LoadTestCreating
 	}
 
 	if c.loadTest.Status.Phase == loadTestV1.LoadTestErrored {

--- a/pkg/backends/jmeter/jmeter.go
+++ b/pkg/backends/jmeter/jmeter.go
@@ -23,9 +23,10 @@ var (
 	MaxWaitTimeForPods = time.Minute * 10
 	//loadTestWorkerLabelSelector is the selector used for selecting jmeter worker resources
 	loadTestWorkerLabelSelector = fmt.Sprintf("%s=%s", loadTestWorkerPodLabelKey, loadTestWorkerPodLabelValue)
-	masterImage                 = "hellofreshtech/kangal-jmeter-master"
-	workerImage                 = "hellofreshtech/kangal-jmeter-worker"
-	imageTag                    = "latest"
+	defaultMasterImageName      = "hellofreshtech/kangal-jmeter-master"
+	defaultWorkerImageName      = "hellofreshtech/kangal-jmeter-worker"
+	defaultMasterImageTag       = "latest"
+	defaultWorkerImageTag       = "latest"
 )
 
 // JMeter enables the controller to run a loadtest using JMeter

--- a/pkg/backends/jmeter/jmeter.go
+++ b/pkg/backends/jmeter/jmeter.go
@@ -69,34 +69,13 @@ func New(kubeClientSet kubernetes.Interface, kangalClientSet clientSetV.Interfac
 	}
 }
 
-// SetDefaults set default values for creating a JMeter loadtest
-func (c *JMeter) SetDefaults() error {
+// CheckOrCreateResources check if JMeter kubernetes resources have been create,
+// if they have not been create them
+func (c *JMeter) CheckOrCreateResources(ctx context.Context) error {
 	if c.loadTest.Status.Phase == "" {
 		c.loadTest.Status.Phase = loadTestV1.LoadTestCreating
 	}
 
-	if c.loadTest.Spec.MasterConfig.Image == "" {
-		c.loadTest.Spec.MasterConfig.Image = masterImage
-	}
-
-	if c.loadTest.Spec.MasterConfig.Tag == "" {
-		c.loadTest.Spec.MasterConfig.Tag = imageTag
-	}
-
-	if c.loadTest.Spec.WorkerConfig.Image == "" {
-		c.loadTest.Spec.WorkerConfig.Image = workerImage
-	}
-
-	if c.loadTest.Spec.WorkerConfig.Tag == "" {
-		c.loadTest.Spec.WorkerConfig.Tag = imageTag
-	}
-
-	return nil
-}
-
-// CheckOrCreateResources check if JMeter kubernetes resources have been create,
-// if they have not been create them
-func (c *JMeter) CheckOrCreateResources(ctx context.Context) error {
 	JMeterServices, err := c.kubeClientSet.CoreV1().Services(c.loadTest.Status.Namespace).List(ctx, metaV1.ListOptions{})
 	if err != nil {
 		return err

--- a/pkg/backends/jmeter/jmeter.go
+++ b/pkg/backends/jmeter/jmeter.go
@@ -39,12 +39,34 @@ type JMeter struct {
 	reportURL        string
 	masterResources  helper.Resources
 	workerResources  helper.Resources
+	masterConfig     loadTestV1.ImageDetails
+	workerConfig     loadTestV1.ImageDetails
 
 	podAnnotations, namespaceAnnotations map[string]string
 }
 
 //New initializes new JMeter provider handler to manage load test resources with Kangal Controller
 func New(kubeClientSet kubernetes.Interface, kangalClientSet clientSetV.Interface, lt *loadTestV1.LoadTest, logger *zap.Logger, namespacesLister coreListersV1.NamespaceLister, reportURL string, podAnnotations, namespaceAnnotations map[string]string, config Config) *JMeter {
+	masterImageName := defaultMasterImageName
+	if config.MasterImageName != "" {
+		masterImageName = config.MasterImageName
+	}
+
+	masterImageTag := defaultMasterImageTag
+	if config.MasterImageTag != "" {
+		masterImageTag = config.MasterImageTag
+	}
+
+	workerImageName := defaultWorkerImageName
+	if config.WorkerImageName != "" {
+		workerImageName = config.WorkerImageName
+	}
+
+	workerImageTag := defaultWorkerImageTag
+	if config.WorkerImageTag != "" {
+		workerImageName = config.WorkerImageTag
+	}
+
 	return &JMeter{
 		kubeClientSet:        kubeClientSet,
 		kangalClientSet:      kangalClientSet,
@@ -65,6 +87,14 @@ func New(kubeClientSet kubernetes.Interface, kangalClientSet clientSetV.Interfac
 			CPURequests:    config.WorkerCPURequests,
 			MemoryLimits:   config.WorkerMemoryLimits,
 			MemoryRequests: config.WorkerMemoryRequests,
+		},
+		masterConfig: loadTestV1.ImageDetails{
+			Image: masterImageName,
+			Tag:   masterImageTag,
+		},
+		workerConfig: loadTestV1.ImageDetails{
+			Image: workerImageName,
+			Tag:   workerImageTag,
 		},
 	}
 }

--- a/pkg/backends/jmeter/jmeter.go
+++ b/pkg/backends/jmeter/jmeter.go
@@ -46,7 +46,16 @@ type JMeter struct {
 }
 
 //New initializes new JMeter provider handler to manage load test resources with Kangal Controller
-func New(kubeClientSet kubernetes.Interface, kangalClientSet clientSetV.Interface, lt *loadTestV1.LoadTest, logger *zap.Logger, namespacesLister coreListersV1.NamespaceLister, reportURL string, podAnnotations, namespaceAnnotations map[string]string, config Config) *JMeter {
+func New(
+	kubeClientSet kubernetes.Interface,
+	kangalClientSet clientSetV.Interface,
+	lt *loadTestV1.LoadTest,
+	logger *zap.Logger,
+	namespacesLister coreListersV1.NamespaceLister,
+	reportURL string,
+	podAnnotations, namespaceAnnotations map[string]string,
+	config Config,
+) *JMeter {
 	masterImageName := defaultMasterImageName
 	if config.MasterImageName != "" {
 		masterImageName = config.MasterImageName
@@ -204,7 +213,12 @@ func (c *JMeter) CheckOrUpdateStatus(ctx context.Context) error {
 				if containerStatus.State.Waiting.Reason != "Pending" &&
 					containerStatus.State.Waiting.Reason != "ContainerCreating" &&
 					containerStatus.State.Waiting.Reason != "PodInitializing" {
-					c.logger.Info("One of containers is unhealthy, marking LoadTest as errored", zap.String("LoadTest", c.loadTest.GetName()), zap.String("pod", pod.Name), zap.String("namespace", namespace.GetName()))
+					c.logger.Info(
+						"One of containers is unhealthy, marking LoadTest as errored",
+						zap.String("LoadTest", c.loadTest.GetName()),
+						zap.String("pod", pod.Name),
+						zap.String("namespace", namespace.GetName()),
+					)
 					c.loadTest.Status.Phase = loadTestV1.LoadTestErrored
 					return nil
 				}

--- a/pkg/backends/jmeter/jmeter_test.go
+++ b/pkg/backends/jmeter/jmeter_test.go
@@ -67,16 +67,6 @@ func TestCheckForTimeout(t *testing.T) {
 	}
 }
 
-func TestSetLoadTestDefaults(t *testing.T) {
-	jm := &JMeter{
-		loadTest: &loadtestV1.LoadTest{},
-	}
-
-	err := jm.SetDefaults()
-	require.NoError(t, err)
-	assert.Equal(t, loadtestV1.LoadTestCreating, jm.loadTest.Status.Phase)
-}
-
 func TestGetLoadTestPhaseFromJob(t *testing.T) {
 	var testPhases = []struct {
 		ExpectedPhase loadtestV1.LoadTestPhase

--- a/pkg/backends/jmeter/jmeter_test.go
+++ b/pkg/backends/jmeter/jmeter_test.go
@@ -138,6 +138,14 @@ func TestJMeter_CheckOrCreateResources(t *testing.T) {
 			},
 			Spec: loadtestV1.LoadTestSpec{
 				DistributedPods: &distributedPodsNum,
+				MasterConfig: loadtestV1.ImageDetails{
+					Image: defaultMasterImageName,
+					Tag:   defaultMasterImageTag,
+				},
+				WorkerConfig: loadtestV1.ImageDetails{
+					Image: defaultWorkerImageName,
+					Tag:   defaultWorkerImageTag,
+				},
 			},
 			Status: loadtestV1.LoadTestStatus{
 				Phase:     "",

--- a/pkg/backends/jmeter/resources.go
+++ b/pkg/backends/jmeter/resources.go
@@ -177,7 +177,7 @@ func (c *JMeter) NewPod(i int, configMap *coreV1.ConfigMap, podAnnotations map[s
 	optionalVolume := true
 
 	imageRef := fmt.Sprintf("%s:%s", loadtest.Spec.WorkerConfig.Image, loadtest.Spec.WorkerConfig.Tag)
-	if imageRef == "" {
+	if imageRef == ":" {
 		imageRef = fmt.Sprintf("%s:%s", c.workerConfig.Image, c.workerConfig.Tag)
 		c.logger.Warn("Loadtest.Spec.WorkerConfig is empty; using default worker image", zap.String("imageRef", imageRef))
 	}
@@ -242,7 +242,7 @@ func (c *JMeter) NewJMeterMasterJob(reportURL string, podAnnotations map[string]
 	var one int32 = 1
 
 	imageRef := fmt.Sprintf("%s:%s", loadtest.Spec.MasterConfig.Image, loadtest.Spec.MasterConfig.Tag)
-	if imageRef == "" {
+	if imageRef == ":" {
 		c.logger.Warn("Loadtest.Spec.MasterConfig is empty; using default master image", zap.String("imageRef", imageRef))
 		imageRef = fmt.Sprintf("%s:%s", c.masterConfig.Image, c.masterConfig.Tag)
 	}

--- a/pkg/backends/jmeter/resources.go
+++ b/pkg/backends/jmeter/resources.go
@@ -178,8 +178,8 @@ func (c *JMeter) NewPod(i int, configMap *coreV1.ConfigMap, podAnnotations map[s
 
 	imageRef := fmt.Sprintf("%s:%s", loadtest.Spec.WorkerConfig.Image, loadtest.Spec.WorkerConfig.Tag)
 	if imageRef == "" {
+		imageRef = fmt.Sprintf("%s:%s", c.workerConfig.Image, c.workerConfig.Tag)
 		c.logger.Warn("Loadtest.Spec.WorkerConfig is empty; using default worker image", zap.String("imageRef", imageRef))
-		imageRef = fmt.Sprintf("%s:%s", defaultWorkerImageName, defaultWorkerImageTag)
 	}
 
 	return &coreV1.Pod{
@@ -244,7 +244,7 @@ func (c *JMeter) NewJMeterMasterJob(reportURL string, podAnnotations map[string]
 	imageRef := fmt.Sprintf("%s:%s", loadtest.Spec.MasterConfig.Image, loadtest.Spec.MasterConfig.Tag)
 	if imageRef == "" {
 		c.logger.Warn("Loadtest.Spec.MasterConfig is empty; using default master image", zap.String("imageRef", imageRef))
-		imageRef = fmt.Sprintf("%s:%s", defaultMasterImageName, defaultMasterImageTag)
+		imageRef = fmt.Sprintf("%s:%s", c.masterConfig.Image, c.masterConfig.Tag)
 	}
 
 	jMeterEnvVars := []coreV1.EnvVar{

--- a/pkg/backends/jmeter/resources.go
+++ b/pkg/backends/jmeter/resources.go
@@ -175,7 +175,12 @@ func (c *JMeter) NewTestdataConfigMap() ([]*coreV1.ConfigMap, error) {
 func (c *JMeter) NewPod(i int, configMap *coreV1.ConfigMap, podAnnotations map[string]string) *coreV1.Pod {
 	loadtest := c.loadTest
 	optionalVolume := true
-	WorkerConfig := loadtest.Spec.WorkerConfig
+
+	imageRef := fmt.Sprintf("%s:%s", loadtest.Spec.WorkerConfig.Image, loadtest.Spec.WorkerConfig.Tag)
+	if imageRef == "" {
+		c.logger.Warn("Loadtest.Spec.WorkerConfig is empty; using default worker image", zap.String("imageRef", imageRef))
+		imageRef = fmt.Sprintf("%s:%s", defaultWorkerImageName, defaultWorkerImageTag)
+	}
 
 	return &coreV1.Pod{
 		ObjectMeta: metaV1.ObjectMeta{
@@ -190,7 +195,7 @@ func (c *JMeter) NewPod(i int, configMap *coreV1.ConfigMap, podAnnotations map[s
 			Containers: []coreV1.Container{
 				{
 					Name:            loadTestWorkerName,
-					Image:           fmt.Sprintf("%s:%s", WorkerConfig.Image, WorkerConfig.Tag),
+					Image:           imageRef,
 					ImagePullPolicy: "Always",
 					Ports: []coreV1.ContainerPort{
 						{ContainerPort: 1099},
@@ -235,7 +240,12 @@ func (c *JMeter) NewPod(i int, configMap *coreV1.ConfigMap, podAnnotations map[s
 func (c *JMeter) NewJMeterMasterJob(reportURL string, podAnnotations map[string]string) *batchV1.Job {
 	loadtest := c.loadTest
 	var one int32 = 1
-	MasterConfig := loadtest.Spec.MasterConfig
+
+	imageRef := fmt.Sprintf("%s:%s", loadtest.Spec.MasterConfig.Image, loadtest.Spec.MasterConfig.Tag)
+	if imageRef == "" {
+		c.logger.Warn("Loadtest.Spec.MasterConfig is empty; using default master image", zap.String("imageRef", imageRef))
+		imageRef = fmt.Sprintf("%s:%s", defaultMasterImageName, defaultMasterImageTag)
+	}
 
 	jMeterEnvVars := []coreV1.EnvVar{
 		{
@@ -281,7 +291,7 @@ func (c *JMeter) NewJMeterMasterJob(reportURL string, podAnnotations map[string]
 					Containers: []coreV1.Container{
 						{
 							Name:            loadTestJobName,
-							Image:           fmt.Sprintf("%s:%s", MasterConfig.Image, MasterConfig.Tag),
+							Image:           imageRef,
 							ImagePullPolicy: "Always",
 							Env:             jMeterEnvVars,
 							VolumeMounts: []coreV1.VolumeMount{

--- a/pkg/backends/jmeter/resources_test.go
+++ b/pkg/backends/jmeter/resources_test.go
@@ -96,8 +96,14 @@ func TestPodResourceConfiguration(t *testing.T) {
 	c := &JMeter{
 		loadTest: &loadtestv1.LoadTest{
 			Spec: loadtestv1.LoadTestSpec{
-				MasterConfig: loadtestv1.ImageDetails{},
-				WorkerConfig: loadtestv1.ImageDetails{},
+				MasterConfig: loadtestv1.ImageDetails{
+					Image: defaultMasterImageName,
+					Tag:   defaultMasterImageTag,
+				},
+				WorkerConfig: loadtestv1.ImageDetails{
+					Image: defaultWorkerImageName,
+					Tag:   defaultWorkerImageTag,
+				},
 			},
 		},
 		masterResources: helper.Resources{

--- a/pkg/backends/jmeter/spec.go
+++ b/pkg/backends/jmeter/spec.go
@@ -17,7 +17,14 @@ var (
 )
 
 //BuildLoadTestSpec validates input and returns valid LoadTestSpec for JMeter backend provider
-func BuildLoadTestSpec(config Config, overwrite bool, distributedPods int32, tags loadTestV1.LoadTestTags, testFileStr, testDataStr, envVarsStr string, masterImageRef, workerImageRef reference.NamedTagged) (loadTestV1.LoadTestSpec, error) {
+func BuildLoadTestSpec(
+	config Config,
+	overwrite bool,
+	distributedPods int32,
+	tags loadTestV1.LoadTestTags,
+	testFileStr, testDataStr, envVarsStr string,
+	masterImageRef, workerImageRef reference.NamedTagged,
+) (loadTestV1.LoadTestSpec, error) {
 	lt := loadTestV1.LoadTestSpec{}
 	// JMeter backend provider needs full spec: from number of distributed pods to envVars
 	if distributedPods <= int32(0) {
@@ -56,5 +63,17 @@ func BuildLoadTestSpec(config Config, overwrite bool, distributedPods int32, tag
 		workerImageTag = workerImageRef.Tag()
 	}
 
-	return loadTestV1.NewSpec(loadTestV1.LoadTestTypeJMeter, overwrite, distributedPods, tags, testFileStr, testDataStr, envVarsStr, loadTestV1.ImageDetails{Image: masterImageName, Tag: masterImageTag}, loadTestV1.ImageDetails{Image: workerImageName, Tag: workerImageTag}, "", time.Duration(0)), nil
+	return loadTestV1.NewSpec(
+		loadTestV1.LoadTestTypeJMeter,
+		overwrite,
+		distributedPods,
+		tags,
+		testFileStr,
+		testDataStr,
+		envVarsStr,
+		loadTestV1.ImageDetails{Image: masterImageName, Tag: masterImageTag},
+		loadTestV1.ImageDetails{Image: workerImageName, Tag: workerImageTag},
+		"",
+		time.Duration(0),
+	), nil
 }

--- a/pkg/backends/jmeter/spec.go
+++ b/pkg/backends/jmeter/spec.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"time"
 
+	"github.com/docker/distribution/reference"
+
 	loadTestV1 "github.com/hellofresh/kangal/pkg/kubernetes/apis/loadtest/v1"
 )
 
@@ -15,7 +17,7 @@ var (
 )
 
 //BuildLoadTestSpec validates input and returns valid LoadTestSpec for JMeter backend provider
-func BuildLoadTestSpec(overwrite bool, distributedPods int32, tags loadTestV1.LoadTestTags, testFileStr, testDataStr, envVarsStr string) (loadTestV1.LoadTestSpec, error) {
+func BuildLoadTestSpec(overwrite bool, distributedPods int32, tags loadTestV1.LoadTestTags, testFileStr, testDataStr, envVarsStr string, masterImageRef, workerImageRef reference.NamedTagged) (loadTestV1.LoadTestSpec, error) {
 	lt := loadTestV1.LoadTestSpec{}
 	// JMeter backend provider needs full spec: from number of distributed pods to envVars
 	if distributedPods <= int32(0) {
@@ -24,5 +26,21 @@ func BuildLoadTestSpec(overwrite bool, distributedPods int32, tags loadTestV1.Lo
 	if testFileStr == "" {
 		return lt, ErrRequireTestFile
 	}
-	return loadTestV1.NewSpec(loadTestV1.LoadTestTypeJMeter, overwrite, distributedPods, tags, testFileStr, testDataStr, envVarsStr, loadTestV1.ImageDetails{Image: masterImage, Tag: imageTag}, loadTestV1.ImageDetails{Image: workerImage, Tag: imageTag}, "", time.Duration(0)), nil
+	// Use defaults if unspecified
+	masterImage := loadTestV1.ImageDetails{Image: defaultMasterImageName, Tag: defaultMasterImageTag}
+	if masterImageRef != nil {
+		masterImage = loadTestV1.ImageDetails{
+			Image: masterImageRef.Name(),
+			Tag:   masterImageRef.Tag(),
+		}
+	}
+	workerImage := loadTestV1.ImageDetails{Image: defaultWorkerImageName, Tag: defaultWorkerImageTag}
+	if workerImageRef != nil {
+		workerImage = loadTestV1.ImageDetails{
+			Image: workerImageRef.Name(),
+			Tag:   workerImageRef.Tag(),
+		}
+	}
+
+	return loadTestV1.NewSpec(loadTestV1.LoadTestTypeJMeter, overwrite, distributedPods, tags, testFileStr, testDataStr, envVarsStr, masterImage, workerImage, "", time.Duration(0)), nil
 }

--- a/pkg/backends/jmeter/spec_test.go
+++ b/pkg/backends/jmeter/spec_test.go
@@ -3,6 +3,8 @@ package jmeter
 import (
 	"testing"
 
+	"github.com/docker/distribution/reference"
+
 	v1 "github.com/hellofresh/kangal/pkg/kubernetes/apis/loadtest/v1"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +12,8 @@ import (
 
 func TestBuildJMeterLoadTestSpec(t *testing.T) {
 	var distributedPods int32 = 3
+	masterImageRef, _ := reference.ParseNormalizedNamed("hellofreshtech/kangal-jmeter-master:3.2.1")
+	workerImageRef, _ := reference.ParseNormalizedNamed("hellofreshtech/kangal-jmeter-worker:1.2.3")
 
 	type args struct {
 		overwrite       bool
@@ -18,6 +22,8 @@ func TestBuildJMeterLoadTestSpec(t *testing.T) {
 		testFileStr     string
 		testDataStr     string
 		envVarsStr      string
+		masterImageRef  reference.NamedTagged
+		workerImageRef  reference.NamedTagged
 	}
 	tests := []struct {
 		name    string
@@ -33,12 +39,14 @@ func TestBuildJMeterLoadTestSpec(t *testing.T) {
 				tags:            v1.LoadTestTags{"team": "kangal"},
 				testFileStr:     "something in the file",
 				testDataStr:     "some test data",
+				masterImageRef:  masterImageRef.(reference.NamedTagged),
+				workerImageRef:  workerImageRef.(reference.NamedTagged),
 			},
 			want: v1.LoadTestSpec{
 				Type:            "JMeter",
 				Overwrite:       true,
-				MasterConfig:    v1.ImageDetails{Image: masterImage, Tag: imageTag},
-				WorkerConfig:    v1.ImageDetails{Image: workerImage, Tag: imageTag},
+				MasterConfig:    v1.ImageDetails{Image: "docker.io/hellofreshtech/kangal-jmeter-master", Tag: "3.2.1"},
+				WorkerConfig:    v1.ImageDetails{Image: "docker.io/hellofreshtech/kangal-jmeter-worker", Tag: "1.2.3"},
 				DistributedPods: &distributedPods,
 				Tags:            v1.LoadTestTags{"team": "kangal"},
 				TestFile:        "something in the file",
@@ -68,7 +76,7 @@ func TestBuildJMeterLoadTestSpec(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := BuildLoadTestSpec(tt.args.overwrite, tt.args.distributedPods, tt.args.tags, tt.args.testFileStr, tt.args.testDataStr, tt.args.envVarsStr)
+			got, err := BuildLoadTestSpec(tt.args.overwrite, tt.args.distributedPods, tt.args.tags, tt.args.testFileStr, tt.args.testDataStr, tt.args.envVarsStr, tt.args.masterImageRef, tt.args.workerImageRef)
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/pkg/backends/jmeter/spec_test.go
+++ b/pkg/backends/jmeter/spec_test.go
@@ -16,6 +16,7 @@ func TestBuildJMeterLoadTestSpec(t *testing.T) {
 	workerImageRef, _ := reference.ParseNormalizedNamed("hellofreshtech/kangal-jmeter-worker:1.2.3")
 
 	type args struct {
+		config          Config
 		overwrite       bool
 		distributedPods int32
 		tags            v1.LoadTestTags
@@ -34,6 +35,7 @@ func TestBuildJMeterLoadTestSpec(t *testing.T) {
 		{
 			name: "Spec is valid",
 			args: args{
+				config:          Config{},
 				overwrite:       true,
 				distributedPods: 3,
 				tags:            v1.LoadTestTags{"team": "kangal"},
@@ -76,7 +78,7 @@ func TestBuildJMeterLoadTestSpec(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := BuildLoadTestSpec(tt.args.overwrite, tt.args.distributedPods, tt.args.tags, tt.args.testFileStr, tt.args.testDataStr, tt.args.envVarsStr, tt.args.masterImageRef, tt.args.workerImageRef)
+			got, err := BuildLoadTestSpec(tt.args.config, tt.args.overwrite, tt.args.distributedPods, tt.args.tags, tt.args.testFileStr, tt.args.testDataStr, tt.args.envVarsStr, tt.args.masterImageRef, tt.args.workerImageRef)
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/pkg/backends/locust/locust.go
+++ b/pkg/backends/locust/locust.go
@@ -36,10 +36,6 @@ type Locust struct {
 
 // CheckOrCreateResources check for resources or create the needed resources for the loadtest type
 func (c *Locust) CheckOrCreateResources(ctx context.Context) error {
-	if c.loadTest.Status.Phase == "" {
-		c.loadTest.Status.Phase = loadTestV1.LoadTestCreating
-	}
-
 	workerJobs, err := c.kubeClientSet.
 		BatchV1().
 		Jobs(c.loadTest.Status.Namespace).
@@ -122,6 +118,10 @@ func (c *Locust) CheckOrCreateResources(ctx context.Context) error {
 
 // CheckOrUpdateStatus check current LoadTest progress
 func (c *Locust) CheckOrUpdateStatus(ctx context.Context) error {
+	if c.loadTest.Status.Phase == "" {
+		c.loadTest.Status.Phase = loadTestV1.LoadTestCreating
+	}
+
 	if c.loadTest.Status.Phase == loadTestV1.LoadTestErrored ||
 		c.loadTest.Status.Phase == loadTestV1.LoadTestFinished {
 		return nil

--- a/pkg/backends/locust/locust.go
+++ b/pkg/backends/locust/locust.go
@@ -86,7 +86,7 @@ func (c *Locust) CheckOrCreateResources(ctx context.Context) error {
 		}
 	}
 
-	masterJob := newMasterJob(c.loadTest, configMap, secret, c.reportURL, c.masterResources, c.podAnnotations, c.logger)
+	masterJob := newMasterJob(c.loadTest, configMap, secret, c.reportURL, c.masterResources, c.podAnnotations, c.image, c.imageTag, c.logger)
 	_, err = c.kubeClientSet.
 		BatchV1().
 		Jobs(c.loadTest.Status.Namespace).
@@ -103,7 +103,7 @@ func (c *Locust) CheckOrCreateResources(ctx context.Context) error {
 		return err
 	}
 
-	workerJob := newWorkerJob(c.loadTest, configMap, secret, masterService, c.workerResources, c.podAnnotations, c.logger)
+	workerJob := newWorkerJob(c.loadTest, configMap, secret, masterService, c.workerResources, c.podAnnotations, c.image, c.imageTag, c.logger)
 	_, err = c.kubeClientSet.
 		BatchV1().
 		Jobs(c.loadTest.Status.Namespace).

--- a/pkg/backends/locust/locust.go
+++ b/pkg/backends/locust/locust.go
@@ -34,31 +34,12 @@ type Locust struct {
 	podAnnotations  map[string]string
 }
 
-// SetDefaults mutates the LoadTest object to add default values to empty fields
-func (c *Locust) SetDefaults() error {
+// CheckOrCreateResources check for resources or create the needed resources for the loadtest type
+func (c *Locust) CheckOrCreateResources(ctx context.Context) error {
 	if c.loadTest.Status.Phase == "" {
 		c.loadTest.Status.Phase = loadTestV1.LoadTestCreating
 	}
 
-	if c.loadTest.Spec.MasterConfig.Image == "" {
-		c.loadTest.Spec.MasterConfig.Image = c.image
-	}
-	if c.loadTest.Spec.MasterConfig.Tag == "" {
-		c.loadTest.Spec.MasterConfig.Tag = c.imageTag
-	}
-
-	if c.loadTest.Spec.WorkerConfig.Image == "" {
-		c.loadTest.Spec.WorkerConfig.Image = c.image
-	}
-	if c.loadTest.Spec.WorkerConfig.Tag == "" {
-		c.loadTest.Spec.WorkerConfig.Tag = c.imageTag
-	}
-
-	return nil
-}
-
-// CheckOrCreateResources check for resources or create the needed resources for the loadtest type
-func (c *Locust) CheckOrCreateResources(ctx context.Context) error {
 	workerJobs, err := c.kubeClientSet.
 		BatchV1().
 		Jobs(c.loadTest.Status.Namespace).

--- a/pkg/backends/locust/locust.go
+++ b/pkg/backends/locust/locust.go
@@ -86,7 +86,7 @@ func (c *Locust) CheckOrCreateResources(ctx context.Context) error {
 		}
 	}
 
-	masterJob := newMasterJob(c.loadTest, configMap, secret, c.reportURL, c.masterResources, c.podAnnotations)
+	masterJob := newMasterJob(c.loadTest, configMap, secret, c.reportURL, c.masterResources, c.podAnnotations, c.logger)
 	_, err = c.kubeClientSet.
 		BatchV1().
 		Jobs(c.loadTest.Status.Namespace).
@@ -103,7 +103,7 @@ func (c *Locust) CheckOrCreateResources(ctx context.Context) error {
 		return err
 	}
 
-	workerJob := newWorkerJob(c.loadTest, configMap, secret, masterService, c.workerResources, c.podAnnotations)
+	workerJob := newWorkerJob(c.loadTest, configMap, secret, masterService, c.workerResources, c.podAnnotations, c.logger)
 	_, err = c.kubeClientSet.
 		BatchV1().
 		Jobs(c.loadTest.Status.Namespace).

--- a/pkg/backends/locust/resources.go
+++ b/pkg/backends/locust/resources.go
@@ -65,15 +65,15 @@ func newMasterJobName(loadTest *loadtestV1.LoadTest) string {
 	return fmt.Sprintf("%s-master", loadTest.ObjectMeta.Name)
 }
 
-func newMasterJob(loadTest *loadtestV1.LoadTest, testfileConfigMap *coreV1.ConfigMap, envvarSecret *coreV1.Secret, reportURL string, masterResources helper.Resources, podAnnotations map[string]string, logger *zap.Logger) *batchV1.Job {
+func newMasterJob(loadTest *loadtestV1.LoadTest, testfileConfigMap *coreV1.ConfigMap, envvarSecret *coreV1.Secret, reportURL string, masterResources helper.Resources, podAnnotations map[string]string, imageName, imageTag string, logger *zap.Logger) *batchV1.Job {
 	name := newMasterJobName(loadTest)
 
 	ownerRef := metaV1.NewControllerRef(loadTest, loadtestV1.SchemeGroupVersion.WithKind("LoadTest"))
 
 	imageRef := fmt.Sprintf("%s:%s", loadTest.Spec.MasterConfig.Image, loadTest.Spec.MasterConfig.Tag)
 	if imageRef == "" {
+		imageRef = fmt.Sprintf("%s:%s", imageName, imageTag)
 		logger.Warn("Loadtest.Spec.MasterConfig is empty; using default image", zap.String("imageRef", imageRef))
-		imageRef = fmt.Sprintf("%s:%s", defaultImage, defaultImageTag)
 	}
 
 	envVars := []coreV1.EnvVar{
@@ -198,15 +198,15 @@ func newWorkerJobName(loadTest *loadtestV1.LoadTest) string {
 	return fmt.Sprintf("%s-worker", loadTest.ObjectMeta.Name)
 }
 
-func newWorkerJob(loadTest *loadtestV1.LoadTest, testfileConfigMap *coreV1.ConfigMap, envvarSecret *coreV1.Secret, masterService *coreV1.Service, workerResources helper.Resources, podAnnotations map[string]string, logger *zap.Logger) *batchV1.Job {
+func newWorkerJob(loadTest *loadtestV1.LoadTest, testfileConfigMap *coreV1.ConfigMap, envvarSecret *coreV1.Secret, masterService *coreV1.Service, workerResources helper.Resources, podAnnotations map[string]string, imageName, imageTag string, logger *zap.Logger) *batchV1.Job {
 	name := newWorkerJobName(loadTest)
 
 	ownerRef := metaV1.NewControllerRef(loadTest, loadtestV1.SchemeGroupVersion.WithKind("LoadTest"))
 
 	imageRef := fmt.Sprintf("%s:%s", loadTest.Spec.MasterConfig.Image, loadTest.Spec.MasterConfig.Tag)
 	if imageRef == "" {
+		imageRef = fmt.Sprintf("%s:%s", imageName, imageTag)
 		logger.Warn("Loadtest.Spec.MasterConfig is empty; using default image", zap.String("imageRef", imageRef))
-		imageRef = fmt.Sprintf("%s:%s", defaultImage, defaultImageTag)
 	}
 
 	envVars := []coreV1.EnvVar{

--- a/pkg/backends/locust/resources.go
+++ b/pkg/backends/locust/resources.go
@@ -71,7 +71,7 @@ func newMasterJob(loadTest *loadtestV1.LoadTest, testfileConfigMap *coreV1.Confi
 	ownerRef := metaV1.NewControllerRef(loadTest, loadtestV1.SchemeGroupVersion.WithKind("LoadTest"))
 
 	imageRef := fmt.Sprintf("%s:%s", loadTest.Spec.MasterConfig.Image, loadTest.Spec.MasterConfig.Tag)
-	if imageRef == "" {
+	if imageRef == ":" {
 		imageRef = fmt.Sprintf("%s:%s", imageName, imageTag)
 		logger.Warn("Loadtest.Spec.MasterConfig is empty; using default image", zap.String("imageRef", imageRef))
 	}
@@ -204,7 +204,7 @@ func newWorkerJob(loadTest *loadtestV1.LoadTest, testfileConfigMap *coreV1.Confi
 	ownerRef := metaV1.NewControllerRef(loadTest, loadtestV1.SchemeGroupVersion.WithKind("LoadTest"))
 
 	imageRef := fmt.Sprintf("%s:%s", loadTest.Spec.MasterConfig.Image, loadTest.Spec.MasterConfig.Tag)
-	if imageRef == "" {
+	if imageRef == ":" {
 		imageRef = fmt.Sprintf("%s:%s", imageName, imageTag)
 		logger.Warn("Loadtest.Spec.MasterConfig is empty; using default image", zap.String("imageRef", imageRef))
 	}

--- a/pkg/backends/locust/resources.go
+++ b/pkg/backends/locust/resources.go
@@ -65,7 +65,16 @@ func newMasterJobName(loadTest *loadtestV1.LoadTest) string {
 	return fmt.Sprintf("%s-master", loadTest.ObjectMeta.Name)
 }
 
-func newMasterJob(loadTest *loadtestV1.LoadTest, testfileConfigMap *coreV1.ConfigMap, envvarSecret *coreV1.Secret, reportURL string, masterResources helper.Resources, podAnnotations map[string]string, imageName, imageTag string, logger *zap.Logger) *batchV1.Job {
+func newMasterJob(
+	loadTest *loadtestV1.LoadTest,
+	testfileConfigMap *coreV1.ConfigMap,
+	envvarSecret *coreV1.Secret,
+	reportURL string,
+	masterResources helper.Resources,
+	podAnnotations map[string]string,
+	imageName, imageTag string,
+	logger *zap.Logger,
+) *batchV1.Job {
 	name := newMasterJobName(loadTest)
 
 	ownerRef := metaV1.NewControllerRef(loadTest, loadtestV1.SchemeGroupVersion.WithKind("LoadTest"))
@@ -198,7 +207,16 @@ func newWorkerJobName(loadTest *loadtestV1.LoadTest) string {
 	return fmt.Sprintf("%s-worker", loadTest.ObjectMeta.Name)
 }
 
-func newWorkerJob(loadTest *loadtestV1.LoadTest, testfileConfigMap *coreV1.ConfigMap, envvarSecret *coreV1.Secret, masterService *coreV1.Service, workerResources helper.Resources, podAnnotations map[string]string, imageName, imageTag string, logger *zap.Logger) *batchV1.Job {
+func newWorkerJob(
+	loadTest *loadtestV1.LoadTest,
+	testfileConfigMap *coreV1.ConfigMap,
+	envvarSecret *coreV1.Secret,
+	masterService *coreV1.Service,
+	workerResources helper.Resources,
+	podAnnotations map[string]string,
+	imageName, imageTag string,
+	logger *zap.Logger,
+) *batchV1.Job {
 	name := newWorkerJobName(loadTest)
 
 	ownerRef := metaV1.NewControllerRef(loadTest, loadtestV1.SchemeGroupVersion.WithKind("LoadTest"))

--- a/pkg/backends/locust/resources.go
+++ b/pkg/backends/locust/resources.go
@@ -3,6 +3,8 @@ package locust
 import (
 	"fmt"
 
+	"go.uber.org/zap"
+
 	batchV1 "k8s.io/api/batch/v1"
 	coreV1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,12 +65,16 @@ func newMasterJobName(loadTest *loadtestV1.LoadTest) string {
 	return fmt.Sprintf("%s-master", loadTest.ObjectMeta.Name)
 }
 
-func newMasterJob(loadTest *loadtestV1.LoadTest, testfileConfigMap *coreV1.ConfigMap, envvarSecret *coreV1.Secret, reportURL string, masterResources helper.Resources, podAnnotations map[string]string) *batchV1.Job {
+func newMasterJob(loadTest *loadtestV1.LoadTest, testfileConfigMap *coreV1.ConfigMap, envvarSecret *coreV1.Secret, reportURL string, masterResources helper.Resources, podAnnotations map[string]string, logger *zap.Logger) *batchV1.Job {
 	name := newMasterJobName(loadTest)
 
 	ownerRef := metaV1.NewControllerRef(loadTest, loadtestV1.SchemeGroupVersion.WithKind("LoadTest"))
 
-	image := fmt.Sprintf("%s:%s", loadTest.Spec.MasterConfig.Image, loadTest.Spec.MasterConfig.Tag)
+	imageRef := fmt.Sprintf("%s:%s", loadTest.Spec.MasterConfig.Image, loadTest.Spec.MasterConfig.Tag)
+	if imageRef == "" {
+		logger.Warn("Loadtest.Spec.MasterConfig is empty; using default image", zap.String("imageRef", imageRef))
+		imageRef = fmt.Sprintf("%s:%s", defaultImage, defaultImageTag)
+	}
 
 	envVars := []coreV1.EnvVar{
 		{Name: "LOCUST_HEADLESS", Value: "true"},
@@ -126,7 +132,7 @@ func newMasterJob(loadTest *loadtestV1.LoadTest, testfileConfigMap *coreV1.Confi
 					Containers: []coreV1.Container{
 						{
 							Name:            "locust",
-							Image:           image,
+							Image:           imageRef,
 							ImagePullPolicy: "Always",
 							Env:             envVars,
 							VolumeMounts: []coreV1.VolumeMount{
@@ -192,12 +198,16 @@ func newWorkerJobName(loadTest *loadtestV1.LoadTest) string {
 	return fmt.Sprintf("%s-worker", loadTest.ObjectMeta.Name)
 }
 
-func newWorkerJob(loadTest *loadtestV1.LoadTest, testfileConfigMap *coreV1.ConfigMap, envvarSecret *coreV1.Secret, masterService *coreV1.Service, workerResources helper.Resources, podAnnotations map[string]string) *batchV1.Job {
+func newWorkerJob(loadTest *loadtestV1.LoadTest, testfileConfigMap *coreV1.ConfigMap, envvarSecret *coreV1.Secret, masterService *coreV1.Service, workerResources helper.Resources, podAnnotations map[string]string, logger *zap.Logger) *batchV1.Job {
 	name := newWorkerJobName(loadTest)
 
 	ownerRef := metaV1.NewControllerRef(loadTest, loadtestV1.SchemeGroupVersion.WithKind("LoadTest"))
 
-	image := fmt.Sprintf("%s:%s", loadTest.Spec.MasterConfig.Image, loadTest.Spec.MasterConfig.Tag)
+	imageRef := fmt.Sprintf("%s:%s", loadTest.Spec.MasterConfig.Image, loadTest.Spec.MasterConfig.Tag)
+	if imageRef == "" {
+		logger.Warn("Loadtest.Spec.MasterConfig is empty; using default image", zap.String("imageRef", imageRef))
+		imageRef = fmt.Sprintf("%s:%s", defaultImage, defaultImageTag)
+	}
 
 	envVars := []coreV1.EnvVar{
 		{Name: "LOCUST_MODE_WORKER", Value: "true"},
@@ -245,7 +255,7 @@ func newWorkerJob(loadTest *loadtestV1.LoadTest, testfileConfigMap *coreV1.Confi
 					Containers: []coreV1.Container{
 						{
 							Name:            "locust",
-							Image:           image,
+							Image:           imageRef,
 							ImagePullPolicy: "Always",
 							Env:             envVars,
 							VolumeMounts: []coreV1.VolumeMount{

--- a/pkg/backends/locust/spec.go
+++ b/pkg/backends/locust/spec.go
@@ -17,7 +17,7 @@ var (
 )
 
 //BuildLoadTestSpec validates input and returns valid LoadTestSpec
-func BuildLoadTestSpec(overwrite bool, distributedPods int32, tags loadTestV1.LoadTestTags, testFileStr, envVarsStr, targetURL string, duration time.Duration, masterImageRef, workerImageRef reference.NamedTagged) (loadTestV1.LoadTestSpec, error) {
+func BuildLoadTestSpec(config Config, overwrite bool, distributedPods int32, tags loadTestV1.LoadTestTags, testFileStr, envVarsStr, targetURL string, duration time.Duration, masterImageRef reference.NamedTagged) (loadTestV1.LoadTestSpec, error) {
 	lt := loadTestV1.LoadTestSpec{}
 	if distributedPods <= int32(0) {
 		return lt, ErrRequireMinOneDistributedPod
@@ -25,20 +25,23 @@ func BuildLoadTestSpec(overwrite bool, distributedPods int32, tags loadTestV1.Lo
 	if testFileStr == "" {
 		return lt, ErrRequireTestFile
 	}
-	// Use defaults if unspecified
-	masterImage := loadTestV1.ImageDetails{Image: defaultImage, Tag: defaultImageTag}
+
+	imageName := defaultImage
+	imageTag := defaultImageTag
+
+	// Use environment variable config if available
+	if config.Image != "" {
+		imageName = config.Image
+	}
+	if config.ImageTag != "" {
+		imageTag = config.ImageTag
+	}
+
+	// Use loadtest data received from proxy if available
 	if masterImageRef != nil {
-		masterImage = loadTestV1.ImageDetails{
-			Image: masterImageRef.Name(),
-			Tag:   masterImageRef.Tag(),
-		}
+		imageName = masterImageRef.Name()
+		imageTag = masterImageRef.Tag()
 	}
-	workerImage := loadTestV1.ImageDetails{Image: defaultImage, Tag: defaultImageTag}
-	if workerImageRef != nil {
-		workerImage = loadTestV1.ImageDetails{
-			Image: workerImageRef.Name(),
-			Tag:   workerImageRef.Tag(),
-		}
-	}
-	return loadTestV1.NewSpec(loadTestV1.LoadTestTypeLocust, overwrite, distributedPods, tags, testFileStr, "", envVarsStr, masterImage, workerImage, targetURL, duration), nil
+
+	return loadTestV1.NewSpec(loadTestV1.LoadTestTypeLocust, overwrite, distributedPods, tags, testFileStr, "", envVarsStr, loadTestV1.ImageDetails{Image: imageName, Tag: imageTag}, loadTestV1.ImageDetails{Image: imageName, Tag: imageTag}, targetURL, duration), nil
 }

--- a/pkg/backends/locust/spec.go
+++ b/pkg/backends/locust/spec.go
@@ -17,7 +17,7 @@ var (
 )
 
 //BuildLoadTestSpec validates input and returns valid LoadTestSpec
-func BuildLoadTestSpec(overwrite bool, distributedPods int32, tags loadTestV1.LoadTestTags, testFileStr, envVarsStr, targetURL string, duration time.Duration, masterImageRef reference.NamedTagged) (loadTestV1.LoadTestSpec, error) {
+func BuildLoadTestSpec(overwrite bool, distributedPods int32, tags loadTestV1.LoadTestTags, testFileStr, envVarsStr, targetURL string, duration time.Duration, masterImageRef, workerImageRef reference.NamedTagged) (loadTestV1.LoadTestSpec, error) {
 	lt := loadTestV1.LoadTestSpec{}
 	if distributedPods <= int32(0) {
 		return lt, ErrRequireMinOneDistributedPod
@@ -33,5 +33,12 @@ func BuildLoadTestSpec(overwrite bool, distributedPods int32, tags loadTestV1.Lo
 			Tag:   masterImageRef.Tag(),
 		}
 	}
-	return loadTestV1.NewSpec(loadTestV1.LoadTestTypeLocust, overwrite, distributedPods, tags, testFileStr, "", envVarsStr, masterImage, loadTestV1.ImageDetails{}, targetURL, duration), nil
+	workerImage := loadTestV1.ImageDetails{Image: defaultImage, Tag: defaultImageTag}
+	if workerImageRef != nil {
+		workerImage = loadTestV1.ImageDetails{
+			Image: workerImageRef.Name(),
+			Tag:   workerImageRef.Tag(),
+		}
+	}
+	return loadTestV1.NewSpec(loadTestV1.LoadTestTypeLocust, overwrite, distributedPods, tags, testFileStr, "", envVarsStr, masterImage, workerImage, targetURL, duration), nil
 }

--- a/pkg/backends/locust/spec.go
+++ b/pkg/backends/locust/spec.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"time"
 
+	"github.com/docker/distribution/reference"
+
 	loadTestV1 "github.com/hellofresh/kangal/pkg/kubernetes/apis/loadtest/v1"
 )
 
@@ -15,7 +17,7 @@ var (
 )
 
 //BuildLoadTestSpec validates input and returns valid LoadTestSpec
-func BuildLoadTestSpec(overwrite bool, distributedPods int32, tags loadTestV1.LoadTestTags, testFileStr, envVarsStr, targetURL string, duration time.Duration) (loadTestV1.LoadTestSpec, error) {
+func BuildLoadTestSpec(overwrite bool, distributedPods int32, tags loadTestV1.LoadTestTags, testFileStr, envVarsStr, targetURL string, duration time.Duration, masterImageRef reference.NamedTagged) (loadTestV1.LoadTestSpec, error) {
 	lt := loadTestV1.LoadTestSpec{}
 	if distributedPods <= int32(0) {
 		return lt, ErrRequireMinOneDistributedPod
@@ -23,5 +25,13 @@ func BuildLoadTestSpec(overwrite bool, distributedPods int32, tags loadTestV1.Lo
 	if testFileStr == "" {
 		return lt, ErrRequireTestFile
 	}
-	return loadTestV1.NewSpec(loadTestV1.LoadTestTypeLocust, overwrite, distributedPods, tags, testFileStr, "", envVarsStr, loadTestV1.ImageDetails{}, loadTestV1.ImageDetails{}, targetURL, duration), nil
+	// Use defaults if unspecified
+	masterImage := loadTestV1.ImageDetails{Image: defaultImage, Tag: defaultImageTag}
+	if masterImageRef != nil {
+		masterImage = loadTestV1.ImageDetails{
+			Image: masterImageRef.Name(),
+			Tag:   masterImageRef.Tag(),
+		}
+	}
+	return loadTestV1.NewSpec(loadTestV1.LoadTestTypeLocust, overwrite, distributedPods, tags, testFileStr, "", envVarsStr, masterImage, loadTestV1.ImageDetails{}, targetURL, duration), nil
 }

--- a/pkg/backends/locust/spec.go
+++ b/pkg/backends/locust/spec.go
@@ -17,7 +17,15 @@ var (
 )
 
 //BuildLoadTestSpec validates input and returns valid LoadTestSpec
-func BuildLoadTestSpec(config Config, overwrite bool, distributedPods int32, tags loadTestV1.LoadTestTags, testFileStr, envVarsStr, targetURL string, duration time.Duration, masterImageRef reference.NamedTagged) (loadTestV1.LoadTestSpec, error) {
+func BuildLoadTestSpec(
+	config Config,
+	overwrite bool,
+	distributedPods int32,
+	tags loadTestV1.LoadTestTags,
+	testFileStr, envVarsStr, targetURL string,
+	duration time.Duration,
+	masterImageRef reference.NamedTagged,
+) (loadTestV1.LoadTestSpec, error) {
 	lt := loadTestV1.LoadTestSpec{}
 	if distributedPods <= int32(0) {
 		return lt, ErrRequireMinOneDistributedPod
@@ -43,5 +51,17 @@ func BuildLoadTestSpec(config Config, overwrite bool, distributedPods int32, tag
 		imageTag = masterImageRef.Tag()
 	}
 
-	return loadTestV1.NewSpec(loadTestV1.LoadTestTypeLocust, overwrite, distributedPods, tags, testFileStr, "", envVarsStr, loadTestV1.ImageDetails{Image: imageName, Tag: imageTag}, loadTestV1.ImageDetails{Image: imageName, Tag: imageTag}, targetURL, duration), nil
+	return loadTestV1.NewSpec(
+		loadTestV1.LoadTestTypeLocust,
+		overwrite,
+		distributedPods,
+		tags,
+		testFileStr,
+		"",
+		envVarsStr,
+		loadTestV1.ImageDetails{Image: imageName, Tag: imageTag},
+		loadTestV1.ImageDetails{Image: imageName, Tag: imageTag},
+		targetURL,
+		duration,
+	), nil
 }

--- a/pkg/backends/locust/spec_test.go
+++ b/pkg/backends/locust/spec_test.go
@@ -14,6 +14,7 @@ import (
 func TestBuildLoadTestSpec(t *testing.T) {
 	var distributedPods int32 = 3
 	masterImageRef, _ := reference.ParseNormalizedNamed("alpine:3.2.1")
+	workerImageRef, _ := reference.ParseNormalizedNamed("alpine:1.2.3")
 
 	type args struct {
 		overwrite       bool
@@ -24,6 +25,7 @@ func TestBuildLoadTestSpec(t *testing.T) {
 		targetURL       string
 		duration        time.Duration
 		masterImageRef  reference.NamedTagged
+		workerImageRef  reference.NamedTagged
 	}
 	tests := []struct {
 		name    string
@@ -41,6 +43,7 @@ func TestBuildLoadTestSpec(t *testing.T) {
 				envVarsStr:      "my-key,my-value",
 				targetURL:       "http://my-app.my-domain.com",
 				masterImageRef:  masterImageRef.(reference.NamedTagged),
+				workerImageRef:  workerImageRef.(reference.NamedTagged),
 			},
 			want: v1.LoadTestSpec{
 				Type:      "Locust",
@@ -49,7 +52,10 @@ func TestBuildLoadTestSpec(t *testing.T) {
 					Image: "docker.io/library/alpine",
 					Tag:   "3.2.1",
 				},
-				WorkerConfig:    v1.ImageDetails{},
+				WorkerConfig: v1.ImageDetails{
+					Image: "docker.io/library/alpine",
+					Tag:   "1.2.3",
+				},
 				DistributedPods: &distributedPods,
 				Tags:            v1.LoadTestTags{"team": "kangal"},
 				TestFile:        "something in the file",
@@ -79,7 +85,7 @@ func TestBuildLoadTestSpec(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := BuildLoadTestSpec(tt.args.overwrite, tt.args.distributedPods, tt.args.tags, tt.args.testFileStr, tt.args.envVarsStr, tt.args.targetURL, tt.args.duration, tt.args.masterImageRef)
+			got, err := BuildLoadTestSpec(tt.args.overwrite, tt.args.distributedPods, tt.args.tags, tt.args.testFileStr, tt.args.envVarsStr, tt.args.targetURL, tt.args.duration, tt.args.masterImageRef, tt.args.workerImageRef)
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/pkg/controller/loadtest.go
+++ b/pkg/controller/loadtest.go
@@ -317,12 +317,6 @@ func (c *Controller) syncHandler(key string) error {
 		return err
 	}
 
-	// mutates the LoadTest object to add default values to empty fields
-	err = backend.SetDefaults()
-	if err != nil {
-		return err
-	}
-
 	// check or create loadtest resources
 	err = backend.CheckOrCreateResources(ctx)
 	if err != nil {

--- a/pkg/controller/test_helper.go
+++ b/pkg/controller/test_helper.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/hellofresh/kangal/pkg/backends"
+
 	coreV1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
@@ -40,13 +42,26 @@ func CreateLoadtest(clientSet clientSetV.Clientset, pods int32, name, testFile, 
 		}
 	}
 
+	loadtestSpec, err := backends.BuildLoadTestSpecByBackend(
+		loadTestType,
+		false,
+		pods,
+		apisLoadTestV1.LoadTestTags{},
+		tf,
+		td,
+		ev,
+		"",
+		0,
+		nil,
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+
 	ltObj := &apisLoadTestV1.LoadTest{}
 	ltObj.Name = name
-	ltObj.Spec.DistributedPods = &pods
-	ltObj.Spec.Type = loadTestType
-	ltObj.Spec.TestFile = tf
-	ltObj.Spec.EnvVars = ev
-	ltObj.Spec.TestData = td
+	ltObj.Spec = loadtestSpec
 
 	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
 	defer cancel()

--- a/pkg/controller/test_helper.go
+++ b/pkg/controller/test_helper.go
@@ -44,6 +44,7 @@ func CreateLoadtest(clientSet clientSetV.Clientset, pods int32, name, testFile, 
 
 	loadtestSpec, err := backends.BuildLoadTestSpecByBackend(
 		loadTestType,
+		backends.Config{},
 		false,
 		pods,
 		apisLoadTestV1.LoadTestTags{},

--- a/pkg/proxy/config.go
+++ b/pkg/proxy/config.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"github.com/hellofresh/kangal/pkg/backends"
 	"github.com/hellofresh/kangal/pkg/core/observability"
 	"github.com/hellofresh/kangal/pkg/report"
 )
@@ -14,6 +15,7 @@ type Config struct {
 	Report          report.Config
 	MaxLoadTestsRun int
 	MasterURL       string
+	Backends        backends.Config
 }
 
 // OpenAPIConfig is the OpenAPI specification-specific parameters

--- a/pkg/proxy/proxy_integration_test.go
+++ b/pkg/proxy/proxy_integration_test.go
@@ -411,10 +411,9 @@ func TestIntegrationGetLoadtest(t *testing.T) {
 		require.NoError(t, err, "Could not get load test information")
 
 		assert.Equal(t, currentNamespace, dat.Namespace)
-		assert.Equal(t, distributedPods, dat.DistributedPods)
 		assert.NotEmpty(t, dat.Phase)
 		assert.NotEqual(t, apisLoadTestV1.LoadTestErrored, dat.Phase)
-		assert.Equal(t, true, dat.HasTestData)
+		assert.Equal(t, false, dat.HasTestData)
 	})
 }
 

--- a/pkg/proxy/request.go
+++ b/pkg/proxy/request.go
@@ -87,7 +87,7 @@ func fromHTTPRequestToListOptions(r *http.Request) (*kubernetes.ListOptions, err
 }
 
 // fromHTTPRequestToLoadTestSpec creates a load test spec from HTTP request
-func fromHTTPRequestToLoadTestSpec(r *http.Request, logger *zap.Logger) (apisLoadTestV1.LoadTestSpec, error) {
+func fromHTTPRequestToLoadTestSpec(r *http.Request, cfg backends.Config, logger *zap.Logger) (apisLoadTestV1.LoadTestSpec, error) {
 	ltType := getLoadTestType(r)
 
 	if e := httpValidator(r); len(e) > 0 {

--- a/pkg/proxy/request.go
+++ b/pkg/proxy/request.go
@@ -155,7 +155,7 @@ func fromHTTPRequestToLoadTestSpec(r *http.Request, cfg backends.Config, logger 
 		return apisLoadTestV1.LoadTestSpec{}, fmt.Errorf("error getting %q from request: %w", workerImage, err)
 	}
 
-	return backends.BuildLoadTestSpecByBackend(ltType, o, dp, tagList, tf, td, ev, turl, dur, masterImageRef, workerImageRef)
+	return backends.BuildLoadTestSpecByBackend(ltType, cfg, o, dp, tagList, tf, td, ev, turl, dur, masterImageRef, workerImageRef)
 }
 
 func getEnvVars(r *http.Request) (string, error) {

--- a/pkg/proxy/request_test.go
+++ b/pkg/proxy/request_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hellofresh/kangal/pkg/backends"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -22,7 +24,7 @@ func TestNewFakeFromHTTPLoadTest(t *testing.T) {
 		t.FailNow()
 	}
 
-	loadTest, err := fromHTTPRequestToLoadTestSpec(r, zap.NewNop())
+	loadTest, err := fromHTTPRequestToLoadTestSpec(r, backends.Config{}, zap.NewNop())
 	require.Error(t, err)
 	assert.Equal(t, apisLoadTestV1.LoadTestSpec{}, loadTest)
 }
@@ -381,7 +383,7 @@ func TestInit(t *testing.T) {
 				t.FailNow()
 			}
 
-			_, err = fromHTTPRequestToLoadTestSpec(request, zap.NewNop())
+			_, err = fromHTTPRequestToLoadTestSpec(request, backends.Config{}, zap.NewNop())
 
 			if ti.expectError {
 				assert.Error(t, err)
@@ -408,7 +410,7 @@ func TestCheckLoadTestSpec(t *testing.T) {
 		t.FailNow()
 	}
 
-	spec, err := fromHTTPRequestToLoadTestSpec(request, zap.NewNop())
+	spec, err := fromHTTPRequestToLoadTestSpec(request, backends.Config{}, zap.NewNop())
 	require.NoError(t, err)
 
 	lt, err := apisLoadTestV1.BuildLoadTestObject(spec)

--- a/pkg/proxy/request_test.go
+++ b/pkg/proxy/request_test.go
@@ -461,3 +461,72 @@ func TestGetDuration(t *testing.T) {
 		assert.Equal(t, scenario.expected, actual)
 	}
 }
+
+func TestGetMasterImage(t *testing.T) {
+	scenarios := []struct {
+		masterImage  string
+		expectedName string
+		expectedTag  string
+		expectNil    bool
+		expectError  bool
+	}{
+		{
+			masterImage: "",
+			expectNil:   true,
+			expectError: false,
+		},
+		{
+			masterImage:  "alpine",
+			expectedName: "docker.io/library/alpine",
+			expectedTag:  "latest",
+			expectError:  false,
+		},
+		{
+			masterImage:  "alpine:3.2.1",
+			expectedName: "docker.io/library/alpine",
+			expectedTag:  "3.2.1",
+			expectError:  false,
+		},
+		{
+			masterImage: "al pine",
+			expectNil:   true,
+			expectError: true,
+		},
+		{
+			masterImage: ":latest",
+			expectNil:   true,
+			expectError: true,
+		},
+		{
+			masterImage: " ",
+			expectNil:   true,
+			expectError: true,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		req, err := http.NewRequest("POST", "/load-test", new(bytes.Buffer))
+		if err != nil {
+			t.Error(err)
+			t.FailNow()
+		}
+
+		req.Form = url.Values{"masterImage": []string{scenario.masterImage}}
+		req.ParseForm()
+
+		actual, err := getMasterImageRef(req)
+
+		if scenario.expectError {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+
+		if scenario.expectNil {
+			assert.Nil(t, actual)
+		} else {
+			assert.Equal(t, scenario.expectedName, actual.Name())
+			assert.Equal(t, scenario.expectedTag, actual.Tag())
+		}
+	}
+}

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -28,7 +28,7 @@ type Runner struct {
 // RunServer runs Kangal proxy API
 func RunServer(ctx context.Context, cfg Config, rr Runner) error {
 
-	proxyHandler := NewProxy(cfg.MaxLoadTestsRun, rr.KubeClient, fromHTTPRequestToLoadTestSpec)
+	proxyHandler := NewProxy(cfg, rr.KubeClient, fromHTTPRequestToLoadTestSpec)
 	// Start instrumented server
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)


### PR DESCRIPTION
Currently loadtests have some empty or hardcoded spec (master/worker image details) when created by the proxy, and the controller later mutates this value. This behavior is not ideal; the spec should be immutable once the resource is created.

Furthermore, we have `MasterConfig` and `WorkerConfig` in the loadtest v1 spec, but they are not used; we should either remove this or expose it via the proxy.

This PR:
- Adds 4 environment variables (`JMETER_MASTER_IMAGE_NAME`, `JMETER_MASTER_IMAGE_TAG`, and the same for worker) to specify default images.
- Removes `SetDefault` function in controller which mutated loadtest spec.
- Updates the proxy to consume `backends.Config` environment variables and use this when creating a new loadtest.
- Adds `masterImage` and `workerImage` fields on `POST /load-test` endpoint in the proxy to allow users to utilize `MasterConfig` and `WorkerConfig` spec when creating a new loadtest.