### PR TITLE
EES-4643 Set go_package explicitly and do not use path=source_relative

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,13 +57,11 @@ protoc: tools
 		--proto_path=$(tools/gateway)/third_party/googleapis \
 		--proto_path=$(tools/protobuf)/src \
 		--proto_path=$(CURDIR)/proto \
-		--go_opt=paths=source_relative \
 		--go_out=$(CURDIR)/pkg/proxy/rpc/pb \
 		--go-grpc_out=$(CURDIR)/pkg/proxy/rpc/pb \
 		--go-grpc_opt=require_unimplemented_servers=false \
 		--grpc-gateway_out=$(CURDIR)/pkg/proxy/rpc/pb \
 		--grpc-gateway_opt=logtostderr=true \
-		--grpc-gateway_opt=paths=source_relative \
 		--openapiv2_out=$(CURDIR)/pkg/proxy/rpc/pb \
 		--openapiv2_opt=logtostderr=true \
 		$(CURDIR)/proto/*/*/*/*.proto

--- a/pkg/proxy/service.go
+++ b/pkg/proxy/service.go
@@ -51,7 +51,7 @@ func (s *implLoadTestServiceServer) Get(ctx context.Context, in *grpcProxyV2.Get
 			Name:            result.Status.Namespace,
 			DistributedPods: *result.Spec.DistributedPods,
 			Phase:           phaseToGRPC(result.Status.Phase),
-			Tags:            tagsToGRPC(result.Spec.Tags),
+			Tags:            result.Spec.Tags,
 			HasEnvVars:      len(result.Spec.EnvVars) != 0,
 			HasTestData:     len(result.Spec.TestData) != 0,
 			Type:            typeToGRPC(result.Spec.Type),
@@ -92,17 +92,4 @@ func typeToGRPC(t apisLoadTestV1.LoadTestType) grpcProxyV2.LoadTestType {
 	}
 
 	return grpcProxyV2.LoadTestType_LOAD_TEST_TYPE_UNSPECIFIED
-}
-
-func tagsToGRPC(tt apisLoadTestV1.LoadTestTags) []*grpcProxyV2.Tag {
-	tags := make([]*grpcProxyV2.Tag, 0, len(tt))
-
-	for k, v := range tt {
-		tags = append(tags, &grpcProxyV2.Tag{
-			Key:   k,
-			Value: v,
-		})
-	}
-
-	return tags
 }

--- a/pkg/proxy/service_test.go
+++ b/pkg/proxy/service_test.go
@@ -51,7 +51,7 @@ func TestImplLoadTestServiceServer_Get(t *testing.T) {
 					Name:            "aaa",
 					DistributedPods: 1,
 					Phase:           grpcProxyV2.LoadTestPhase_LOAD_TEST_PHASE_RUNNING,
-					Tags:            []*grpcProxyV2.Tag{{Key: "team", Value: "kangal"}},
+					Tags:            map[string]string{"team": "kangal"},
 					HasEnvVars:      false,
 					HasTestData:     false,
 					Type:            grpcProxyV2.LoadTestType_LOAD_TEST_TYPE_JMETER,

--- a/proto/grpc/proxy/v2/proxy.proto
+++ b/proto/grpc/proxy/v2/proxy.proto
@@ -5,11 +5,6 @@ import "google/api/annotations.proto";
 
 option go_package = "grpc/proxy/v2";
 
-message Tag {
-    string key = 1;
-    string value = 2;
-}
-
 enum LoadTestType {
     LOAD_TEST_TYPE_UNSPECIFIED = 0;
     LOAD_TEST_TYPE_JMETER = 1;
@@ -31,7 +26,7 @@ message LoadTestStatus {
     string name = 1;
     int32 distributed_pods = 2;
     LoadTestPhase phase = 3;
-    repeated Tag tags = 4;
+    map<string, string> tags = 4;
     bool has_env_vars = 5;
     bool has_test_data = 6;
     LoadTestType type = 7;
@@ -46,7 +41,7 @@ message GetResponse {
 }
 
 message ListRequest {
-    repeated Tag tags = 1;
+    map<string, string> tags = 1;
     int64 limit = 2;
     string continue = 3;
 }

--- a/proto/grpc/proxy/v2/proxy.proto
+++ b/proto/grpc/proxy/v2/proxy.proto
@@ -3,6 +3,8 @@ package grpc.proxy.v2;
 
 import "google/api/annotations.proto";
 
+option go_package = "grpc/proxy/v2";
+
 message Tag {
     string key = 1;
     string value = 2;


### PR DESCRIPTION
Minor improvements for protobuf tooling:
- finally found out how to use `go_package` correctly to get rid of warnings from transpiler
- use map for tags as they are map actually internally