### PR TITLE
Prevent controller from changing spec

### DIFF
--- a/charts/kangal/Chart.yaml
+++ b/charts/kangal/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - performance tests
   - tests runner
 name: kangal
-version: 1.3.0
+version: 1.4.0
 home: https://github.com/hellofresh/kangal
 icon: https://raw.githubusercontent.com/hellofresh/kangal/master/kangal_logo.svg
 maintainers:

--- a/charts/kangal/README.md
+++ b/charts/kangal/README.md
@@ -69,15 +69,21 @@ To install Kangal to your infrastructure you need 3 deployments: Kangal-Proxy, K
 
 The following table lists the common configurable parameters for `Kangal` chart:
 
-| Parameter                         | Description                                                                                         | Default                      |
-|-----------------------------------|-----------------------------------------------------------------------------------------------------|------------------------------|
-| `fullnameOverride`                | String to fully override kangal.fullname template with a string                                     | `nil`                        |
-| `nameOverride`                    | String to partially override kangal.fullname template with a string (will prepend the release name) | `nil`                        |
-| `configmap.AWS_ACCESS_KEY_ID`     | AWS access key ID. If not defined report will not be stored                                         | ``                           |
-| `configmap.AWS_SECRET_ACCESS_KEY` | AWS secret access key                                                                               | ``                           |
-| `configmap.AWS_BUCKET_NAME`       | The name of the bucket for saving reports                                                           | `my-bucket`                  |
-| `configmap.AWS_ENDPOINT_URL`      | Storage connection parameter                                                                        | `s3.us-east-1.amazonaws.com` |
-| `configmap.AWS_DEFAULT_REGION`    | Storage connection parameter                                                                        | `us-east-1`                  |
+| Parameter                           | Description                                                                                         | Default                               |
+|-------------------------------------|-----------------------------------------------------------------------------------------------------|---------------------------------------|
+| `fullnameOverride`                  | String to fully override kangal.fullname template with a string                                     | `nil`                                 |
+| `nameOverride`                      | String to partially override kangal.fullname template with a string (will prepend the release name) | `nil`                                 |
+| `configmap.AWS_ACCESS_KEY_ID`       | AWS access key ID. If not defined report will not be stored                                         | ``                                    |
+| `configmap.AWS_SECRET_ACCESS_KEY`   | AWS secret access key                                                                               | ``                                    |
+| `configmap.AWS_BUCKET_NAME`         | The name of the bucket for saving reports                                                           | `my-bucket`                           |
+| `configmap.AWS_ENDPOINT_URL`        | Storage connection parameter                                                                        | `s3.us-east-1.amazonaws.com`          |
+| `configmap.AWS_DEFAULT_REGION`      | Storage connection parameter                                                                        | `us-east-1`                           |
+| `configmap.JMETER_MASTER_IMAGE_NAME | Default JMeter master image name/repository if none is provided when creating a new loadtest        | "hellofreshtech/kangal-jmeter-master" |
+| `configmap.JMETER_MASTER_IMAGE_TAG  | Tag of the JMeter master image above                                                                | "latest"                              |
+| `configmap.JMETER_WORKER_IMAGE_NAME | Default JMeter worker image name/repository if none is provided when creating a new loadtest        | "hellofreshtech/kangal-jmeter-worker" |
+| `configmap.JMETER_WORKER_IMAGE_TAG  | Tag of the JMeter worker image above                                                                | "latest"                              |
+| `configmap.LOCUST_IMAGE             | Default Locust image name/repository if none is provided when creating a new loadtest               | "locustio/locust"                     |
+| `configmap.LOCUST_IMAGE_TAG         | Tag of the Locust image above                                                                       | "1.3.0"                               |
 
 Deployment specific configurations:
 
@@ -147,11 +153,21 @@ Deployment specific configurations:
 | `controller.service.ports.http`       | Service port                               | `80`                         |
 | `controller.env.KANGAL_PROXY_URL`     | Kangal Proxy URL used to persist reports   | `https://kangal-proxy.local` |
 
+### Kangal Controller (JMeter specific)
+| Parameter                                      | Description                 | Default           |
+|------------------------------------------------|-----------------------------|-------------------|
+| `controller.env.JMETER_MASTER_CPU_LIMITS`      | Master container CPU limits | ``                |
+| `controller.env.JMETER_MASTER_CPU_REQUESTS`    | Master CPU requests         | ``                |
+| `controller.env.JMETER_MASTER_MEMORY_LIMITS`   | Master memory limits        | ``                |
+| `controller.env.JMETER_MASTER_MEMORY_REQUESTS` | Master memory requests      | ``                |
+| `controller.env.JMETER_WORKER_CPU_LIMITS`      | Master container CPU limits | ``                |
+| `controller.env.JMETER_WORKER_CPU_REQUESTS`    | Master CPU requests         | ``                |
+| `controller.env.JMETER_WORKER_MEMORY_LIMITS`   | Master memory limits        | ``                |
+| `controller.env.JMETER_WORKER_MEMORY_REQUESTS` | Master memory requests      | ``                |
+
 ### Kangal Controller (Locust specific)
 | Parameter                                      | Description                 | Default           |
 |------------------------------------------------|-----------------------------|-------------------|
-| `controller.env.LOCUST_IMAGE`                  | Locust image                | `locustio/locust` |
-| `controller.env.LOCUST_IMAGE_TAG`              | Locust image tag            | `1.3.0`           |
 | `controller.env.LOCUST_MASTER_CPU_LIMITS`      | Master container CPU limits | ``                |
 | `controller.env.LOCUST_MASTER_CPU_REQUESTS`    | Master CPU requests         | ``                |
 | `controller.env.LOCUST_MASTER_MEMORY_LIMITS`   | Master memory limits        | ``                |

--- a/charts/kangal/values.yaml
+++ b/charts/kangal/values.yaml
@@ -125,8 +125,6 @@ controller:
   # Environmental variables to set
   env:
     KANGAL_PROXY_URL: "https://kangal-proxy.local"
-    LOCUST_IMAGE: "locustio/locust"
-    LOCUST_IMAGE_TAG: "1.3.0"
 
 openapi-ui:
   enabled: true
