### PR TITLE
EES-4641 Use k8s errors to find out about LT not found

### DIFF
--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -6,12 +6,10 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
-
 	"strings"
 	"time"
 
 	"go.uber.org/zap"
-
 	coreV1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -8,14 +8,13 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/hellofresh/kangal/pkg/backends"
-
 	"github.com/go-chi/chi"
 	"github.com/go-chi/render"
 	"go.uber.org/zap"
 	k8sAPIErrors "k8s.io/apimachinery/pkg/api/errors"
 	restClient "k8s.io/client-go/rest"
 
+	"github.com/hellofresh/kangal/pkg/backends"
 	loadtest "github.com/hellofresh/kangal/pkg/controller"
 	cHttp "github.com/hellofresh/kangal/pkg/core/http"
 	mPkg "github.com/hellofresh/kangal/pkg/core/middleware"
@@ -162,7 +161,7 @@ func (p *Proxy) Create(w http.ResponseWriter, r *http.Request) {
 				// Remove the old tests
 				err := p.kubeClient.DeleteLoadTest(ctx, item.Name)
 				if err != nil {
-					logger.Error("Could not delete load test with error:", zap.Error(err))
+					logger.Error("Could not delete load test with error", zap.Error(err))
 					render.Render(w, r, cHttp.ErrResponse(http.StatusConflict, err.Error()))
 					return
 				}
@@ -220,7 +219,7 @@ func (p *Proxy) Delete(w http.ResponseWriter, r *http.Request) {
 
 	err := p.kubeClient.DeleteLoadTest(ctx, ltID)
 	if err != nil {
-		logger.Error("Could not delete load test with error:", zap.Error(err))
+		logger.Error("Could not delete load test with error", zap.Error(err))
 		render.Render(w, r, cHttp.ErrResponse(http.StatusBadRequest, err.Error()))
 		return
 	}
@@ -242,7 +241,7 @@ func (p *Proxy) Get(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		logger.Error("Could not get load test info with error:", zap.Error(err))
 
-		if k8sErr, ok := err.(k8sAPIErrors.APIStatus); ok && k8sErr.Status().Code == http.StatusNotFound {
+		if k8sAPIErrors.IsNotFound(err) {
 			render.Render(w, r, cHttp.ErrResponse(http.StatusNotFound, err.Error()))
 			return
 		}
@@ -275,7 +274,7 @@ func (p *Proxy) GetLogs(w http.ResponseWriter, r *http.Request) {
 
 	loadTest, err := p.kubeClient.GetLoadTest(ctx, ltID)
 	if err != nil {
-		logger.Error("Could not get load test info with error:", zap.Error(err))
+		logger.Error("Could not get load test info with error", zap.Error(err))
 		render.Render(w, r, cHttp.ErrResponse(http.StatusBadRequest, err.Error()))
 		return
 	}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -239,7 +239,7 @@ func (p *Proxy) Get(w http.ResponseWriter, r *http.Request) {
 
 	result, err := p.kubeClient.GetLoadTest(ctx, ltID)
 	if err != nil {
-		logger.Error("Could not get load test info with error:", zap.Error(err))
+		logger.Error("Could not get load test info with error", zap.Error(err))
 
 		if k8sAPIErrors.IsNotFound(err) {
 			render.Render(w, r, cHttp.ErrResponse(http.StatusNotFound, err.Error()))

--- a/pkg/report/handler.go
+++ b/pkg/report/handler.go
@@ -10,15 +10,15 @@ import (
 	"strings"
 	"time"
 
-	khttp "github.com/hellofresh/kangal/pkg/core/http"
-	kk8s "github.com/hellofresh/kangal/pkg/kubernetes"
-
 	"github.com/go-chi/chi"
 	"github.com/go-chi/render"
 	"github.com/minio/minio-go/v6"
 	"github.com/spf13/afero"
 	"go.uber.org/zap"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8sAPIErrors "k8s.io/apimachinery/pkg/api/errors"
+
+	khttp "github.com/hellofresh/kangal/pkg/core/http"
+	kk8s "github.com/hellofresh/kangal/pkg/kubernetes"
 )
 
 var httpClient = &http.Client{
@@ -125,7 +125,7 @@ func PersistHandler(kubeClient *kk8s.Client, logger *zap.Logger) func(w http.Res
 		loadTestName := chi.URLParam(r, "id")
 
 		_, err := kubeClient.GetLoadTest(r.Context(), loadTestName)
-		if errors.IsNotFound(err) {
+		if k8sAPIErrors.IsNotFound(err) {
 			render.Render(w, r, khttp.ErrResponse(http.StatusNotFound, err.Error()))
 			return
 		}


### PR DESCRIPTION
Use k8s errors to find out about LT not found - use built-in k8s errors to find out if object is not found instead of type casting errors and checking fields manually
