### PR TITLE
Normalise Locust ENV name

### DIFF
--- a/charts/kangal/Chart.yaml
+++ b/charts/kangal/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - performance tests
   - tests runner
 name: kangal
-version: 1.4.1
+version: 1.4.2
 home: https://github.com/hellofresh/kangal
 icon: https://raw.githubusercontent.com/hellofresh/kangal/master/kangal_logo.svg
 maintainers:

--- a/charts/kangal/README.md
+++ b/charts/kangal/README.md
@@ -82,7 +82,7 @@ The following table lists the common configurable parameters for `Kangal` chart:
 | `configmap.JMETER_MASTER_IMAGE_TAG`  | Tag of the JMeter master image above                                                                | `latest`                              |
 | `configmap.JMETER_WORKER_IMAGE_NAME` | Default JMeter worker image name/repository if none is provided when creating a new loadtest        | `hellofreshtech/kangal-jmeter-worker` |
 | `configmap.JMETER_WORKER_IMAGE_TAG`  | Tag of the JMeter worker image above                                                                | `latest`                              |
-| `configmap.LOCUST_IMAGE`             | Default Locust image name/repository if none is provided when creating a new loadtest               | `locustio/locust`                     |
+| `configmap.LOCUST_IMAGE_NAME`        | Default Locust image name/repository if none is provided when creating a new loadtest               | `locustio/locust`                     |
 | `configmap.LOCUST_IMAGE_TAG`         | Tag of the Locust image above                                                                       | `1.3.0`                               |
 
 Deployment specific configurations:

--- a/charts/kangal/values.yaml
+++ b/charts/kangal/values.yaml
@@ -176,5 +176,5 @@ configMap:
   JMETER_MASTER_IMAGE_TAG: "latest"
   JMETER_WORKER_IMAGE_NAME: "hellofreshtech/kangal-jmeter-worker"
   JMETER_WORKER_IMAGE_TAG: "latest"
-  LOCUST_IMAGE: "locustio/locust"
+  LOCUST_IMAGE_NAME: "locustio/locust"
   LOCUST_IMAGE_TAG: "1.3.0"

--- a/pkg/backends/locust/config.go
+++ b/pkg/backends/locust/config.go
@@ -3,6 +3,7 @@ package locust
 // Config specific to Locust backend
 type Config struct {
 	Image                string `envconfig:"LOCUST_IMAGE"`
+	ImageName            string `envconfig:"LOCUST_IMAGE_NAME"`
 	ImageTag             string `envconfig:"LOCUST_IMAGE_TAG"`
 	MasterCPULimits      string `envconfig:"LOCUST_MASTER_CPU_LIMITS"`
 	MasterCPURequests    string `envconfig:"LOCUST_MASTER_CPU_REQUESTS"`

--- a/pkg/backends/locust/spec.go
+++ b/pkg/backends/locust/spec.go
@@ -34,13 +34,19 @@ func BuildLoadTestSpec(
 	imageName := defaultImage
 	imageTag := defaultImageTag
 
+	// this is to ensure backward compatibility
+	if config.Image != "" && config.ImageName == "" {
+		config.ImageName = config.Image
+	}
+
 	// Use environment variable config if available
-	if config.Image != "" {
-		imageName = config.Image
+	if config.ImageName != "" {
+		imageName = config.ImageName
 	}
 	if config.ImageTag != "" {
 		imageTag = config.ImageTag
 	}
+
 	return loadTestV1.NewSpec(
 		loadTestV1.LoadTestTypeLocust,
 		overwrite,


### PR DESCRIPTION
EES-4597

Locust is using a different pattern compared to JMeter.
To keep things simple, they should use the same naming pattern.

So instead of `LOCUST_IMAGE`, should be `LOCUST_IMAGE_NAME`.
This PR introduces this change and also keep compatibility with old name.