### PR TITLE
adding a phase filter for GET request

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Run golangci linter
         uses: golangci/golangci-lint-action@v1
         with:
-          version: v1.30
+          version: v2.3
 
       - name: Lint GoReleaser
         uses: goreleaser/goreleaser-action@v2
@@ -64,7 +64,7 @@ jobs:
           make test-unit
 
       - name: Setup Kind
-        uses: engineerd/setup-kind@v0.4.0
+        uses: engineerd/setup-kind@v0.5.0
 
       - name: Install Kangal CRD
         run: |

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ More info about the Custom Resources in [official Kubernetes documentation](http
 ### Kangal Proxy
 Provides the following HTTP methods for `/load-test` endpoint:
  - POST - allowing the user to create a new LoadTest
- - GET - allowing the user to see current LoadTest status / logs / report / metrics
+ - GET - allowing the user to see information (status/logs/report) for specific LoadTest and get an overview for all the currently existing loadtests
  - DELETE - allowing the user to stop and delete existing LoadTest
 
  The Kangal Proxy is documented using the [OpenAPI Spec](https://swagger.io/specification/).

--- a/docs/user-flow.md
+++ b/docs/user-flow.md
@@ -102,7 +102,7 @@ You can filter by `tags`
 curl 'http://${KANGAL_PROXY_ADDRESS}/load-test?tags=tag1:value1'
 ```
 
-You can filter by `phase`
+You can filter by `phase`, possible phases are: `creating, starting, running, finished, errored`
 
 ```bash
 curl 'http://${KANGAL_PROXY_ADDRESS}/load-test?phase=running'

--- a/docs/user-flow.md
+++ b/docs/user-flow.md
@@ -102,6 +102,17 @@ You can filter by `tags`
 curl 'http://${KANGAL_PROXY_ADDRESS}/load-test?tags=tag1:value1'
 ```
 
+You can filter by `phase`
+
+```bash
+curl 'http://${KANGAL_PROXY_ADDRESS}/load-test?phase=running'
+```
+
+All together
+```bash
+curl 'http://${KANGAL_PROXY_ADDRESS}/load-test?phase=running&tags=tag1:value1'
+```
+
 And limit your search
 
 ```bash

--- a/openapi.json
+++ b/openapi.json
@@ -33,7 +33,8 @@
 						"in": "query",
 						"description": "Filter the result by current phase.",
 						"schema": {
-							"type": "string"
+							"type": "string",
+							"enum": ["creating", "starting", "running", "finished", "errored"]
 						},
 						"example": "phase:running"
 					},

--- a/openapi.json
+++ b/openapi.json
@@ -29,6 +29,15 @@
 						"example": "department:platform,team:kangal"
 					},
 					{
+						"name": "phase",
+						"in": "query",
+						"description": "Filter the result by current phase.",
+						"schema": {
+							"type": "string"
+						},
+						"example": "phase:running"
+					},
+					{
 						"name": "limit",
 						"in": "query",
 						"description": "Limit the result when querying on a large cluster",

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -40,6 +40,8 @@ type Client struct {
 type ListOptions struct {
 	// List of tags.
 	Tags map[string]string
+	// Phase of loadTest
+	Phase string
 	// Limit.
 	Limit int64
 	// Continue.
@@ -135,6 +137,18 @@ func (c *Client) ListLoadTest(ctx context.Context, opt ListOptions) (*apisLoadTe
 	}
 
 	return loadTests, nil
+}
+
+// ListLoadTestsByPhase returns a list of loadtests filtered by phase
+func (c *Client) ListLoadTestsByPhase(list *apisLoadTestV1.LoadTestList, phase string) (*apisLoadTestV1.LoadTestList, error) {
+	filteredList := apisLoadTestV1.LoadTestList{}
+	// CRD-s currently don't support custom field selectors, so we have to iterate via all load tests and check status phase
+	for _, loadTest := range list.Items {
+		if string(loadTest.Status.Phase) == phase {
+			filteredList.Items = append(filteredList.Items, loadTest)
+		}
+	}
+	return &filteredList, nil
 }
 
 // CountActiveLoadTests returns a number of currently running load tests

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -140,7 +140,7 @@ func (c *Client) ListLoadTest(ctx context.Context, opt ListOptions) (*apisLoadTe
 }
 
 // ListLoadTestsByPhase returns a list of loadtests filtered by phase
-func (c *Client) ListLoadTestsByPhase(list *apisLoadTestV1.LoadTestList, phase string) (*apisLoadTestV1.LoadTestList, error) {
+func (c *Client) ListLoadTestsByPhase(list *apisLoadTestV1.LoadTestList, phase string) *apisLoadTestV1.LoadTestList {
 	filteredList := apisLoadTestV1.LoadTestList{}
 	// CRD-s currently don't support custom field selectors, so we have to iterate via all load tests and check status phase
 	for _, loadTest := range list.Items {
@@ -148,7 +148,7 @@ func (c *Client) ListLoadTestsByPhase(list *apisLoadTestV1.LoadTestList, phase s
 			filteredList.Items = append(filteredList.Items, loadTest)
 		}
 	}
-	return &filteredList, nil
+	return &filteredList
 }
 
 // CountActiveLoadTests returns a number of currently running load tests

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -142,6 +142,7 @@ func (c *Client) ListLoadTest(ctx context.Context, opt ListOptions) (*apisLoadTe
 // ListLoadTestsByPhase returns a list of loadtests filtered by phase
 func (c *Client) ListLoadTestsByPhase(list *apisLoadTestV1.LoadTestList, phase string) *apisLoadTestV1.LoadTestList {
 	filteredList := apisLoadTestV1.LoadTestList{}
+	phase = strings.ToLower(phase)
 	// CRD-s currently don't support custom field selectors, so we have to iterate via all load tests and check status phase
 	for _, loadTest := range list.Items {
 		if string(loadTest.Status.Phase) == phase {

--- a/pkg/kubernetes/client_test.go
+++ b/pkg/kubernetes/client_test.go
@@ -319,7 +319,7 @@ func TestClientListLoadTestsByPhase(t *testing.T) {
 					},
 				},
 			},
-			status:      "running",
+			status:      "Running",
 			resultCount: 1,
 		},
 		{

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -98,6 +98,16 @@ func (p *Proxy) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if opt.Phase != "" {
+		loadTests, err = p.kubeClient.ListLoadTestsByPhase(loadTests, opt.Phase)
+		if err != nil {
+			logger.Error("could not list load tests by phase", zap.Error(err))
+			render.Render(w, r, cHttp.ErrResponse(http.StatusInternalServerError, err.Error()))
+
+			return
+		}
+	}
+
 	items := make([]LoadTestStatus, len(loadTests.Items))
 
 	for i, lt := range loadTests.Items {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -99,13 +99,7 @@ func (p *Proxy) List(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if opt.Phase != "" {
-		loadTests, err = p.kubeClient.ListLoadTestsByPhase(loadTests, opt.Phase)
-		if err != nil {
-			logger.Error("could not list load tests by phase", zap.Error(err))
-			render.Render(w, r, cHttp.ErrResponse(http.StatusInternalServerError, err.Error()))
-
-			return
-		}
+		loadTests = p.kubeClient.ListLoadTestsByPhase(loadTests, opt.Phase)
 	}
 
 	items := make([]LoadTestStatus, len(loadTests.Items))

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -184,7 +185,7 @@ func TestProxy_List(t *testing.T) {
 			error:               errors.New("client error"),
 			expectedCode:        500,
 			expectedContentType: "application/json; charset=utf-8",
-			expectedResponse:    "{\"error\":\"client error\"}\n",
+			expectedResponse:    `{"error":"client error"}`,
 		},
 		{
 			scenario:            "invalid limit",
@@ -192,7 +193,7 @@ func TestProxy_List(t *testing.T) {
 			result:              &apisLoadTestV1.LoadTestList{},
 			expectedCode:        400,
 			expectedContentType: "application/json; charset=utf-8",
-			expectedResponse:    "{\"error\":\"strconv.ParseInt: parsing \\\"foobar\\\": invalid syntax\"}\n",
+			expectedResponse:    `{"error":"strconv.ParseInt: parsing \"foobar\": invalid syntax"}`,
 		},
 		{
 			scenario:            "invalid tags",
@@ -200,7 +201,7 @@ func TestProxy_List(t *testing.T) {
 			result:              &apisLoadTestV1.LoadTestList{},
 			expectedCode:        400,
 			expectedContentType: "application/json; charset=utf-8",
-			expectedResponse:    "{\"error\":\"missing tag label\"}\n",
+			expectedResponse:    `{"error":"missing tag label"}`,
 		},
 		{
 			scenario:            "invalid phase",
@@ -208,7 +209,7 @@ func TestProxy_List(t *testing.T) {
 			result:              &apisLoadTestV1.LoadTestList{},
 			expectedCode:        200,
 			expectedContentType: "application/json; charset=utf-8",
-			expectedResponse:    "{\"limit\":0,\"continue\":\"\",\"remain\":null,\"items\":[]}\n",
+			expectedResponse:    `{"limit":0,"continue":"","remain":null,"items":[]}`,
 		},
 		{
 			scenario:  "valid phase",
@@ -236,7 +237,7 @@ func TestProxy_List(t *testing.T) {
 			},
 			expectedCode:        200,
 			expectedContentType: "application/json; charset=utf-8",
-			expectedResponse:    "{\"limit\":0,\"continue\":\"\",\"remain\":null,\"items\":[{\"type\":\"JMeter\",\"distributedPods\":2,\"loadtestName\":\"random\",\"phase\":\"running\",\"tags\":{},\"hasEnvVars\":false,\"hasTestData\":true}]}\n",
+			expectedResponse:    `{"limit":0,"continue":"","remain":null,"items":[{"type":"JMeter","distributedPods":2,"loadtestName":"random","phase":"running","tags":{},"hasEnvVars":false,"hasTestData":true}]}`,
 		},
 		{
 			scenario:  "success",
@@ -273,7 +274,7 @@ func TestProxy_List(t *testing.T) {
 			},
 			expectedCode:        200,
 			expectedContentType: "application/json; charset=utf-8",
-			expectedResponse:    "{\"limit\":10,\"continue\":\"continue\",\"remain\":42,\"items\":[{\"type\":\"JMeter\",\"distributedPods\":2,\"loadtestName\":\"random\",\"phase\":\"running\",\"tags\":{\"department\":\"platform\",\"team\":\"kangal\"},\"hasEnvVars\":false,\"hasTestData\":true}]}\n",
+			expectedResponse:    `{"limit":10,"continue":"continue","remain":42,"items":[{"type":"JMeter","distributedPods":2,"loadtestName":"random","phase":"running","tags":{"department":"platform","team":"kangal"},"hasEnvVars":false,"hasTestData":true}]}`,
 		},
 	}
 
@@ -306,7 +307,7 @@ func TestProxy_List(t *testing.T) {
 
 			assert.Equal(t, tc.expectedCode, resp.StatusCode)
 			assert.Equal(t, resp.Header.Get("Content-Type"), tc.expectedContentType)
-			assert.Equal(t, tc.expectedResponse, string(respBody))
+			assert.Equal(t, tc.expectedResponse, strings.Trim(string(respBody), "\n"))
 		})
 	}
 }

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -203,6 +203,42 @@ func TestProxy_List(t *testing.T) {
 			expectedResponse:    "{\"error\":\"missing tag label\"}\n",
 		},
 		{
+			scenario:            "invalid phase",
+			urlParams:           "phase=foo",
+			result:              &apisLoadTestV1.LoadTestList{},
+			expectedCode:        200,
+			expectedContentType: "application/json; charset=utf-8",
+			expectedResponse:    "{\"limit\":0,\"continue\":\"\",\"remain\":null,\"items\":[]}\n",
+		},
+		{
+			scenario:  "valid phase",
+			urlParams: "phase=running",
+			result: &apisLoadTestV1.LoadTestList{
+				ListMeta: metaV1.ListMeta{
+					Continue:           "continue",
+					RemainingItemCount: &remainCount,
+				},
+				Items: []apisLoadTestV1.LoadTest{
+					{
+						Spec: apisLoadTestV1.LoadTestSpec{
+							Type:            apisLoadTestV1.LoadTestTypeJMeter,
+							DistributedPods: &distributedPods,
+							Tags:            apisLoadTestV1.LoadTestTags{},
+							TestFile:        "file content\n",
+							TestData:        "test data\n",
+						},
+						Status: apisLoadTestV1.LoadTestStatus{
+							Phase:     apisLoadTestV1.LoadTestRunning,
+							Namespace: "random",
+						},
+					},
+				},
+			},
+			expectedCode:        200,
+			expectedContentType: "application/json; charset=utf-8",
+			expectedResponse:    "{\"limit\":0,\"continue\":\"\",\"remain\":null,\"items\":[{\"type\":\"JMeter\",\"distributedPods\":2,\"loadtestName\":\"random\",\"phase\":\"running\",\"tags\":{},\"hasEnvVars\":false,\"hasTestData\":true}]}\n",
+		},
+		{
 			scenario:  "success",
 			urlParams: "tags=department:platform,team:kangal&limit=10",
 			result: &apisLoadTestV1.LoadTestList{

--- a/pkg/proxy/request.go
+++ b/pkg/proxy/request.go
@@ -78,6 +78,11 @@ func fromHTTPRequestToListOptions(r *http.Request) (*kubernetes.ListOptions, err
 		opt.Limit = limit
 	}
 
+	// Build phase filter.
+	if phaseVal := params.Get("phase"); phaseVal != "" {
+		opt.Phase = phaseVal
+	}
+
 	// Build continue.
 	opt.Continue = params.Get("continue")
 

--- a/pkg/proxy/request.go
+++ b/pkg/proxy/request.go
@@ -79,9 +79,7 @@ func fromHTTPRequestToListOptions(r *http.Request) (*kubernetes.ListOptions, err
 	}
 
 	// Build phase filter.
-	if phaseVal := params.Get("phase"); phaseVal != "" {
-		opt.Phase = phaseVal
-	}
+	opt.Phase = params.Get("phase")
 
 	// Build continue.
 	opt.Continue = params.Get("continue")


### PR DESCRIPTION
EES-273
In order to see the overview of the currently existing load test, we add a filter by phase. Now you can get all the load tests of the selected phase.
Example: this request will show all currently running load tests.
`curl 'http://${KANGAL_PROXY_ADDRESS}/load-test?phase=running'`

This filter can be combined with filtering by tags:
`curl 'http://${KANGAL_PROXY_ADDRESS}/load-test?phase=running&tags=tag1:value1'`