### PR TITLE
EES-4591 Logger returns if it is running in debug mode

### DIFF
--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -45,7 +45,7 @@ func NewControllerCmd(ctx context.Context) *cobra.Command {
 				return err
 			}
 
-			logger, err := observability.NewLogger(cfg.Logger)
+			logger, _, err := observability.NewLogger(cfg.Logger)
 			if err != nil {
 				return fmt.Errorf("could not build logger instance: %w", err)
 			}

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -39,7 +39,7 @@ func NewProxyCmd(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("could not load config from env: %w", err)
 			}
 
-			logger, err := observability.NewLogger(cfg.Logger)
+			logger, _, err := observability.NewLogger(cfg.Logger)
 			if err != nil {
 				return fmt.Errorf("could not build logger instance: %w", err)
 			}

--- a/pkg/core/observability/logger.go
+++ b/pkg/core/observability/logger.go
@@ -22,14 +22,14 @@ func (w *stdLoggerWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-// NewLogger initializes and returns logger instance
-func NewLogger(cfg LoggerConfig) (*zap.Logger, error) {
+// NewLogger initializes and returns logger instance and flag if it is in debug mode
+func NewLogger(cfg LoggerConfig) (*zap.Logger, bool, error) {
 	var err error
 	logConfig := zap.NewProductionConfig()
 
 	logLevel := new(zap.AtomicLevel)
 	if err := logLevel.UnmarshalText([]byte(cfg.Level)); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	logConfig.Level = *logLevel
@@ -41,11 +41,11 @@ func NewLogger(cfg LoggerConfig) (*zap.Logger, error) {
 
 	logger, err := logConfig.Build()
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	// override std logger to write into app logger
 	log.SetOutput(&stdLoggerWriter{logger})
 
-	return logger, nil
+	return logger, logConfig.Development, nil
 }


### PR DESCRIPTION
Logger is aware if debug mode is enabled, so it returns corresponding flag, so that other parts can enable some debug features based on this flag.

Not used right now, but going to be used in upcoming PRs.