### PR TITLE
Fix ingress annotation in Kangal chart

### DIFF
--- a/charts/kangal/Chart.yaml
+++ b/charts/kangal/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - performance tests
   - tests runner
 name: kangal
-version: 1.2.2
+version: 1.3.0
 home: https://github.com/hellofresh/kangal
 icon: https://raw.githubusercontent.com/hellofresh/kangal/master/kangal_logo.svg
 maintainers:

--- a/charts/kangal/templates/ingress.yaml
+++ b/charts/kangal/templates/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
     chart: {{ template "<CHARTNAME>.chart" $ }}
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
-{{- with $value.annotations }}
+{{- with $value.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}


### PR DESCRIPTION
We have an issue with Ingress annotations not being applied . So we found a problem in 
https://github.com/hellofresh/kangal/blob/master/charts/kangal/templates/ingress.yaml#L20

https://github.com/hellofresh/kangal/blob/master/charts/kangal/values.yaml#L27-L30

Should be:
`{{- with $value.ingress.annotations }}`

Instead of:
`{{- with $value.annotations }}`