@@ -174,3 +172,9 @@ configMap:
   AWS_ENDPOINT_URL: "s3.us-east-1.amazonaws.com"
   AWS_BUCKET_NAME: "my-bucket"
   AWS_DEFAULT_REGION: "us-east-1"
+  JMETER_MASTER_IMAGE_NAME: "hellofreshtech/kangal-jmeter-master"
+  JMETER_MASTER_IMAGE_TAG: "latest"
+  JMETER_WORKER_IMAGE_NAME: "hellofreshtech/kangal-jmeter-worker"
+  JMETER_WORKER_IMAGE_TAG: "latest"
+  LOCUST_IMAGE: "locustio/locust"
+  LOCUST_IMAGE_TAG: "1.3.0"

--- a/pkg/backends/backend.go
+++ b/pkg/backends/backend.go
@@ -70,7 +70,7 @@ func BuildLoadTestSpecByBackend(
 	case loadTestV1.LoadTestTypeFake:
 		return fake.BuildLoadTestSpec(tags, overwrite)
 	case loadTestV1.LoadTestTypeLocust:
-		return locust.BuildLoadTestSpec(overwrite, distributedPods, tags, testFileStr, envVarsStr, targetURL, duration)
+		return locust.BuildLoadTestSpec(config.Locust, overwrite, distributedPods, tags, testFileStr, envVarsStr, targetURL, duration)
 	}
 	return loadTestV1.LoadTestSpec{}, fmt.Errorf("load test provider not found to build specs: %s", loadTestType)
 }

