### PR TITLE
EES-4696 - Updating log levels for controller and proxy

### DIFF
--- a/charts/kangal/Chart.yaml
+++ b/charts/kangal/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - performance tests
   - tests runner
 name: kangal
-version: 1.4.2
+version: 1.4.3
 home: https://github.com/hellofresh/kangal
 icon: https://raw.githubusercontent.com/hellofresh/kangal/master/kangal_logo.svg
 maintainers:

--- a/charts/kangal/templates/clusterrole.yaml
+++ b/charts/kangal/templates/clusterrole.yaml
@@ -3,7 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     kubernetes.io/bootstrapping: rbac-defaults
-  name: system:controller:kangal-controller:{{ $.Release.Namespace }}
+  name: system-controller-kangal-controller-{{ $.Release.Namespace }}
 rules:
 
   - apiGroups:

--- a/charts/kangal/templates/clusterrolebinding.yaml
+++ b/charts/kangal/templates/clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system:controller:kangal-controller:{{ $.Release.Namespace }}
+  name: system-controller-kangal-controller-{{ $.Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/kangal/values.yaml
+++ b/charts/kangal/values.yaml
@@ -63,7 +63,7 @@ proxy:
   # Health check
   livenessProbe:
     httpGet:
-      path: /
+      path: /status
       port: http
     initialDelaySeconds: 15
     periodSeconds: 10

--- a/pkg/controller/loadtest.go
+++ b/pkg/controller/loadtest.go
@@ -255,7 +255,7 @@ func (c *Controller) processNextWorkItem() bool {
 		// Finally, if no error occurs we Forget this item so it does not
 		// get queued again until another change happens.
 		c.workQueue.Forget(obj)
-		c.logger.Info("Successfully synced", zap.String("loadTest", key))
+		c.logger.Debug("Successfully synced", zap.String("loadTest", key))
 		return nil
 	}(obj)
 
@@ -390,7 +390,7 @@ func (c *Controller) handleObject(obj interface{}) {
 		c.logger.Debug("Processing object", zap.String("loadtest", object.GetName()))
 		foo, err := c.loadtestsLister.Get(ownerRef.Name)
 		if err != nil {
-			c.logger.Info("ignoring orphaned object", zap.String("loadtest", object.GetSelfLink()),
+			c.logger.Debug("ignoring orphaned object", zap.String("loadtest", object.GetSelfLink()),
 				zap.String("object_owner", ownerRef.Name))
 			return
 		}

--- a/pkg/core/middleware/request_logger.go
+++ b/pkg/core/middleware/request_logger.go
@@ -9,8 +9,6 @@ import (
 	"go.uber.org/zap"
 )
 
-var static = [...]string{".css", ".js", ".png", ".jpg", ".jpeg", ".ico"}
-
 // RequestLogger is a struct for logging request
 type RequestLogger struct{}
 
@@ -39,7 +37,7 @@ func (m *RequestLogger) Handler(next http.Handler) http.Handler {
 			zap.String("duration-fmt", m.Duration.String()),
 		)
 
-		if IsStaticRequest(r) {
+		if IsStatusRequest(r) {
 			logEntry.Debug("Finished serving request")
 			return
 		}
@@ -48,12 +46,10 @@ func (m *RequestLogger) Handler(next http.Handler) http.Handler {
 	})
 }
 
-// IsStaticRequest checks extension suffix
-func IsStaticRequest(r *http.Request) bool {
-	for _, ext := range static {
-		if strings.HasSuffix(r.URL.Path, ext) {
-			return true
-		}
+// IsStatusRequest checks if the request is a health check request
+func IsStatusRequest(r *http.Request) bool {
+	if strings.HasSuffix(r.URL.Path, "status") {
+		return true
 	}
 
 	return false


### PR DESCRIPTION
This PR is dedicated to reducing the number of unnecessary logs:
- changes endpoint for health check from `/` to `/status`
- excludes log for requesting `/status` from info level
- excludes log for syncing load tests from info level