### PR TITLE
Add configmaps GET permission

### DIFF
--- a/charts/kangal/Chart.yaml
+++ b/charts/kangal/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - performance tests
   - tests runner
 name: kangal
-version: 1.2.1
+version: 1.2.2
 home: https://github.com/hellofresh/kangal
 icon: https://raw.githubusercontent.com/hellofresh/kangal/master/kangal_logo.svg
 maintainers:

--- a/charts/kangal/templates/clusterrole.yaml
+++ b/charts/kangal/templates/clusterrole.yaml
@@ -77,6 +77,7 @@ rules:
     resources:
       - configmaps
     verbs:
+      - get
       - create
 
   - apiGroups:


### PR DESCRIPTION
EES-4318

With the addition of Locust implementation, now Kangal requires an extra permission, a GET for ConfigMaps.