### PR TITLE
EES-4643 Minor tests cleanup to make them a bit clearer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ tools: $(tools/protoc) $(tools/protobuf) $(tools/protoc-gen-go) $(tools/protoc-g
 .PHONY: tools
 
 dev-lint: protoc
-	@printf "$(OK_COLOR)==> Linting ProtoBuf$(NO_COLOR)\n"
+	@printf "$(OK_COLOR)==> Linting code$(NO_COLOR)\n"
 	@docker run --rm -v $(CURDIR):/app -w /app golangci/golangci-lint:v1.33.0 golangci-lint run -v
 
 dev-buf: protoc

--- a/pkg/proxy/proxy_integration_test.go
+++ b/pkg/proxy/proxy_integration_test.go
@@ -54,8 +54,7 @@ func TestIntegrationCreateLoadtestFormPostAllFiles(t *testing.T) {
 	var createdLoadTestName string
 
 	t.Run("Creates the loadtest", func(t *testing.T) {
-		request, err := createRequestWrapper(requestFiles, distributedPods, string(loadtestType), tagsString, false)
-		require.NoError(t, err)
+		request := createRequestWrapper(t, requestFiles, distributedPods, string(loadtestType), tagsString, false)
 
 		resp, err := http.Post(fmt.Sprintf("http://localhost:%d/load-test", httpPort), request.contentType, request.body)
 		require.NoError(t, err, "Could not create POST request")
@@ -104,8 +103,7 @@ func TestIntegrationCreateLoadtestDuplicates(t *testing.T) {
 	var createdLoadTestName string
 
 	t.Run("Creates first loadtest, must succeed", func(t *testing.T) {
-		request, err := createRequestWrapper(requestFiles, distributedPods, string(loadtestType), "", false)
-		require.NoError(t, err)
+		request := createRequestWrapper(t, requestFiles, distributedPods, string(loadtestType), "", false)
 
 		resp, err := http.Post(fmt.Sprintf("http://localhost:%d/load-test", httpPort), request.contentType, request.body)
 		require.NoError(t, err, "Could not create POST request")
@@ -120,8 +118,7 @@ func TestIntegrationCreateLoadtestDuplicates(t *testing.T) {
 	})
 
 	t.Run("Creates second loadtest, must fail", func(t *testing.T) {
-		request, err := createRequestWrapper(requestFiles, distributedPods, string(loadtestType), "", false)
-		require.NoError(t, err)
+		request := createRequestWrapper(t, requestFiles, distributedPods, string(loadtestType), "", false)
 
 		resp, err := http.Post(fmt.Sprintf("http://localhost:%d/load-test", httpPort), request.contentType, request.body)
 		require.NoError(t, err, "Could not create POST request")
@@ -152,8 +149,7 @@ func TestIntegrationCreateLoadtestReachMaxLimit(t *testing.T) {
 	var createdLoadTestName string
 
 	t.Run("Creates first loadtest, must succeed", func(t *testing.T) {
-		request, err := createRequestWrapper(requestFiles, distributedPods, string(loadtestType), "", false)
-		require.NoError(t, err)
+		request := createRequestWrapper(t, requestFiles, distributedPods, string(loadtestType), "", false)
 
 		resp, err := http.Post(fmt.Sprintf("http://localhost:%d/load-test", httpPort), request.contentType, request.body)
 		require.NoError(t, err, "Could not create POST request")
@@ -171,8 +167,7 @@ func TestIntegrationCreateLoadtestReachMaxLimit(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Creates second loadtest, must fail", func(t *testing.T) {
-		request, err := createRequestWrapper(requestFilesSecond, distributedPods, string(loadtestType), "", false)
-		require.NoError(t, err)
+		request := createRequestWrapper(t, requestFilesSecond, distributedPods, string(loadtestType), "", false)
 
 		resp, err := http.Post(fmt.Sprintf("http://localhost:%d/load-test", httpPort), request.contentType, request.body)
 		require.NoError(t, err, "Could not create POST request")
@@ -197,8 +192,7 @@ func TestIntegrationCreateLoadtestFormPostOneFile(t *testing.T) {
 	var createdLoadTestName string
 
 	t.Run("Creates the loadtest", func(t *testing.T) {
-		request, err := createRequestWrapper(requestFiles, distributedPods, string(loadtestType), "", false)
-		require.NoError(t, err)
+		request := createRequestWrapper(t, requestFiles, distributedPods, string(loadtestType), "", false)
 
 		resp, err := http.Post(fmt.Sprintf("http://localhost:%d/load-test", httpPort), request.contentType, request.body)
 		require.NoError(t, err, "Could not create POST request")
@@ -245,8 +239,7 @@ func TestIntegrationCreateLoadtestEmptyTestFile(t *testing.T) {
 	var body io.ReadCloser
 
 	t.Run("Creates the loadtest with empty testFile", func(t *testing.T) {
-		request, err := createRequestWrapper(requestFiles, distributedPods, string(loadtestType), "", false)
-		require.NoError(t, err)
+		request := createRequestWrapper(t, requestFiles, distributedPods, string(loadtestType), "", false)
 
 		resp, err := http.Post(fmt.Sprintf("http://localhost:%d/load-test", httpPort), request.contentType, request.body)
 		require.NoError(t, err, "Could not create POST request")
@@ -292,8 +285,7 @@ func TestIntegrationCreateLoadtestEmptyTestDataFile(t *testing.T) {
 	var body io.ReadCloser
 
 	t.Run("Creates the loadtest", func(t *testing.T) {
-		request, err := createRequestWrapper(requestFiles, distributedPods, string(loadtestType), "", false)
-		require.NoError(t, err)
+		request := createRequestWrapper(t, requestFiles, distributedPods, string(loadtestType), "", false)
 
 		resp, err := http.Post(fmt.Sprintf("http://localhost:%d/load-test", httpPort), request.contentType, request.body)
 		require.NoError(t, err, "Could not create POST request")

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/go-chi/chi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 	corev1 "k8s.io/api/core/v1"
 	k8sAPIErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -106,11 +105,8 @@ func TestHTTPValidator(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			request, err := buildMocFormReq(tt.requestFiles, tt.distributedPods, tt.loadTestType, "")
-			if err != nil {
-				t.Error(err)
-				t.FailNow()
-			}
+			request := buildMocFormReq(t, tt.requestFiles, tt.distributedPods, tt.loadTestType, "")
+
 			result := httpValidator(request)
 			assert.Equal(t, tt.expectedResponse, result.Get(tt.failingLine))
 		})
@@ -138,12 +134,7 @@ func TestCreateWithTimeout(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			request, err := buildMocFormReq(tt.requestFiles, tt.distributedPods, tt.loadTestType, "")
-
-			if err != nil {
-				t.Error(err)
-				t.FailNow()
-			}
+			request := buildMocFormReq(t, tt.requestFiles, tt.distributedPods, tt.loadTestType, "")
 
 			// Pass a context with a timeout to tell a blocking function that it
 			// should abandon its work after the timeout elapses.
@@ -331,7 +322,7 @@ func TestProxyCreate(t *testing.T) {
 				"testFile": "testdata/valid/loadtest.jmx",
 			},
 			http.StatusCreated,
-			"{\"type\":\"JMeter\",\"distributedPods\":10,\"phase\":\"creating\",\"tags\":{\"team\":\"kangal\"},\"hasEnvVars\":false,\"hasTestData\":false}\n",
+			`{"type":"JMeter","distributedPods":10,"phase":"creating","tags":{"team":"kangal"},"hasEnvVars":false,"hasTestData":false}` + "\n",
 			"application/json; charset=utf-8",
 			nil,
 		},
@@ -346,7 +337,7 @@ func TestProxyCreate(t *testing.T) {
 				"envVars":  "testdata/valid/envvars.csv",
 			},
 			http.StatusCreated,
-			"{\"type\":\"Fake\",\"distributedPods\":10,\"phase\":\"creating\",\"tags\":{},\"hasEnvVars\":true,\"hasTestData\":true}\n",
+			`{"type":"Fake","distributedPods":10,"phase":"creating","tags":{},"hasEnvVars":true,"hasTestData":true}` + "\n",
 			"application/json; charset=utf-8",
 			nil,
 		},
@@ -359,7 +350,7 @@ func TestProxyCreate(t *testing.T) {
 				"testFile": "testdata/valid/loadtest.jmx",
 			},
 			http.StatusConflict,
-			"{\"error\":\"test creation error\"}\n",
+			`{"error":"test creation error"}` + "\n",
 			"application/json; charset=utf-8",
 			errors.New("test creation error"),
 		},
@@ -431,7 +422,7 @@ func TestNewProxyRecreate(t *testing.T) {
 					},
 				},
 			},
-			"{\"error\":\"Load test with given testfile already exists, aborting. Please delete existing load test and try again.\"}\n",
+			`{"error":"Load test with given testfile already exists, aborting. Please delete existing load test and try again."}` + "\n",
 			http.StatusBadRequest,
 			false,
 			nil,
@@ -452,7 +443,7 @@ func TestNewProxyRecreate(t *testing.T) {
 					},
 				},
 			},
-			"{\"error\":\"loadtests.kangal.hellofresh.com \\\"\\\" not found\"}\n",
+			`{"error":"loadtests.kangal.hellofresh.com \"\" not found"}` + "\n",
 			http.StatusConflict,
 			true,
 			nil,
@@ -510,7 +501,7 @@ func TestProxyCreateWithErrors(t *testing.T) {
 	}{
 		{
 			"Limit exceeded",
-			"{\"error\":\"Number of active load tests reached limit\"}\n",
+			`{"error":"Number of active load tests reached limit"}` + "\n",
 			http.StatusTooManyRequests,
 			&apisLoadTestV1.LoadTestList{
 				Items: []apisLoadTestV1.LoadTest{
@@ -526,7 +517,7 @@ func TestProxyCreateWithErrors(t *testing.T) {
 		},
 		{
 			"Can't count tests",
-			"{\"error\":\"Could not count active load tests\"}\n",
+			`{"error":"Could not count active load tests"}` + "\n",
 			http.StatusInternalServerError,
 			&apisLoadTestV1.LoadTestList{
 				Items: []apisLoadTestV1.LoadTest{},
@@ -536,7 +527,7 @@ func TestProxyCreateWithErrors(t *testing.T) {
 		},
 		{
 			"Can't count labeled tests",
-			"{\"error\":\"Could not count active load tests with given hash\"}\n",
+			`{"error":"Could not count active load tests with given hash"}` + "\n",
 			http.StatusInternalServerError,
 			&apisLoadTestV1.LoadTestList{},
 			nil,
@@ -581,10 +572,7 @@ func TestProxyCreateWithErrors(t *testing.T) {
 				"testFile": "testdata/valid/loadtest.jmx",
 			}
 			requestWrap, err := createRequestWrapper(requestFiles, "2", "Fake", "", false)
-			if nil != err {
-				t.Error(err)
-				t.FailNow()
-			}
+			require.NoError(t, err)
 
 			req := httptest.NewRequest("POST", "http://example.com/load-test", requestWrap.body)
 			req = req.WithContext(ctx)
@@ -657,7 +645,7 @@ func TestProxyGet(t *testing.T) {
 			})
 			c := kube.NewClient(loadtestClientSet.KangalV1().LoadTests(), kubeClientSet, logger)
 			b := backends.New(
-				backends.WithLogger(zap.NewNop()),
+				backends.WithLogger(logger),
 			)
 
 			req := httptest.NewRequest("GET", "http://example.com/load-test/testname", nil)
@@ -693,7 +681,7 @@ func TestProxyDelete(t *testing.T) {
 		{
 			"Error on deleting test",
 			http.StatusBadRequest,
-			"{\"error\":\"some error\"}\n",
+			`{"error":"some error"}` + "\n",
 			errors.New("some error"),
 		},
 	} {
@@ -748,7 +736,7 @@ func TestProxyGetLogs(t *testing.T) {
 					Namespace: "",
 				}},
 			http.StatusNoContent,
-			"{\"error\":\"no logs found in load test resources\"}\n",
+			`{"error":"no logs found in load test resources"}` + "\n",
 			nil,
 			nil,
 			"",
@@ -761,7 +749,7 @@ func TestProxyGetLogs(t *testing.T) {
 					Namespace: "aaa",
 				}},
 			http.StatusBadRequest,
-			"{\"error\":\"error on listing pods\"}\n",
+			`{"error":"error on listing pods"}` + "\n",
 			nil,
 			errors.New("error on listing pods"),
 			"",
@@ -780,7 +768,7 @@ func TestProxyGetLogs(t *testing.T) {
 				},
 			},
 			http.StatusBadRequest,
-			"{\"error\":\"error on getting loadtest\"}\n",
+			`{"error":"error on getting loadtest"}` + "\n",
 			errors.New("error on getting loadtest"),
 			nil,
 			"",
@@ -828,16 +816,15 @@ func TestProxyGetLogs(t *testing.T) {
 
 }
 
-func buildMocFormReq(requestFiles map[string]string, distributedPods, ltType, tagsString string) (*http.Request, error) {
+func buildMocFormReq(t *testing.T, requestFiles map[string]string, distributedPods, ltType, tagsString string) *http.Request {
+	t.Helper()
+
 	request, err := createRequestWrapper(requestFiles, distributedPods, ltType, tagsString, false)
-	if err != nil {
-		return nil, err
-	}
+	require.NoError(t, err)
 
 	req, err := http.NewRequest("POST", "/load-test", request.body)
-	if err != nil {
-		return nil, err
-	}
+	require.NoError(t, err)
+
 	req.Header.Set("Content-Type", request.contentType)
-	return req, nil
+	return req
 }

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -377,7 +377,7 @@ func TestProxyCreate(t *testing.T) {
 			testProxyHandler := NewProxy(1, b, c)
 			handler := testProxyHandler.Create
 
-			requestWrap, _ := createRequestWrapper(tt.requestFiles, strconv.Itoa(tt.distributedPods), string(tt.loadTestType), tt.tagsString, false)
+			requestWrap := createRequestWrapper(t, tt.requestFiles, strconv.Itoa(tt.distributedPods), string(tt.loadTestType), tt.tagsString, false)
 
 			req := httptest.NewRequest("POST", "http://example.com/foo", requestWrap.body)
 			req.Header.Set("Content-Type", requestWrap.contentType)
@@ -470,7 +470,7 @@ func TestNewProxyRecreate(t *testing.T) {
 			requestFiles := map[string]string{
 				"testFile": "testdata/valid/loadtest.jmx",
 			}
-			requestWrap, _ := createRequestWrapper(requestFiles, "2", "Fake", "", tt.overwrite)
+			requestWrap := createRequestWrapper(t, requestFiles, "2", "Fake", "", tt.overwrite)
 
 			req := httptest.NewRequest("POST", "http://example.com/load-test", requestWrap.body)
 			req = req.WithContext(ctx)
@@ -571,8 +571,7 @@ func TestProxyCreateWithErrors(t *testing.T) {
 			requestFiles := map[string]string{
 				"testFile": "testdata/valid/loadtest.jmx",
 			}
-			requestWrap, err := createRequestWrapper(requestFiles, "2", "Fake", "", false)
-			require.NoError(t, err)
+			requestWrap := createRequestWrapper(t, requestFiles, "2", "Fake", "", false)
 
 			req := httptest.NewRequest("POST", "http://example.com/load-test", requestWrap.body)
 			req = req.WithContext(ctx)
@@ -819,8 +818,7 @@ func TestProxyGetLogs(t *testing.T) {
 func buildMocFormReq(t *testing.T, requestFiles map[string]string, distributedPods, ltType, tagsString string) *http.Request {
 	t.Helper()
 
-	request, err := createRequestWrapper(requestFiles, distributedPods, ltType, tagsString, false)
-	require.NoError(t, err)
+	request := createRequestWrapper(t, requestFiles, distributedPods, ltType, tagsString, false)
 
 	req, err := http.NewRequest("POST", "/load-test", request.body)
 	require.NoError(t, err)

--- a/pkg/proxy/request_test.go
+++ b/pkg/proxy/request_test.go
@@ -9,20 +9,16 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 
 	apisLoadTestV1 "github.com/hellofresh/kangal/pkg/kubernetes/apis/loadtest/v1"
 )
 
 func TestNewFakeFromHTTPLoadTest(t *testing.T) {
 	ltType := apisLoadTestV1.LoadTestTypeFake
-	r, err := buildMocFormReq(map[string]string{}, "", string(ltType), "")
-	if err != nil {
-		t.Error(err)
-		t.FailNow()
-	}
+	r := buildMocFormReq(t, map[string]string{}, "", string(ltType), "")
 
-	loadTest, err := fromHTTPRequestToLoadTestSpec(r, zap.NewNop())
+	loadTest, err := fromHTTPRequestToLoadTestSpec(r, zaptest.NewLogger(t))
 	require.Error(t, err)
 	assert.Equal(t, apisLoadTestV1.LoadTestSpec{}, loadTest)
 }
@@ -48,11 +44,7 @@ func TestDistributedPods(t *testing.T) {
 		},
 	} {
 		t.Run(ti.tag, func(t *testing.T) {
-			request, err := buildMocFormReq(map[string]string{}, ti.distributedPods, string(apisLoadTestV1.LoadTestTypeJMeter), "")
-			if err != nil {
-				t.Error(err)
-				t.FailNow()
-			}
+			request := buildMocFormReq(t, map[string]string{}, ti.distributedPods, string(apisLoadTestV1.LoadTestTypeJMeter), "")
 
 			n, err := getDistributedPods(request)
 			assert.Equal(t, n, ti.expectedResponse)
@@ -97,11 +89,7 @@ func TestTestFile(t *testing.T) {
 		},
 	} {
 		t.Run(ti.tag, func(t *testing.T) {
-			request, err := buildMocFormReq(ti.requestFile, "1", string(apisLoadTestV1.LoadTestTypeJMeter), "")
-			if err != nil {
-				t.Error(err)
-				t.FailNow()
-			}
+			request := buildMocFormReq(t, ti.requestFile, "1", string(apisLoadTestV1.LoadTestTypeJMeter), "")
 
 			n, err := getTestFile(request)
 			assert.Equal(t, ti.expectedResponse, n)
@@ -146,11 +134,7 @@ func TestDataFile(t *testing.T) {
 		},
 	} {
 		t.Run(ti.tag, func(t *testing.T) {
-			request, err := buildMocFormReq(ti.requestFile, "1", string(apisLoadTestV1.LoadTestTypeJMeter), "")
-			if err != nil {
-				t.Error(err)
-				t.FailNow()
-			}
+			request := buildMocFormReq(t, ti.requestFile, "1", string(apisLoadTestV1.LoadTestTypeJMeter), "")
 
 			n, err := getTestData(request)
 			assert.Equal(t, ti.expectedResponse, n)
@@ -195,11 +179,7 @@ func TestEnvVarFile(t *testing.T) {
 		},
 	} {
 		t.Run(ti.tag, func(t *testing.T) {
-			request, err := buildMocFormReq(ti.requestFile, "1", string(apisLoadTestV1.LoadTestTypeJMeter), "")
-			if err != nil {
-				t.Error(err)
-				t.FailNow()
-			}
+			request := buildMocFormReq(t, ti.requestFile, "1", string(apisLoadTestV1.LoadTestTypeJMeter), "")
 
 			n, err := getEnvVars(request)
 			assert.Equal(t, ti.expectedResponse, n)
@@ -260,11 +240,7 @@ func TestTags(t *testing.T) {
 		t.Run(tc.scenario, func(t *testing.T) {
 			t.Parallel()
 
-			req, err := buildMocFormReq(nil, "1", string(apisLoadTestV1.LoadTestTypeJMeter), tc.input)
-			if err != nil {
-				t.Error(err)
-				t.FailNow()
-			}
+			req := buildMocFormReq(t, nil, "1", string(apisLoadTestV1.LoadTestTypeJMeter), tc.input)
 
 			result, err := getTags(req)
 
@@ -375,13 +351,9 @@ func TestInit(t *testing.T) {
 	} {
 
 		t.Run(ti.tag, func(t *testing.T) {
-			request, err := buildMocFormReq(ti.requestFile, ti.distributedPods, string(ltType), ti.tags)
-			if err != nil {
-				t.Error(err)
-				t.FailNow()
-			}
+			request := buildMocFormReq(t, ti.requestFile, ti.distributedPods, string(ltType), ti.tags)
 
-			_, err = fromHTTPRequestToLoadTestSpec(request, zap.NewNop())
+			_, err := fromHTTPRequestToLoadTestSpec(request, zaptest.NewLogger(t))
 
 			if ti.expectError {
 				assert.Error(t, err)
@@ -402,13 +374,9 @@ func TestCheckLoadTestSpec(t *testing.T) {
 	}
 	distributedPods := "2"
 
-	request, err := buildMocFormReq(requestFiles, distributedPods, string(ltType), "label:value")
-	if err != nil {
-		t.Error(err)
-		t.FailNow()
-	}
+	request := buildMocFormReq(t, requestFiles, distributedPods, string(ltType), "label:value")
 
-	spec, err := fromHTTPRequestToLoadTestSpec(request, zap.NewNop())
+	spec, err := fromHTTPRequestToLoadTestSpec(request, zaptest.NewLogger(t))
 	require.NoError(t, err)
 
 	lt, err := apisLoadTestV1.BuildLoadTestObject(spec)


### PR DESCRIPTION
- use helper function capabilities
- use backticks to reduce number of escaped chars
- use zaptest to get logs in the failed tests output