### PR TITLE
Add new backend interfaces

### DIFF
--- a/pkg/backends/backend.go
+++ b/pkg/backends/backend.go
@@ -16,6 +16,69 @@ import (
 	clientSetV "github.com/hellofresh/kangal/pkg/kubernetes/generated/clientset/versioned"
 )
 
+// Backend is basic methods a backend must implement
+type Backend interface {
+	// Type must return backend unique type string, called by both Proxy and Controller
+	Type() loadTestV1.LoadTestType
+
+	// TransformLoadTestSpec should validate and transform LoadTestSpec, called by Proxy
+	TransformLoadTestSpec(spec *loadTestV1.LoadTestSpec) error
+
+	// Sync should create resources if not exists, called by Controller
+	Sync(ctx context.Context, loadTest loadTestV1.LoadTest, reportURL string) error
+	// Sync should update status with current resource state, called by Controller
+	SyncStatus(ctx context.Context, loadTest loadTestV1.LoadTest, loadTestStatus *loadTestV1.LoadTestStatus) error
+}
+
+// BackendGetEnvConfig backend must implement this if it has Environment Variables
+// This method is called by both commands, Proxy and Controller
+type BackendGetEnvConfig interface {
+	// GetEnvConfig get from backend a envConfig struct pointer
+	GetEnvConfig() interface{}
+}
+
+// BackendSetDefaults backend must implement this if wants to set default values
+// This method is called by both commands, Proxy and Controller
+type BackendSetDefaults interface {
+	// SetDefaultValues gives a chance to backend initialize itself
+	SetDefaults()
+}
+
+// BackendSetLogger interface can be implemented by backend to receive an logger
+// This method is called by both commands, Proxy and Controller
+type BackendSetLogger interface {
+	// SetLogger gives backend a logger instance
+	SetLogger(*zap.Logger)
+}
+
+// BackendSetPodAnnotations interface can be implemented by backend to receive pod annotations
+// This method is called only by command Controller
+type BackendSetPodAnnotations interface {
+	// SetLogger gives backend a logger instance
+	SetPodAnnotations(map[string]string)
+}
+
+// BackendSetKubeClientSet interface can be implemented by backend to receive an kubeClientSet
+// This method is called only by command Controller
+type BackendSetKubeClientSet interface {
+	// SetKubeClientSet gives backend a kubeClientSet instance
+	SetKubeClientSet(kubernetes.Interface)
+}
+
+// BackendSetKangalClientSet interface can be implemented by backend to receive an kangalClientSet
+// This method is called only by command Controller
+type BackendSetKangalClientSet interface {
+	// SetKangalClientSet gives backend a kangalClientSet instance
+	SetKangalClientSet(clientSetV.Interface)
+}
+
+// BackendSetNamespaceLister interface can be implemented by backend to receive an namespaceLister
+// This method is called only by command Controller
+type BackendSetNamespaceLister interface {
+	// SetNamespaceLister gives backend a namespaceLister instance
+	SetNamespaceLister(coreListersV1.NamespaceLister)
+}
+
 // LoadTestType defines the methods that a loadtest type needs to implement
 // for the controller to be able to run it
 type LoadTestType interface {

--- a/pkg/backends/options.go
+++ b/pkg/backends/options.go
@@ -1,0 +1,67 @@
+package backends
+
+import (
+	clientSetV "github.com/hellofresh/kangal/pkg/kubernetes/generated/clientset/versioned"
+	"go.uber.org/zap"
+
+	"k8s.io/client-go/kubernetes"
+	coreListersV1 "k8s.io/client-go/listers/core/v1"
+)
+
+// Option allows to configure backends
+type Option func(*Registry)
+
+// WithLogger adds given logger to each registered backend that implements BackendLogger
+func WithLogger(logger *zap.Logger) Option {
+	return func(b *Registry) {
+		for _, item := range b.registry {
+			if iface, ok := item.(BackendSetLogger); ok {
+				iface.SetLogger(logger)
+			}
+		}
+	}
+}
+
+// WithPodAnnotations adds given logger to each registered backend that implements BackendLogger
+func WithPodAnnotations(podAnnotations map[string]string) Option {
+	return func(b *Registry) {
+		for _, item := range b.registry {
+			if iface, ok := item.(BackendSetPodAnnotations); ok {
+				iface.SetPodAnnotations(podAnnotations)
+			}
+		}
+	}
+}
+
+// WithKubeClientSet adds given kubeClientSet to each registered backend that implements BackendKubeClientSet
+func WithKubeClientSet(kubeClientSet kubernetes.Interface) Option {
+	return func(b *Registry) {
+		for _, item := range b.registry {
+			if iface, ok := item.(BackendSetKubeClientSet); ok {
+				iface.SetKubeClientSet(kubeClientSet)
+			}
+		}
+	}
+}
+
+// WithKangalClientSet adds given kangalClientSet to each registered backend that implements BackendKangalClientSet
+func WithKangalClientSet(kangalClientSet clientSetV.Interface) Option {
+	return func(b *Registry) {
+		for _, item := range b.registry {
+			if iface, ok := item.(BackendSetKangalClientSet); ok {
+				iface.SetKangalClientSet(kangalClientSet)
+			}
+		}
+	}
+}
+
+// WithNamespaceLister adds given namespaceLister to each registered backend that implements BackendNamespaceLister
+func WithNamespaceLister(namespaceLister coreListersV1.NamespaceLister) Option {
+	return func(b *Registry) {
+		for _, item := range b.registry {
+			if iface, ok := item.(BackendSetNamespaceLister); ok {
+				iface.SetNamespaceLister(namespaceLister)
+			}
+		}
+	}
+}

--- a/pkg/backends/registry.go
+++ b/pkg/backends/registry.go
@@ -1,0 +1,67 @@
+package backends
+
+import (
+	"errors"
+
+	loadTestV1 "github.com/hellofresh/kangal/pkg/kubernetes/apis/loadtest/v1"
+	"github.com/kelseyhightower/envconfig"
+)
+
+var (
+	// ErrBackendRegistered returned when try to register a backend twice
+	ErrBackendRegistered = errors.New("Backend already registered")
+	// ErrNoBackendRegistered returned when no backend found for given type
+	ErrNoBackendRegistered = errors.New("No backend registered")
+)
+
+// defaultRegistry contains the list of available backends
+var defaultRegistry = map[loadTestV1.LoadTestType]Backend{}
+
+// register should be called to register your backend
+func register(b Backend) {
+	if _, exists := defaultRegistry[b.Type()]; exists {
+		panic(ErrBackendRegistered)
+	}
+
+	if envConfig, ok := b.(BackendGetEnvConfig); ok {
+		err := envconfig.Process("", envConfig.GetEnvConfig())
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	defaultRegistry[b.Type()] = b
+}
+
+// Registry you can use this to add information to backends and to resolve to then
+type Registry struct {
+	registry map[loadTestV1.LoadTestType]Backend
+}
+
+// New creates a new Backend instance
+func New(opts ...Option) *Registry {
+	b := &Registry{
+		registry: defaultRegistry,
+	}
+
+	for _, opt := range opts {
+		opt(b)
+	}
+
+	for _, item := range b.registry {
+		if iface, ok := item.(BackendSetDefaults); ok {
+			iface.SetDefaults()
+		}
+	}
+
+	return b
+}
+
+// Resolve return the given backend name from the registry
+func (b *Registry) Resolve(loadTestType loadTestV1.LoadTestType) (Backend, error) {
+	resolved, exists := b.registry[loadTestType]
+	if !exists {
+		return nil, ErrNoBackendRegistered
+	}
+	return resolved, nil
+}


### PR DESCRIPTION
This PR introduces new interfaces for the backends to implement instead the way is done now.
This will make it easy to implement new backends.

The backend are required to implement the following interface:
```go
// Backend is basic methods a backend must implement
type Backend interface {
	// Type must return backend unique type string, called by both Proxy and Controller
	Type() loadTestV1.LoadTestType

	// TransformLoadTestSpec should validate and transform LoadTestSpec, called by Proxy
	TransformLoadTestSpec(spec *loadTestV1.LoadTestSpec) error

	// Sync should create resources if not exists, called by Controller
	Sync(ctx context.Context, loadTest loadTestV1.LoadTest, reportURL string) error
	// Sync should update status with current resource state, called by Controller
	SyncStatus(ctx context.Context, loadTest loadTestV1.LoadTest, loadTestStatus *loadTestV1.LoadTestStatus) error
}
```

and optionally to those:

```go
// BackendGetEnvConfig backend must implement this if it has Environment Variables
// This method is called by both commands, Proxy and Controller
type BackendGetEnvConfig interface {
	// GetEnvConfig get from backend a envConfig struct pointer
	GetEnvConfig() interface{}
}

// BackendSetDefaults backend must implement this if wants to set default values
// This method is called by both commands, Proxy and Controller
type BackendSetDefaults interface {
	// SetDefaultValues gives a chance to backend initialize itself
	SetDefaults()
}

// BackendSetLogger interface can be implemented by backend to receive an logger
// This method is called by both commands, Proxy and Controller
type BackendSetLogger interface {
	// SetLogger gives backend a logger instance
	SetLogger(*zap.Logger)
}

// BackendSetPodAnnotations interface can be implemented by backend to receive pod annotations
// This method is called only by command Controller
type BackendSetPodAnnotations interface {
	// SetLogger gives backend a logger instance
	SetPodAnnotations(map[string]string)
}

// BackendSetKubeClientSet interface can be implemented by backend to receive an kubeClientSet
// This method is called only by command Controller
type BackendSetKubeClientSet interface {
	// SetKubeClientSet gives backend a kubeClientSet instance
	SetKubeClientSet(kubernetes.Interface)
}

// BackendSetKangalClientSet interface can be implemented by backend to receive an kangalClientSet
// This method is called only by command Controller
type BackendSetKangalClientSet interface {
	// SetKangalClientSet gives backend a kangalClientSet instance
	SetKangalClientSet(clientSetV.Interface)
}

// BackendSetNamespaceLister interface can be implemented by backend to receive an namespaceLister
// This method is called only by command Controller
type BackendSetNamespaceLister interface {
	// SetNamespaceLister gives backend a namespaceLister instance
	SetNamespaceLister(coreListersV1.NamespaceLister)
}
```

An important change is those lines:

```go
	Sync(ctx context.Context, loadTest loadTestV1.LoadTest, reportURL string) error
	SyncStatus(ctx context.Context, loadTest loadTestV1.LoadTest, loadTestStatus *loadTestV1.LoadTestStatus) error
```

Passing `LoadTest` by value and status by reference, this way backends cannot mutate `LoadTest`, but only `LoadTestStatus`