### PR TITLE
Use proper string to int conversion

### DIFF
--- a/pkg/proxy/request.go
+++ b/pkg/proxy/request.go
@@ -192,7 +192,7 @@ func getOverwrite(r *http.Request) (bool, error) {
 
 func getDistributedPods(r *http.Request) (int32, error) {
 	nn := r.FormValue(distributedPods)
-	dn, err := strconv.Atoi(nn)
+	dn, err := strconv.ParseInt(nn, 10, 32)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
EES-4598

GitHub CodeQL is complaining about `int32` when using a int from `Atoi`.
This PR changes the function `Atoi` to `ParseInt`.