--- a/pkg/backends/backend.go
+++ b/pkg/backends/backend.go
@@ -57,6 +57,7 @@ func NewLoadTest(
 // BuildLoadTestSpecByBackend returns a valid LoadTestSpec based on backend rules
 func BuildLoadTestSpecByBackend(
 	loadTestType loadTestV1.LoadTestType,
+	config Config,
 	overwrite bool,
 	distributedPods int32,
 	tags loadTestV1.LoadTestTags,

--- a/pkg/backends/backend.go
+++ b/pkg/backends/backend.go
@@ -19,9 +19,6 @@ import (
 // LoadTestType defines the methods that a loadtest type needs to implement
 // for the controller to be able to run it
 type LoadTestType interface {
-	// SetDefaults mutates the LoadTest object to add default values to empty fields
-	SetDefaults() error
-
 	// CheckOrCreateResources check for resources or create the needed resources for the loadtest type
 	CheckOrCreateResources(ctx context.Context) error
 

--- a/pkg/backends/backend.go
+++ b/pkg/backends/backend.go
@@ -33,7 +33,16 @@ type Config struct {
 }
 
 // NewLoadTest returns a new LoadTestType
-func NewLoadTest(loadTest *loadTestV1.LoadTest, kubeClientSet kubernetes.Interface, kangalClientSet clientSetV.Interface, logger *zap.Logger, namespacesLister coreListersV1.NamespaceLister, reportURL string, podAnnotations, namespaceAnnotations map[string]string, backendsConfig Config) (LoadTestType, error) {
+func NewLoadTest(
+	loadTest *loadTestV1.LoadTest,
+	kubeClientSet kubernetes.Interface,
+	kangalClientSet clientSetV.Interface,
+	logger *zap.Logger,
+	namespacesLister coreListersV1.NamespaceLister,
+	reportURL string,
+	podAnnotations, namespaceAnnotations map[string]string,
+	backendsConfig Config,
+) (LoadTestType, error) {
 	switch loadTest.Spec.Type {
 	case loadTestV1.LoadTestTypeJMeter:
 		return jmeter.New(kubeClientSet, kangalClientSet, loadTest, logger, namespacesLister, reportURL, podAnnotations, namespaceAnnotations, backendsConfig.JMeter), nil
@@ -46,7 +55,14 @@ func NewLoadTest(loadTest *loadTestV1.LoadTest, kubeClientSet kubernetes.Interfa
 }
 
 // BuildLoadTestSpecByBackend returns a valid LoadTestSpec based on backend rules
-func BuildLoadTestSpecByBackend(loadTestType loadTestV1.LoadTestType, overwrite bool, distributedPods int32, tags loadTestV1.LoadTestTags, testFileStr, testDataStr, envVarsStr, targetURL string, duration time.Duration) (loadTestV1.LoadTestSpec, error) {
+func BuildLoadTestSpecByBackend(
+	loadTestType loadTestV1.LoadTestType,
+	overwrite bool,
+	distributedPods int32,
+	tags loadTestV1.LoadTestTags,
+	testFileStr, testDataStr, envVarsStr, targetURL string,
+	duration time.Duration,
+) (loadTestV1.LoadTestSpec, error) {
 	switch loadTestType {
 	case loadTestV1.LoadTestTypeJMeter:
 		return jmeter.BuildLoadTestSpec(overwrite, distributedPods, tags, testFileStr, testDataStr, envVarsStr)

--- a/pkg/backends/backend.go
+++ b/pkg/backends/backend.go
@@ -66,7 +66,7 @@ func BuildLoadTestSpecByBackend(
 ) (loadTestV1.LoadTestSpec, error) {
 	switch loadTestType {
 	case loadTestV1.LoadTestTypeJMeter:
-		return jmeter.BuildLoadTestSpec(overwrite, distributedPods, tags, testFileStr, testDataStr, envVarsStr)
+		return jmeter.BuildLoadTestSpec(config.JMeter, overwrite, distributedPods, tags, testFileStr, testDataStr, envVarsStr)
 	case loadTestV1.LoadTestTypeFake:
 		return fake.BuildLoadTestSpec(tags, overwrite)
 	case loadTestV1.LoadTestTypeLocust:

--- a/pkg/backends/fake/fake.go
+++ b/pkg/backends/fake/fake.go
@@ -33,23 +33,6 @@ func New(kubeClientSet kubernetes.Interface, lt *loadTestV1.LoadTest, logger *za
 	}
 }
 
-// SetDefaults set default values for creating a Fake LoadTest pods
-func (c *Fake) SetDefaults() error {
-	if c.loadTest.Status.Phase == "" {
-		c.loadTest.Status.Phase = loadTestV1.LoadTestCreating
-	}
-
-	if c.loadTest.Spec.MasterConfig.Image == "" {
-		c.loadTest.Spec.MasterConfig.Image = sleepImage
-	}
-
-	if c.loadTest.Spec.MasterConfig.Tag == "" {
-		c.loadTest.Spec.MasterConfig.Tag = imageTag
-	}
-
-	return nil
-}
-
 // CheckOrCreateResources check if Fake kubernetes resources have been create, if they have not been create them
 func (c *Fake) CheckOrCreateResources(ctx context.Context) error {
 	// Get the Namespace resource
@@ -83,6 +66,10 @@ func (c *Fake) CheckOrUpdateStatus(ctx context.Context) error {
 	}
 	if err != nil {
 		return err
+	}
+
+	if c.loadTest.Status.Phase == "" {
+		c.loadTest.Status.Phase = loadTestV1.LoadTestCreating
 	}
 
 	if c.loadTest.Status.Phase == loadTestV1.LoadTestErrored {

--- a/pkg/backends/fake/fake_test.go
+++ b/pkg/backends/fake/fake_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	batchV1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,17 +29,6 @@ func (e *StatusError) Error() string {
 
 func (e *StatusError) Status() metav1.Status {
 	return metav1.Status{Reason: metav1.StatusReasonNotFound}
-}
-
-func TestSetLoadTestDefaults(t *testing.T) {
-	lt := createFake()
-
-	err := lt.SetDefaults()
-	require.NoError(t, err)
-	assert.Equal(t, loadtestV1.LoadTestCreating, lt.loadTest.Status.Phase)
-	assert.Equal(t, sleepImage, lt.loadTest.Spec.MasterConfig.Image)
-	assert.Equal(t, imageTag, lt.loadTest.Spec.MasterConfig.Tag)
-	assert.Equal(t, imageTag, lt.loadTest.Spec.MasterConfig.Tag)
 }
 
 func TestCheckOrCreateResources(t *testing.T) {

--- a/pkg/backends/fake/spec.go
+++ b/pkg/backends/fake/spec.go
@@ -9,5 +9,17 @@ import (
 //BuildLoadTestSpec returns LoadTestSpec for Fake backend provider
 func BuildLoadTestSpec(tags loadTestV1.LoadTestTags, overwrite bool) (loadTestV1.LoadTestSpec, error) {
 	// in general Fake backend provider doesn't need any fields except overwrite flag
-	return loadTestV1.NewSpec(loadTestV1.LoadTestTypeFake, overwrite, 1, tags, "", "", "", loadTestV1.ImageDetails{Image: sleepImage, Tag: imageTag}, loadTestV1.ImageDetails{}, "", time.Duration(0)), nil
+	return loadTestV1.NewSpec(
+		loadTestV1.LoadTestTypeFake,
+		overwrite,
+		1,
+		tags,
+		"",
+		"",
+		"",
+		loadTestV1.ImageDetails{Image: sleepImage, Tag: imageTag},
+		loadTestV1.ImageDetails{},
+		"",
+		time.Duration(0),
+	), nil
 }

--- a/pkg/backends/jmeter/config.go
+++ b/pkg/backends/jmeter/config.go
@@ -2,10 +2,14 @@ package jmeter
 
 // Config specific to JMeter backend
 type Config struct {
+	MasterImageName      string `envconfig:"JMETER_MASTER_IMAGE_NAME"`
+	MasterImageTag       string `envconfig:"JMETER_MASTER_IMAGE_TAG"`
 	MasterCPULimits      string `envconfig:"JMETER_MASTER_CPU_LIMITS"`
 	MasterCPURequests    string `envconfig:"JMETER_MASTER_CPU_REQUESTS"`
 	MasterMemoryLimits   string `envconfig:"JMETER_MASTER_MEMORY_LIMITS"`
 	MasterMemoryRequests string `envconfig:"JMETER_MASTER_MEMORY_REQUESTS"`
+	WorkerImageName      string `envconfig:"JMETER_WORKER_IMAGE_NAME"`
+	WorkerImageTag       string `envconfig:"JMETER_WORKER_IMAGE_TAG"`
 	WorkerCPULimits      string `envconfig:"JMETER_WORKER_CPU_LIMITS"`
 	WorkerCPURequests    string `envconfig:"JMETER_WORKER_CPU_REQUESTS"`
 	WorkerMemoryLimits   string `envconfig:"JMETER_WORKER_MEMORY_LIMITS"`

--- a/pkg/backends/jmeter/jmeter.go
+++ b/pkg/backends/jmeter/jmeter.go
@@ -23,9 +23,10 @@ var (
 	MaxWaitTimeForPods = time.Minute * 10
 	//loadTestWorkerLabelSelector is the selector used for selecting jmeter worker resources
 	loadTestWorkerLabelSelector = fmt.Sprintf("%s=%s", loadTestWorkerPodLabelKey, loadTestWorkerPodLabelValue)
-	masterImage                 = "hellofreshtech/kangal-jmeter-master"
-	workerImage                 = "hellofreshtech/kangal-jmeter-worker"
-	imageTag                    = "latest"
+	defaultMasterImageName      = "hellofreshtech/kangal-jmeter-master"
+	defaultWorkerImageName      = "hellofreshtech/kangal-jmeter-worker"
+	defaultMasterImageTag       = "latest"
+	defaultWorkerImageTag       = "latest"
 )
 
 // JMeter enables the controller to run a loadtest using JMeter
@@ -38,6 +39,8 @@ type JMeter struct {
 	reportURL        string
 	masterResources  helper.Resources
 	workerResources  helper.Resources
+	masterConfig     loadTestV1.ImageDetails
+	workerConfig     loadTestV1.ImageDetails
 
 	podAnnotations, namespaceAnnotations map[string]string
 }
@@ -53,6 +56,26 @@ func New(
 	podAnnotations, namespaceAnnotations map[string]string,
 	config Config,
 ) *JMeter {
+	masterImageName := defaultMasterImageName
+	if config.MasterImageName != "" {
+		masterImageName = config.MasterImageName
+	}
+
+	masterImageTag := defaultMasterImageTag
+	if config.MasterImageTag != "" {
+		masterImageTag = config.MasterImageTag
+	}
+
+	workerImageName := defaultWorkerImageName
+	if config.WorkerImageName != "" {
+		workerImageName = config.WorkerImageName
+	}
+
+	workerImageTag := defaultWorkerImageTag
+	if config.WorkerImageTag != "" {
+		workerImageName = config.WorkerImageTag
+	}
+
 	return &JMeter{
 		kubeClientSet:        kubeClientSet,
 		kangalClientSet:      kangalClientSet,
@@ -73,6 +96,14 @@ func New(
 			CPURequests:    config.WorkerCPURequests,
 			MemoryLimits:   config.WorkerMemoryLimits,
 			MemoryRequests: config.WorkerMemoryRequests,
+		},
+		masterConfig: loadTestV1.ImageDetails{
+			Image: masterImageName,
+			Tag:   masterImageTag,
+		},
+		workerConfig: loadTestV1.ImageDetails{
+			Image: workerImageName,
+			Tag:   workerImageTag,
 		},
 	}
 }

--- a/pkg/backends/jmeter/jmeter.go
+++ b/pkg/backends/jmeter/jmeter.go
@@ -43,7 +43,16 @@ type JMeter struct {
 }
 
 //New initializes new JMeter provider handler to manage load test resources with Kangal Controller
-func New(kubeClientSet kubernetes.Interface, kangalClientSet clientSetV.Interface, lt *loadTestV1.LoadTest, logger *zap.Logger, namespacesLister coreListersV1.NamespaceLister, reportURL string, podAnnotations, namespaceAnnotations map[string]string, config Config) *JMeter {
+func New(
+	kubeClientSet kubernetes.Interface,
+	kangalClientSet clientSetV.Interface,
+	lt *loadTestV1.LoadTest,
+	logger *zap.Logger,
+	namespacesLister coreListersV1.NamespaceLister,
+	reportURL string,
+	podAnnotations, namespaceAnnotations map[string]string,
+	config Config,
+) *JMeter {
 	return &JMeter{
 		kubeClientSet:        kubeClientSet,
 		kangalClientSet:      kangalClientSet,
@@ -117,7 +126,11 @@ func (c *JMeter) CheckOrCreateResources(ctx context.Context) error {
 			c.logger.Error("Error on creating new JMeter service", zap.Error(err))
 			return err
 		}
-		c.logger.Info("Created JMeter resources", zap.String("LoadTest", c.loadTest.GetName()), zap.String("namespace", c.loadTest.Status.Namespace))
+		c.logger.Info(
+			"Created JMeter resources",
+			zap.String("LoadTest", c.loadTest.GetName()),
+			zap.String("namespace", c.loadTest.Status.Namespace),
+		)
 
 	}
 	return nil
@@ -173,7 +186,12 @@ func (c *JMeter) CheckOrUpdateStatus(ctx context.Context) error {
 				if containerStatus.State.Waiting.Reason != "Pending" &&
 					containerStatus.State.Waiting.Reason != "ContainerCreating" &&
 					containerStatus.State.Waiting.Reason != "PodInitializing" {
-					c.logger.Info("One of containers is unhealthy, marking LoadTest as errored", zap.String("LoadTest", c.loadTest.GetName()), zap.String("pod", pod.Name), zap.String("namespace", namespace.GetName()))
+					c.logger.Info(
+						"One of containers is unhealthy, marking LoadTest as errored",
+						zap.String("LoadTest", c.loadTest.GetName()),
+						zap.String("pod", pod.Name),
+						zap.String("namespace", namespace.GetName()),
+					)
 					c.loadTest.Status.Phase = loadTestV1.LoadTestErrored
 					return nil
 				}

--- a/pkg/backends/jmeter/jmeter.go
+++ b/pkg/backends/jmeter/jmeter.go
@@ -68,31 +68,6 @@ func New(kubeClientSet kubernetes.Interface, kangalClientSet clientSetV.Interfac
 	}
 }
 
-// SetDefaults set default values for creating a JMeter loadtest
-func (c *JMeter) SetDefaults() error {
-	if c.loadTest.Status.Phase == "" {
-		c.loadTest.Status.Phase = loadTestV1.LoadTestCreating
-	}
-
-	if c.loadTest.Spec.MasterConfig.Image == "" {
-		c.loadTest.Spec.MasterConfig.Image = masterImage
-	}
-
-	if c.loadTest.Spec.MasterConfig.Tag == "" {
-		c.loadTest.Spec.MasterConfig.Tag = imageTag
-	}
-
-	if c.loadTest.Spec.WorkerConfig.Image == "" {
-		c.loadTest.Spec.WorkerConfig.Image = workerImage
-	}
-
-	if c.loadTest.Spec.WorkerConfig.Tag == "" {
-		c.loadTest.Spec.WorkerConfig.Tag = imageTag
-	}
-
-	return nil
-}
-
 // CheckOrCreateResources check if JMeter kubernetes resources have been create,
 // if they have not been create them
 func (c *JMeter) CheckOrCreateResources(ctx context.Context) error {
@@ -160,6 +135,10 @@ func (c *JMeter) CheckOrUpdateStatus(ctx context.Context) error {
 			c.loadTest.Status.Phase = loadTestV1.LoadTestFinished
 			return nil
 		}
+	}
+
+	if c.loadTest.Status.Phase == "" {
+		c.loadTest.Status.Phase = loadTestV1.LoadTestCreating
 	}
 
 	if c.loadTest.Status.Phase == loadTestV1.LoadTestErrored {

--- a/pkg/backends/jmeter/jmeter_test.go
+++ b/pkg/backends/jmeter/jmeter_test.go
@@ -67,16 +67,6 @@ func TestCheckForTimeout(t *testing.T) {
 	}
 }
 
-func TestSetLoadTestDefaults(t *testing.T) {
-	jm := &JMeter{
-		loadTest: &loadtestV1.LoadTest{},
-	}
-
-	err := jm.SetDefaults()
-	require.NoError(t, err)
-	assert.Equal(t, loadtestV1.LoadTestCreating, jm.loadTest.Status.Phase)
-}
-
 func TestGetLoadTestPhaseFromJob(t *testing.T) {
 	var testPhases = []struct {
 		ExpectedPhase loadtestV1.LoadTestPhase

--- a/pkg/backends/jmeter/jmeter_test.go
+++ b/pkg/backends/jmeter/jmeter_test.go
@@ -138,6 +138,14 @@ func TestJMeter_CheckOrCreateResources(t *testing.T) {
 			},
 			Spec: loadtestV1.LoadTestSpec{
 				DistributedPods: &distributedPodsNum,
+				MasterConfig: loadtestV1.ImageDetails{
+					Image: defaultMasterImageName,
+					Tag:   defaultMasterImageTag,
+				},
+				WorkerConfig: loadtestV1.ImageDetails{
+					Image: defaultWorkerImageName,
+					Tag:   defaultWorkerImageTag,
+				},
 			},
 			Status: loadtestV1.LoadTestStatus{
 				Phase:     "",

--- a/pkg/backends/jmeter/resources_test.go
+++ b/pkg/backends/jmeter/resources_test.go
@@ -96,8 +96,14 @@ func TestPodResourceConfiguration(t *testing.T) {
 	c := &JMeter{
 		loadTest: &loadtestv1.LoadTest{
 			Spec: loadtestv1.LoadTestSpec{
-				MasterConfig: loadtestv1.ImageDetails{},
-				WorkerConfig: loadtestv1.ImageDetails{},
+				MasterConfig: loadtestv1.ImageDetails{
+					Image: defaultMasterImageName,
+					Tag:   defaultMasterImageTag,
+				},
+				WorkerConfig: loadtestv1.ImageDetails{
+					Image: defaultWorkerImageName,
+					Tag:   defaultWorkerImageTag,
+				},
 			},
 		},
 		masterResources: helper.Resources{

--- a/pkg/backends/jmeter/spec.go
+++ b/pkg/backends/jmeter/spec.go
@@ -16,6 +16,7 @@ var (
 
 //BuildLoadTestSpec validates input and returns valid LoadTestSpec for JMeter backend provider
 func BuildLoadTestSpec(
+	config Config,
 	overwrite bool,
 	distributedPods int32,
 	tags loadTestV1.LoadTestTags,
@@ -29,6 +30,25 @@ func BuildLoadTestSpec(
 	if testFileStr == "" {
 		return lt, ErrRequireTestFile
 	}
+	masterImageName := defaultMasterImageName
+	masterImageTag := defaultMasterImageTag
+	workerImageName := defaultWorkerImageName
+	workerImageTag := defaultWorkerImageTag
+
+	// Use environment variable config if available
+	if config.MasterImageName != "" {
+		masterImageName = config.MasterImageName
+	}
+	if config.MasterImageTag != "" {
+		masterImageTag = config.MasterImageTag
+	}
+	if config.WorkerImageName != "" {
+		workerImageName = config.WorkerImageName
+	}
+	if config.WorkerImageTag != "" {
+		workerImageTag = config.WorkerImageTag
+	}
+
 	return loadTestV1.NewSpec(
 		loadTestV1.LoadTestTypeJMeter,
 		overwrite,
@@ -37,8 +57,8 @@ func BuildLoadTestSpec(
 		testFileStr,
 		testDataStr,
 		envVarsStr,
-		loadTestV1.ImageDetails{Image: masterImage, Tag: imageTag},
-		loadTestV1.ImageDetails{Image: workerImage, Tag: imageTag},
+		loadTestV1.ImageDetails{Image: masterImageName, Tag: masterImageTag},
+		loadTestV1.ImageDetails{Image: workerImageName, Tag: workerImageTag},
 		"",
 		time.Duration(0),
 	), nil

--- a/pkg/backends/jmeter/spec.go
+++ b/pkg/backends/jmeter/spec.go
@@ -15,7 +15,12 @@ var (
 )
 
 //BuildLoadTestSpec validates input and returns valid LoadTestSpec for JMeter backend provider
-func BuildLoadTestSpec(overwrite bool, distributedPods int32, tags loadTestV1.LoadTestTags, testFileStr, testDataStr, envVarsStr string) (loadTestV1.LoadTestSpec, error) {
+func BuildLoadTestSpec(
+	overwrite bool,
+	distributedPods int32,
+	tags loadTestV1.LoadTestTags,
+	testFileStr, testDataStr, envVarsStr string,
+) (loadTestV1.LoadTestSpec, error) {
 	lt := loadTestV1.LoadTestSpec{}
 	// JMeter backend provider needs full spec: from number of distributed pods to envVars
 	if distributedPods <= int32(0) {
@@ -24,5 +29,17 @@ func BuildLoadTestSpec(overwrite bool, distributedPods int32, tags loadTestV1.Lo
 	if testFileStr == "" {
 		return lt, ErrRequireTestFile
 	}
-	return loadTestV1.NewSpec(loadTestV1.LoadTestTypeJMeter, overwrite, distributedPods, tags, testFileStr, testDataStr, envVarsStr, loadTestV1.ImageDetails{Image: masterImage, Tag: imageTag}, loadTestV1.ImageDetails{Image: workerImage, Tag: imageTag}, "", time.Duration(0)), nil
+	return loadTestV1.NewSpec(
+		loadTestV1.LoadTestTypeJMeter,
+		overwrite,
+		distributedPods,
+		tags,
+		testFileStr,
+		testDataStr,
+		envVarsStr,
+		loadTestV1.ImageDetails{Image: masterImage, Tag: imageTag},
+		loadTestV1.ImageDetails{Image: workerImage, Tag: imageTag},
+		"",
+		time.Duration(0),
+	), nil
 }

--- a/pkg/backends/jmeter/spec_test.go
+++ b/pkg/backends/jmeter/spec_test.go
@@ -12,6 +12,7 @@ func TestBuildJMeterLoadTestSpec(t *testing.T) {
 	var distributedPods int32 = 3
 
 	type args struct {
+		config          Config
 		overwrite       bool
 		distributedPods int32
 		tags            v1.LoadTestTags
@@ -28,6 +29,7 @@ func TestBuildJMeterLoadTestSpec(t *testing.T) {
 		{
 			name: "Spec is valid",
 			args: args{
+				config:          Config{},
 				overwrite:       true,
 				distributedPods: 3,
 				tags:            v1.LoadTestTags{"team": "kangal"},
@@ -37,8 +39,8 @@ func TestBuildJMeterLoadTestSpec(t *testing.T) {
 			want: v1.LoadTestSpec{
 				Type:            "JMeter",
 				Overwrite:       true,
-				MasterConfig:    v1.ImageDetails{Image: masterImage, Tag: imageTag},
-				WorkerConfig:    v1.ImageDetails{Image: workerImage, Tag: imageTag},
+				MasterConfig:    v1.ImageDetails{Image: defaultMasterImageName, Tag: defaultMasterImageTag},
+				WorkerConfig:    v1.ImageDetails{Image: defaultWorkerImageName, Tag: defaultWorkerImageTag},
 				DistributedPods: &distributedPods,
 				Tags:            v1.LoadTestTags{"team": "kangal"},
 				TestFile:        "something in the file",
@@ -68,7 +70,7 @@ func TestBuildJMeterLoadTestSpec(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := BuildLoadTestSpec(tt.args.overwrite, tt.args.distributedPods, tt.args.tags, tt.args.testFileStr, tt.args.testDataStr, tt.args.envVarsStr)
+			got, err := BuildLoadTestSpec(tt.args.config, tt.args.overwrite, tt.args.distributedPods, tt.args.tags, tt.args.testFileStr, tt.args.testDataStr, tt.args.envVarsStr)
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/pkg/backends/locust/locust.go
+++ b/pkg/backends/locust/locust.go
@@ -86,7 +86,7 @@ func (c *Locust) CheckOrCreateResources(ctx context.Context) error {
 		}
 	}
 
-	masterJob := newMasterJob(c.loadTest, configMap, secret, c.reportURL, c.masterResources, c.podAnnotations)
+	masterJob := newMasterJob(c.loadTest, configMap, secret, c.reportURL, c.masterResources, c.podAnnotations, c.image, c.imageTag, c.logger)
 	_, err = c.kubeClientSet.
 		BatchV1().
 		Jobs(c.loadTest.Status.Namespace).
@@ -103,7 +103,7 @@ func (c *Locust) CheckOrCreateResources(ctx context.Context) error {
 		return err
 	}
 
-	workerJob := newWorkerJob(c.loadTest, configMap, secret, masterService, c.workerResources, c.podAnnotations)
+	workerJob := newWorkerJob(c.loadTest, configMap, secret, masterService, c.workerResources, c.podAnnotations, c.image, c.imageTag, c.logger)
 	_, err = c.kubeClientSet.
 		BatchV1().
 		Jobs(c.loadTest.Status.Namespace).

--- a/pkg/backends/locust/locust.go
+++ b/pkg/backends/locust/locust.go
@@ -34,29 +34,6 @@ type Locust struct {
 	podAnnotations  map[string]string
 }
 
-// SetDefaults mutates the LoadTest object to add default values to empty fields
-func (c *Locust) SetDefaults() error {
-	if c.loadTest.Status.Phase == "" {
-		c.loadTest.Status.Phase = loadTestV1.LoadTestCreating
-	}
-
-	if c.loadTest.Spec.MasterConfig.Image == "" {
-		c.loadTest.Spec.MasterConfig.Image = c.image
-	}
-	if c.loadTest.Spec.MasterConfig.Tag == "" {
-		c.loadTest.Spec.MasterConfig.Tag = c.imageTag
-	}
-
-	if c.loadTest.Spec.WorkerConfig.Image == "" {
-		c.loadTest.Spec.WorkerConfig.Image = c.image
-	}
-	if c.loadTest.Spec.WorkerConfig.Tag == "" {
-		c.loadTest.Spec.WorkerConfig.Tag = c.imageTag
-	}
-
-	return nil
-}
-
 // CheckOrCreateResources check for resources or create the needed resources for the loadtest type
 func (c *Locust) CheckOrCreateResources(ctx context.Context) error {
 	workerJobs, err := c.kubeClientSet.
@@ -141,6 +118,10 @@ func (c *Locust) CheckOrCreateResources(ctx context.Context) error {
 
 // CheckOrUpdateStatus check current LoadTest progress
 func (c *Locust) CheckOrUpdateStatus(ctx context.Context) error {
+	if c.loadTest.Status.Phase == "" {
+		c.loadTest.Status.Phase = loadTestV1.LoadTestCreating
+	}
+
 	if c.loadTest.Status.Phase == loadTestV1.LoadTestErrored ||
 		c.loadTest.Status.Phase == loadTestV1.LoadTestFinished {
 		return nil

--- a/pkg/backends/locust/resources.go
+++ b/pkg/backends/locust/resources.go
@@ -63,7 +63,14 @@ func newMasterJobName(loadTest *loadtestV1.LoadTest) string {
 	return fmt.Sprintf("%s-master", loadTest.ObjectMeta.Name)
 }
 
-func newMasterJob(loadTest *loadtestV1.LoadTest, testfileConfigMap *coreV1.ConfigMap, envvarSecret *coreV1.Secret, reportURL string, masterResources helper.Resources, podAnnotations map[string]string) *batchV1.Job {
+func newMasterJob(
+	loadTest *loadtestV1.LoadTest,
+	testfileConfigMap *coreV1.ConfigMap,
+	envvarSecret *coreV1.Secret,
+	reportURL string,
+	masterResources helper.Resources,
+	podAnnotations map[string]string,
+) *batchV1.Job {
 	name := newMasterJobName(loadTest)
 
 	ownerRef := metaV1.NewControllerRef(loadTest, loadtestV1.SchemeGroupVersion.WithKind("LoadTest"))
@@ -192,7 +199,14 @@ func newWorkerJobName(loadTest *loadtestV1.LoadTest) string {
 	return fmt.Sprintf("%s-worker", loadTest.ObjectMeta.Name)
 }
 
-func newWorkerJob(loadTest *loadtestV1.LoadTest, testfileConfigMap *coreV1.ConfigMap, envvarSecret *coreV1.Secret, masterService *coreV1.Service, workerResources helper.Resources, podAnnotations map[string]string) *batchV1.Job {
+func newWorkerJob(
+	loadTest *loadtestV1.LoadTest,
+	testfileConfigMap *coreV1.ConfigMap,
+	envvarSecret *coreV1.Secret,
+	masterService *coreV1.Service,
+	workerResources helper.Resources,
+	podAnnotations map[string]string,
+) *batchV1.Job {
 	name := newWorkerJobName(loadTest)
 
 	ownerRef := metaV1.NewControllerRef(loadTest, loadtestV1.SchemeGroupVersion.WithKind("LoadTest"))

--- a/pkg/backends/locust/spec.go
+++ b/pkg/backends/locust/spec.go
@@ -15,7 +15,13 @@ var (
 )
 
 //BuildLoadTestSpec validates input and returns valid LoadTestSpec
-func BuildLoadTestSpec(overwrite bool, distributedPods int32, tags loadTestV1.LoadTestTags, testFileStr, envVarsStr, targetURL string, duration time.Duration) (loadTestV1.LoadTestSpec, error) {
+func BuildLoadTestSpec(
+	overwrite bool,
+	distributedPods int32,
+	tags loadTestV1.LoadTestTags,
+	testFileStr, envVarsStr, targetURL string,
+	duration time.Duration,
+) (loadTestV1.LoadTestSpec, error) {
 	lt := loadTestV1.LoadTestSpec{}
 	if distributedPods <= int32(0) {
 		return lt, ErrRequireMinOneDistributedPod
@@ -23,5 +29,17 @@ func BuildLoadTestSpec(overwrite bool, distributedPods int32, tags loadTestV1.Lo
 	if testFileStr == "" {
 		return lt, ErrRequireTestFile
 	}
-	return loadTestV1.NewSpec(loadTestV1.LoadTestTypeLocust, overwrite, distributedPods, tags, testFileStr, "", envVarsStr, loadTestV1.ImageDetails{}, loadTestV1.ImageDetails{}, targetURL, duration), nil
+	return loadTestV1.NewSpec(
+		loadTestV1.LoadTestTypeLocust,
+		overwrite,
+		distributedPods,
+		tags,
+		testFileStr,
+		"",
+		envVarsStr,
+		loadTestV1.ImageDetails{},
+		loadTestV1.ImageDetails{},
+		targetURL,
+		duration,
+	), nil
 }

--- a/pkg/backends/locust/spec.go
+++ b/pkg/backends/locust/spec.go
@@ -16,6 +16,7 @@ var (
 
 //BuildLoadTestSpec validates input and returns valid LoadTestSpec
 func BuildLoadTestSpec(
+	config Config,
 	overwrite bool,
 	distributedPods int32,
 	tags loadTestV1.LoadTestTags,
@@ -29,6 +30,17 @@ func BuildLoadTestSpec(
 	if testFileStr == "" {
 		return lt, ErrRequireTestFile
 	}
+
+	imageName := defaultImage
+	imageTag := defaultImageTag
+
+	// Use environment variable config if available
+	if config.Image != "" {
+		imageName = config.Image
+	}
+	if config.ImageTag != "" {
+		imageTag = config.ImageTag
+	}
 	return loadTestV1.NewSpec(
 		loadTestV1.LoadTestTypeLocust,
 		overwrite,
@@ -37,8 +49,8 @@ func BuildLoadTestSpec(
 		testFileStr,
 		"",
 		envVarsStr,
-		loadTestV1.ImageDetails{},
-		loadTestV1.ImageDetails{},
+		loadTestV1.ImageDetails{Image: imageName, Tag: imageTag},
+		loadTestV1.ImageDetails{Image: imageName, Tag: imageTag},
 		targetURL,
 		duration,
 	), nil

--- a/pkg/backends/locust/spec_test.go
+++ b/pkg/backends/locust/spec_test.go
@@ -13,6 +13,7 @@ func TestBuildLoadTestSpec(t *testing.T) {
 	var distributedPods int32 = 3
 
 	type args struct {
+		config          Config
 		overwrite       bool
 		distributedPods int32
 		tags            v1.LoadTestTags
@@ -30,6 +31,7 @@ func TestBuildLoadTestSpec(t *testing.T) {
 		{
 			name: "Spec is valid",
 			args: args{
+				config:          Config{},
 				overwrite:       true,
 				distributedPods: 3,
 				tags:            v1.LoadTestTags{"team": "kangal"},
@@ -40,13 +42,12 @@ func TestBuildLoadTestSpec(t *testing.T) {
 			want: v1.LoadTestSpec{
 				Type:            "Locust",
 				Overwrite:       true,
-				MasterConfig:    v1.ImageDetails{},
-				WorkerConfig:    v1.ImageDetails{},
 				DistributedPods: &distributedPods,
 				Tags:            v1.LoadTestTags{"team": "kangal"},
 				TestFile:        "something in the file",
 				EnvVars:         "my-key,my-value",
 				TargetURL:       "http://my-app.my-domain.com",
+				MasterConfig:    v1.ImageDetails{Image: defaultImage, Tag: defaultImageTag},
 			},
 			wantErr: false,
 		},
@@ -71,7 +72,7 @@ func TestBuildLoadTestSpec(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := BuildLoadTestSpec(tt.args.overwrite, tt.args.distributedPods, tt.args.tags, tt.args.testFileStr, tt.args.envVarsStr, tt.args.targetURL, tt.args.duration)
+			got, err := BuildLoadTestSpec(tt.args.config, tt.args.overwrite, tt.args.distributedPods, tt.args.tags, tt.args.testFileStr, tt.args.envVarsStr, tt.args.targetURL, tt.args.duration)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -82,7 +83,7 @@ func TestBuildLoadTestSpec(t *testing.T) {
 			assert.Equal(t, tt.want.Type, got.Type)
 			assert.Equal(t, tt.want.Overwrite, got.Overwrite)
 			assert.Equal(t, tt.want.MasterConfig, got.MasterConfig)
-			assert.Equal(t, tt.want.WorkerConfig, got.WorkerConfig)
+			assert.Equal(t, tt.want.MasterConfig, got.WorkerConfig)
 			assert.Equal(t, &tt.want.DistributedPods, &got.DistributedPods)
 			assert.Equal(t, tt.want.Tags, got.Tags)
 			assert.Equal(t, tt.want.TestFile, got.TestFile)

--- a/pkg/controller/loadtest.go
+++ b/pkg/controller/loadtest.go
@@ -317,12 +317,6 @@ func (c *Controller) syncHandler(key string) error {
 		return err
 	}
 
-	// mutates the LoadTest object to add default values to empty fields
-	err = backend.SetDefaults()
-	if err != nil {
-		return err
-	}
-
 	// check or create loadtest resources
 	err = backend.CheckOrCreateResources(ctx)
 	if err != nil {

--- a/pkg/controller/test_helper.go
+++ b/pkg/controller/test_helper.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/hellofresh/kangal/pkg/backends"
+
 	coreV1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
@@ -40,13 +42,25 @@ func CreateLoadtest(clientSet clientSetV.Clientset, pods int32, name, testFile, 
 		}
 	}
 
+	loadtestSpec, err := backends.BuildLoadTestSpecByBackend(
+		loadTestType,
+		backends.Config{},
+		false,
+		pods,
+		apisLoadTestV1.LoadTestTags{},
+		tf,
+		td,
+		ev,
+		"",
+		0,
+	)
+	if err != nil {
+		return err
+	}
+
 	ltObj := &apisLoadTestV1.LoadTest{}
 	ltObj.Name = name
-	ltObj.Spec.DistributedPods = &pods
-	ltObj.Spec.Type = loadTestType
-	ltObj.Spec.TestFile = tf
-	ltObj.Spec.EnvVars = ev
-	ltObj.Spec.TestData = td
+	ltObj.Spec = loadtestSpec
 
 	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
 	defer cancel()

--- a/pkg/proxy/config.go
+++ b/pkg/proxy/config.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"github.com/hellofresh/kangal/pkg/backends"
 	"github.com/hellofresh/kangal/pkg/core/observability"
 	"github.com/hellofresh/kangal/pkg/report"
 )
@@ -14,6 +15,7 @@ type Config struct {
 	Report          report.Config
 	MaxLoadTestsRun int
 	MasterURL       string
+	Backends        backends.Config
 }
 
 // OpenAPIConfig is the OpenAPI specification-specific parameters

--- a/pkg/proxy/proxy_integration_test.go
+++ b/pkg/proxy/proxy_integration_test.go
@@ -411,10 +411,9 @@ func TestIntegrationGetLoadtest(t *testing.T) {
 		require.NoError(t, err, "Could not get load test information")
 
 		assert.Equal(t, currentNamespace, dat.Namespace)
-		assert.Equal(t, distributedPods, dat.DistributedPods)
 		assert.NotEmpty(t, dat.Phase)
 		assert.NotEqual(t, apisLoadTestV1.LoadTestErrored, dat.Phase)
-		assert.Equal(t, true, dat.HasTestData)
+		assert.Equal(t, false, dat.HasTestData)
 	})
 }
 

--- a/pkg/proxy/request.go
+++ b/pkg/proxy/request.go
@@ -84,7 +84,7 @@ func fromHTTPRequestToListOptions(r *http.Request) (*kubernetes.ListOptions, err
 }
 
 // fromHTTPRequestToLoadTestSpec creates a load test spec from HTTP request
-func fromHTTPRequestToLoadTestSpec(r *http.Request, logger *zap.Logger) (apisLoadTestV1.LoadTestSpec, error) {
+func fromHTTPRequestToLoadTestSpec(r *http.Request, cfg backends.Config, logger *zap.Logger) (apisLoadTestV1.LoadTestSpec, error) {
 	ltType := getLoadTestType(r)
 
 	if e := httpValidator(r); len(e) > 0 {
@@ -140,7 +140,7 @@ func fromHTTPRequestToLoadTestSpec(r *http.Request, logger *zap.Logger) (apisLoa
 		return apisLoadTestV1.LoadTestSpec{}, fmt.Errorf("error getting %q from request: %w", duration, err)
 	}
 
-	return backends.BuildLoadTestSpecByBackend(ltType, o, dp, tagList, tf, td, ev, turl, dur)
+	return backends.BuildLoadTestSpecByBackend(ltType, cfg, o, dp, tagList, tf, td, ev, turl, dur)
 }
 
 func getEnvVars(r *http.Request) (string, error) {

--- a/pkg/proxy/request_test.go
+++ b/pkg/proxy/request_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hellofresh/kangal/pkg/backends"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -22,7 +24,7 @@ func TestNewFakeFromHTTPLoadTest(t *testing.T) {
 		t.FailNow()
 	}
 
-	loadTest, err := fromHTTPRequestToLoadTestSpec(r, zap.NewNop())
+	loadTest, err := fromHTTPRequestToLoadTestSpec(r, backends.Config{}, zap.NewNop())
 	require.Error(t, err)
 	assert.Equal(t, apisLoadTestV1.LoadTestSpec{}, loadTest)
 }
@@ -381,7 +383,7 @@ func TestInit(t *testing.T) {
 				t.FailNow()
 			}
 
-			_, err = fromHTTPRequestToLoadTestSpec(request, zap.NewNop())
+			_, err = fromHTTPRequestToLoadTestSpec(request, backends.Config{}, zap.NewNop())
 
 			if ti.expectError {
 				assert.Error(t, err)
@@ -408,7 +410,7 @@ func TestCheckLoadTestSpec(t *testing.T) {
 		t.FailNow()
 	}
 
-	spec, err := fromHTTPRequestToLoadTestSpec(request, zap.NewNop())
+	spec, err := fromHTTPRequestToLoadTestSpec(request, backends.Config{}, zap.NewNop())
 	require.NoError(t, err)
 
 	lt, err := apisLoadTestV1.BuildLoadTestObject(spec)

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -28,7 +28,7 @@ type Runner struct {
 // RunServer runs Kangal proxy API
 func RunServer(ctx context.Context, cfg Config, rr Runner) error {
 
-	proxyHandler := NewProxy(cfg.MaxLoadTestsRun, rr.KubeClient, fromHTTPRequestToLoadTestSpec)
+	proxyHandler := NewProxy(cfg, rr.KubeClient, fromHTTPRequestToLoadTestSpec)
 	// Start instrumented server
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)


### PR DESCRIPTION
This PR is split from https://github.com/hellofresh/kangal/pull/44.

Currently loadtests have some empty or hardcoded spec (master/worker image details) when created by the proxy, and the controller later mutates this value. This behavior is not ideal; the spec should be immutable once the resource is created.

This PR:
- Removes `SetDefault` in the controller which mutates loadtest spec.
- Updates the proxy to consume `backends.Config` environment variables and use this when creating a new loadtest.
  - This is done so the spec will never have empty spec fields
- Adds 4 environment variables (`JMETER_MASTER_IMAGE_NAME`, `JMETER_MASTER_IMAGE_TAG`, and the same for worker) to specify default images.
  - This is done to allow users to specify custom images used for the loadtest backend.
  - It was already available in locust, this PR simply adds the same capability for JMeter.