### PR TITLE
Fix typo in available testing backend

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -428,7 +428,7 @@
 					},
 					"type": {
 						"type": "string",
-						"enum": ["jMeter", "Fake", "Locust"]
+						"enum": ["JMeter", "Fake", "Locust"]
 					},
 					"overwrite": {
 						"type": "boolean"


### PR DESCRIPTION
the typo in the api-docs causes an astonishing error while onboarding through the open-api specs

```
{
    "error": "load test provider not found to build specs: jMeter"
}
```