### PR TITLE
Fixed CI release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,13 @@ jobs:
               google.golang.org/grpc/cmd/protoc-gen-go-grpc
           make protoc
 
+      # action required as workaround for goreleaser error:
+      # ⨯ release failed after 0.03s error=git is currently in a dirty state, please check in your pipeline what can be changing the following files:
+      #    ?? googleapis/
+      # we do not need this dir after all the protobuf code was generated
+      - name: Clean up project source tree
+        run: rm -rf googleapis
+
       - name: Docker Login
         if: success() && startsWith(github.ref, 'refs/tags/')
         env:


### PR DESCRIPTION
Hotfix for failing build - https://github.com/hellofresh/kangal/runs/1452857789?check_suite_focus=true - clean up source tree after code was generated from protobuf

I'm working on more reliable compile-time tooling solution, this hotfix only to unblock releases.