### PR TITLE
Wait for JMeter worker pods to be running before master creation

### DIFF
--- a/pkg/backends/jmeter/resources.go
+++ b/pkg/backends/jmeter/resources.go
@@ -381,9 +381,13 @@ func (b *Backend) CreatePodsWithTestdata(ctx context.Context, configMaps []*core
 
 		// JMeter requires all workers to be running before master starts
 		// So, wait to pod be running before continue
-		watchObj, _ := b.kubeClientSet.CoreV1().Pods(namespace).Watch(ctx, metaV1.ListOptions{
+		watchObj, err := b.kubeClientSet.CoreV1().Pods(namespace).Watch(ctx, metaV1.ListOptions{
 			FieldSelector: fmt.Sprintf("metadata.name=%s", pod.ObjectMeta.Name),
 		})
+		if err != nil {
+			b.logger.Warn("unable to watch pod state", zap.Error(err))
+			continue
+		}
 		waitfor.Resource(watchObj, (waitfor.Condition{}).PodRunning)
 	}
 	b.logger.Info("Created pods with test data", zap.String("LoadTest", loadTest.GetName()), zap.String("namespace", namespace))

--- a/pkg/controller/controller_integration_test.go
+++ b/pkg/controller/controller_integration_test.go
@@ -37,6 +37,9 @@ func TestIntegrationKangalController(t *testing.T) {
 	err := CreateLoadTest(clientSet, distributedPods, expectedLoadtestName, testFile, testData, envVars, loadtestType)
 	require.NoError(t, err)
 
+	err = WaitLoadTest(clientSet, expectedLoadtestName)
+	require.NoError(t, err)
+
 	t.Cleanup(func() {
 		err := DeleteLoadTest(clientSet, expectedLoadtestName, t.Name())
 		assert.NoError(t, err)

--- a/pkg/controller/controller_integration_test.go
+++ b/pkg/controller/controller_integration_test.go
@@ -34,7 +34,7 @@ func TestIntegrationKangalController(t *testing.T) {
 
 	client := kubeClient(t)
 
-	err := CreateLoadtest(clientSet, distributedPods, expectedLoadtestName, testFile, testData, envVars, loadtestType)
+	err := CreateLoadTest(clientSet, distributedPods, expectedLoadtestName, testFile, testData, envVars, loadtestType)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -43,7 +43,7 @@ func TestIntegrationKangalController(t *testing.T) {
 	})
 
 	t.Run("Checking the name of created loadtest", func(t *testing.T) {
-		createdName, err := GetLoadtest(clientSet, expectedLoadtestName)
+		createdName, err := GetLoadTest(clientSet, expectedLoadtestName)
 		require.NoError(t, err)
 		assert.Equal(t, expectedLoadtestName, createdName)
 	})

--- a/pkg/controller/controller_integration_test.go
+++ b/pkg/controller/controller_integration_test.go
@@ -11,6 +11,7 @@ import (
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	_ "github.com/hellofresh/kangal/pkg/backends/fake"
+	"github.com/hellofresh/kangal/pkg/core/waitfor"
 	loadTestV1 "github.com/hellofresh/kangal/pkg/kubernetes/apis/loadtest/v1"
 )
 
@@ -52,7 +53,7 @@ func TestIntegrationKangalController(t *testing.T) {
 			FieldSelector: fmt.Sprintf("metadata.name=%s", expectedLoadtestName),
 		})
 
-		watchEvent, err := WaitResource(watchObj, (WaitCondition{}).Added)
+		watchEvent, err := waitfor.Resource(watchObj, (waitfor.Condition{}).Added)
 		require.NoError(t, err)
 
 		namespace := watchEvent.Object.(*coreV1.Namespace)
@@ -64,7 +65,7 @@ func TestIntegrationKangalController(t *testing.T) {
 			LabelSelector: "app=loadtest-master",
 		})
 
-		watchEvent, err := WaitResource(watchObj, (WaitCondition{}).PodRunning)
+		watchEvent, err := waitfor.Resource(watchObj, (waitfor.Condition{}).PodRunning)
 		require.NoError(t, err)
 
 		pod := watchEvent.Object.(*coreV1.Pod)
@@ -76,7 +77,7 @@ func TestIntegrationKangalController(t *testing.T) {
 			FieldSelector: fmt.Sprintf("metadata.name=%s", expectedLoadtestName),
 		})
 
-		watchEvent, err := WaitResource(watchObj, (WaitCondition{}).LoadtestRunning)
+		watchEvent, err := waitfor.Resource(watchObj, (waitfor.Condition{}).LoadTestRunning)
 		require.NoError(t, err)
 
 		loadtest := watchEvent.Object.(*loadTestV1.LoadTest)
@@ -89,7 +90,7 @@ func TestIntegrationKangalController(t *testing.T) {
 			FieldSelector: fmt.Sprintf("metadata.name=%s", expectedLoadtestName),
 		})
 
-		watchEvent, err := WaitResource(watchObj, (WaitCondition{}).LoadtestFinished)
+		watchEvent, err := waitfor.Resource(watchObj, (waitfor.Condition{}).LoadTestFinished)
 		require.NoError(t, err)
 
 		loadtest := watchEvent.Object.(*loadTestV1.LoadTest)

--- a/pkg/controller/jmeter_integration_test.go
+++ b/pkg/controller/jmeter_integration_test.go
@@ -51,7 +51,7 @@ func TestIntegrationJMeter(t *testing.T) {
 
 	client := kubeClient(t)
 
-	err := CreateLoadtest(clientSet, distributedPods, expectedLoadtestName, testFile, testData, envVars, loadtestType)
+	err := CreateLoadTest(clientSet, distributedPods, expectedLoadtestName, testFile, testData, envVars, loadtestType)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		err := DeleteLoadTest(clientSet, expectedLoadtestName, t.Name())
@@ -60,7 +60,7 @@ func TestIntegrationJMeter(t *testing.T) {
 	var jmeterNamespace *coreV1.Namespace
 
 	t.Run("Checking the name of created loadtest", func(t *testing.T) {
-		createdName, err := GetLoadtest(clientSet, expectedLoadtestName)
+		createdName, err := GetLoadTest(clientSet, expectedLoadtestName)
 		require.NoError(t, err)
 		assert.Equal(t, expectedLoadtestName, createdName)
 	})
@@ -86,7 +86,7 @@ func TestIntegrationJMeter(t *testing.T) {
 				break
 			}
 		}
-		assert.NotNil(t, len(cm.Items))
+		assert.NotEmpty(t, cm.Items)
 	})
 
 	t.Run("Checking env vars secret is created and not empty", func(t *testing.T) {
@@ -152,7 +152,7 @@ func TestIntegrationJMeter(t *testing.T) {
 
 	t.Run("Checking loadtest is in Running state", func(t *testing.T) {
 		var phase string
-		phase, err = GetLoadtestPhase(clientSet, expectedLoadtestName)
+		phase, err = GetLoadTestPhase(clientSet, expectedLoadtestName)
 		require.NoError(t, err)
 		assert.Equal(t, string(loadTestV1.LoadTestRunning), phase)
 	})

--- a/pkg/controller/jmeter_integration_test.go
+++ b/pkg/controller/jmeter_integration_test.go
@@ -111,8 +111,6 @@ func TestIntegrationJMeter(t *testing.T) {
 	t.Run("Checking all worker pods are created", func(t *testing.T) {
 		var podsCount int
 		for i := 0; i < 5; i++ {
-			//added sleep to wait for kangal controller to create all required resources
-			waitfor.Time(ShortWaitSec)
 			pods, _ := GetDistributedPods(client.CoreV1(), jmeterNamespace.Name)
 
 			if len(pods.Items) == int(distributedPods) {

--- a/pkg/controller/jmeter_integration_test.go
+++ b/pkg/controller/jmeter_integration_test.go
@@ -24,11 +24,6 @@ var (
 	clientSet clientSetV.Clientset
 )
 
-const (
-	ShortWaitSec = 1
-	LongWaitSec  = 5
-)
-
 func TestMain(m *testing.M) {
 	clientSet = kubeTestClient()
 	res := m.Run()
@@ -72,7 +67,6 @@ func TestIntegrationJMeter(t *testing.T) {
 
 	t.Run("Checking namespace is created", func(t *testing.T) {
 		for i := 0; i < 5; i++ {
-			waitfor.Time(LongWaitSec)
 			jmeterNamespace, _ = client.CoreV1().Namespaces().Get(context.Background(), expectedLoadtestName, metaV1.GetOptions{})
 			if jmeterNamespace != nil {
 				break
@@ -85,7 +79,6 @@ func TestIntegrationJMeter(t *testing.T) {
 	t.Run("Checking JMeter configmap is created", func(t *testing.T) {
 		var cm *coreV1.ConfigMapList
 		for i := 0; i < 5; i++ {
-			waitfor.Time(ShortWaitSec)
 			cm, _ = client.CoreV1().ConfigMaps(jmeterNamespace.Name).List(context.Background(), metaV1.ListOptions{LabelSelector: "app=hf-jmeter"})
 			if len(cm.Items) != 0 {
 				break
@@ -98,7 +91,6 @@ func TestIntegrationJMeter(t *testing.T) {
 		var secretsCount int
 		var secretItem coreV1.Secret
 		for i := 0; i < 5; i++ {
-			waitfor.Time(LongWaitSec)
 			secrets, err := GetSecret(client.CoreV1(), jmeterNamespace.Name)
 			require.NoError(t, err, "Could not get namespace secrets")
 
@@ -144,7 +136,6 @@ func TestIntegrationJMeter(t *testing.T) {
 	t.Run("Checking Job is created", func(t *testing.T) {
 		var job *batchV1.Job
 		for i := 0; i < 5; i++ {
-			waitfor.Time(LongWaitSec)
 			job, err = client.BatchV1().Jobs(jmeterNamespace.Name).Get(context.Background(), "loadtest-master", metaV1.GetOptions{})
 			require.NoError(t, err, "Could not get job")
 

--- a/pkg/controller/jmeter_integration_test.go
+++ b/pkg/controller/jmeter_integration_test.go
@@ -53,17 +53,22 @@ func TestIntegrationJMeter(t *testing.T) {
 
 	err := CreateLoadTest(clientSet, distributedPods, expectedLoadtestName, testFile, testData, envVars, loadtestType)
 	require.NoError(t, err)
+
+	err = WaitLoadTest(clientSet, expectedLoadtestName)
+	require.NoError(t, err)
+
 	t.Cleanup(func() {
 		err := DeleteLoadTest(clientSet, expectedLoadtestName, t.Name())
 		assert.NoError(t, err)
 	})
-	var jmeterNamespace *coreV1.Namespace
 
 	t.Run("Checking the name of created loadtest", func(t *testing.T) {
 		createdName, err := GetLoadTest(clientSet, expectedLoadtestName)
 		require.NoError(t, err)
 		assert.Equal(t, expectedLoadtestName, createdName)
 	})
+
+	var jmeterNamespace *coreV1.Namespace
 
 	t.Run("Checking namespace is created", func(t *testing.T) {
 		for i := 0; i < 5; i++ {

--- a/pkg/controller/loadtest.go
+++ b/pkg/controller/loadtest.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/hellofresh/kangal/pkg/backends"
 	"github.com/hellofresh/kangal/pkg/core/observability"
+	kubekangal "github.com/hellofresh/kangal/pkg/kubernetes"
 	loadtestV1 "github.com/hellofresh/kangal/pkg/kubernetes/apis/loadtest/v1"
 	clientSetV "github.com/hellofresh/kangal/pkg/kubernetes/generated/clientset/versioned"
 	sampleScheme "github.com/hellofresh/kangal/pkg/kubernetes/generated/clientset/versioned/scheme"
@@ -32,10 +33,8 @@ import (
 
 const (
 	controllerAgentName = "kangal"
-	// KubeTimeout timeout for kubernetes methods
-	KubeTimeout = 15 * time.Second
-	falseString = "false"
-	trueString  = "true"
+	falseString         = "false"
+	trueString          = "true"
 )
 
 // Controller is the controller implementation for LoadTest resources
@@ -275,7 +274,7 @@ func (c *Controller) processNextWorkItem() bool {
 // converge the two. It then updates the Status block of the LoadTest resource
 // with the current status of the resource.
 func (c *Controller) syncHandler(key string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), kubekangal.KubeTimeout)
 	defer cancel()
 
 	_, name, err := cache.SplitMetaNamespaceKey(key)

--- a/pkg/controller/test_helper.go
+++ b/pkg/controller/test_helper.go
@@ -5,17 +5,16 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"time"
 
 	coreV1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/watch"
 	typeV1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	watchtools "k8s.io/client-go/tools/watch"
 
 	"github.com/hellofresh/kangal/pkg/backends"
+	"github.com/hellofresh/kangal/pkg/core/waitfor"
+	"github.com/hellofresh/kangal/pkg/kubernetes"
 	apisLoadTestV1 "github.com/hellofresh/kangal/pkg/kubernetes/apis/loadtest/v1"
 	clientSetV "github.com/hellofresh/kangal/pkg/kubernetes/generated/clientset/versioned"
 )
@@ -69,7 +68,7 @@ func CreateLoadtest(clientSet clientSetV.Clientset, pods int32, name, testFile, 
 	ltObj.Name = name
 	ltObj.Spec = loadTestSpec
 
-	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), kubernetes.KubeTimeout)
 	defer cancel()
 
 	_, err = clientSet.KangalV1().LoadTests().Create(ctx, ltObj, metaV1.CreateOptions{})
@@ -97,7 +96,7 @@ func WaitLoadtest(clientSet clientSetV.Clientset, loadtestName string) error {
 		return err
 	}
 
-	_, err = WaitResource(watchObj, (WaitCondition{}).LoadtestRunning)
+	_, err = waitfor.Resource(watchObj, (waitfor.Condition{}).LoadTestRunning)
 
 	return err
 }
@@ -105,7 +104,7 @@ func WaitLoadtest(clientSet clientSetV.Clientset, loadtestName string) error {
 // DeleteLoadTest deletes a load test CR
 func DeleteLoadTest(clientSet clientSetV.Clientset, loadtestName string, testname string) error {
 	fmt.Printf("Deleting object %v for the test %v \n", loadtestName, testname)
-	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), kubernetes.KubeTimeout)
 	defer cancel()
 
 	if err := clientSet.KangalV1().LoadTests().Delete(ctx, loadtestName, metaV1.DeleteOptions{}); err != nil {
@@ -116,7 +115,7 @@ func DeleteLoadTest(clientSet clientSetV.Clientset, loadtestName string, testnam
 
 // GetLoadtest returns a load test name
 func GetLoadtest(clientSet clientSetV.Clientset, loadtestName string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), kubernetes.KubeTimeout)
 	defer cancel()
 
 	result, err := clientSet.KangalV1().LoadTests().Get(ctx, loadtestName, metaV1.GetOptions{})
@@ -128,7 +127,7 @@ func GetLoadtest(clientSet clientSetV.Clientset, loadtestName string) (string, e
 
 // GetLoadtestTestdata returns a load test name
 func GetLoadtestTestdata(clientSet clientSetV.Clientset, loadtestName string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), kubernetes.KubeTimeout)
 	defer cancel()
 
 	result, err := clientSet.KangalV1().LoadTests().Get(ctx, loadtestName, metaV1.GetOptions{})
@@ -140,7 +139,7 @@ func GetLoadtestTestdata(clientSet clientSetV.Clientset, loadtestName string) (s
 
 // GetLoadtestLabels returns load test labels.
 func GetLoadtestLabels(clientSet clientSetV.Clientset, loadtestName string) (map[string]string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), kubernetes.KubeTimeout)
 	defer cancel()
 
 	result, err := clientSet.KangalV1().LoadTests().Get(ctx, loadtestName, metaV1.GetOptions{})
@@ -152,7 +151,7 @@ func GetLoadtestLabels(clientSet clientSetV.Clientset, loadtestName string) (map
 
 // GetLoadtestEnvVars returns a load test name
 func GetLoadtestEnvVars(clientSet clientSetV.Clientset, loadtestName string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), kubernetes.KubeTimeout)
 	defer cancel()
 
 	result, err := clientSet.KangalV1().LoadTests().Get(ctx, loadtestName, metaV1.GetOptions{})
@@ -164,7 +163,7 @@ func GetLoadtestEnvVars(clientSet clientSetV.Clientset, loadtestName string) (st
 
 // GetLoadtestNamespace returns a load test namespace
 func GetLoadtestNamespace(clientSet clientSetV.Clientset, loadtestName string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), kubernetes.KubeTimeout)
 	defer cancel()
 
 	result, err := clientSet.KangalV1().LoadTests().Get(ctx, loadtestName, metaV1.GetOptions{})
@@ -176,7 +175,7 @@ func GetLoadtestNamespace(clientSet clientSetV.Clientset, loadtestName string) (
 
 // GetLoadtestPhase returns the current phase of given loadtest
 func GetLoadtestPhase(clientSet clientSetV.Clientset, loadtestName string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), kubernetes.KubeTimeout)
 	defer cancel()
 
 	result, err := clientSet.KangalV1().LoadTests().Get(ctx, loadtestName, metaV1.GetOptions{})
@@ -188,7 +187,7 @@ func GetLoadtestPhase(clientSet clientSetV.Clientset, loadtestName string) (stri
 
 // GetDistributedPods returns a number of distributed pods in load test namespace
 func GetDistributedPods(clientSet typeV1.CoreV1Interface, namespace string) (coreV1.PodList, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), kubernetes.KubeTimeout)
 	defer cancel()
 
 	opts := metaV1.ListOptions{
@@ -203,7 +202,7 @@ func GetDistributedPods(clientSet typeV1.CoreV1Interface, namespace string) (cor
 
 // GetSecret returns a list of created secrets according to the given label
 func GetSecret(clientSet typeV1.CoreV1Interface, namespace string) (coreV1.SecretList, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), kubernetes.KubeTimeout)
 	defer cancel()
 
 	opts := metaV1.ListOptions{
@@ -224,62 +223,4 @@ func BuildConfig() (*rest.Config, error) {
 		return nil, err
 	}
 	return config, nil
-}
-
-// WaitCondition contains useful functions for watch conditions
-type WaitCondition struct {
-}
-
-// Added waits until resources exists
-func (WaitCondition) Added(event watch.Event) (bool, error) {
-	if watch.Added == event.Type {
-		return true, nil
-	}
-
-	return false, nil
-}
-
-// PodRunning waits until Pod are with status phase running
-func (WaitCondition) PodRunning(event watch.Event) (bool, error) {
-	if coreV1.PodRunning == event.Object.(*coreV1.Pod).Status.Phase {
-		return true, nil
-	}
-
-	return false, nil
-}
-
-// LoadtestRunning waits until Loadtest are with status phase running
-func (WaitCondition) LoadtestRunning(event watch.Event) (bool, error) {
-	if apisLoadTestV1.LoadTestRunning == event.Object.(*apisLoadTestV1.LoadTest).Status.Phase {
-		return true, nil
-	}
-
-	return false, nil
-}
-
-// LoadtestFinished waits until Loadtest are with status phase finished
-func (WaitCondition) LoadtestFinished(event watch.Event) (bool, error) {
-	if apisLoadTestV1.LoadTestFinished == event.Object.(*apisLoadTestV1.LoadTest).Status.Phase {
-		return true, nil
-	}
-
-	return false, nil
-}
-
-// WaitResource waits until a kubernetes resources to match a condition
-func WaitResource(obj watch.Interface, condFunc watchtools.ConditionFunc) (*watch.Event, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
-	defer cancel()
-
-	return watchtools.UntilWithoutRetry(ctx, obj, condFunc)
-}
-
-// WaitResourceWithContext is WaitResource with custom context when the default context is not suitable
-func WaitResourceWithContext(ctx context.Context, obj watch.Interface, condFunc watchtools.ConditionFunc) (*watch.Event, error) {
-	return watchtools.UntilWithoutRetry(ctx, obj, condFunc)
-}
-
-// WaitForResource sleeps to wait kubernetes resources to be created
-func WaitForResource(d time.Duration) {
-	time.Sleep(d * time.Second)
 }

--- a/pkg/controller/test_helper.go
+++ b/pkg/controller/test_helper.go
@@ -19,8 +19,8 @@ import (
 	clientSetV "github.com/hellofresh/kangal/pkg/kubernetes/generated/clientset/versioned"
 )
 
-// CreateLoadtest creates a load test CR
-func CreateLoadtest(clientSet clientSetV.Clientset, pods int32, name, testFile, testData, envVars string, loadTestType apisLoadTestV1.LoadTestType) error {
+// CreateLoadTest creates a load test CR
+func CreateLoadTest(clientSet clientSetV.Clientset, pods int32, name, testFile, testData, envVars string, loadTestType apisLoadTestV1.LoadTestType) error {
 	var ev, td = "", ""
 	tf, err := readFile(testFile)
 	if err != nil {
@@ -87,8 +87,8 @@ func readFile(filename string) (string, error) {
 	return str, nil
 }
 
-// WaitLoadtest waits until Loadtest resources exists
-func WaitLoadtest(clientSet clientSetV.Clientset, loadtestName string) error {
+// WaitLoadTest waits until Loadtest resources exists
+func WaitLoadTest(clientSet clientSetV.Clientset, loadtestName string) error {
 	watchObj, err := clientSet.KangalV1().LoadTests().Watch(context.Background(), metaV1.ListOptions{
 		FieldSelector: fmt.Sprintf("metadata.name=%s", loadtestName),
 	})
@@ -113,8 +113,8 @@ func DeleteLoadTest(clientSet clientSetV.Clientset, loadtestName string, testnam
 	return nil
 }
 
-// GetLoadtest returns a load test name
-func GetLoadtest(clientSet clientSetV.Clientset, loadtestName string) (string, error) {
+// GetLoadTest returns a load test name
+func GetLoadTest(clientSet clientSetV.Clientset, loadtestName string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), kubernetes.KubeTimeout)
 	defer cancel()
 
@@ -125,8 +125,8 @@ func GetLoadtest(clientSet clientSetV.Clientset, loadtestName string) (string, e
 	return result.Name, nil
 }
 
-// GetLoadtestTestdata returns a load test name
-func GetLoadtestTestdata(clientSet clientSetV.Clientset, loadtestName string) (string, error) {
+// GetLoadTestTestdata returns a load test name
+func GetLoadTestTestdata(clientSet clientSetV.Clientset, loadtestName string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), kubernetes.KubeTimeout)
 	defer cancel()
 
@@ -137,8 +137,8 @@ func GetLoadtestTestdata(clientSet clientSetV.Clientset, loadtestName string) (s
 	return result.Spec.TestData, nil
 }
 
-// GetLoadtestLabels returns load test labels.
-func GetLoadtestLabels(clientSet clientSetV.Clientset, loadtestName string) (map[string]string, error) {
+// GetLoadTestLabels returns load test labels.
+func GetLoadTestLabels(clientSet clientSetV.Clientset, loadtestName string) (map[string]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), kubernetes.KubeTimeout)
 	defer cancel()
 
@@ -149,8 +149,8 @@ func GetLoadtestLabels(clientSet clientSetV.Clientset, loadtestName string) (map
 	return result.Labels, nil
 }
 
-// GetLoadtestEnvVars returns a load test name
-func GetLoadtestEnvVars(clientSet clientSetV.Clientset, loadtestName string) (string, error) {
+// GetLoadTestEnvVars returns a load test name
+func GetLoadTestEnvVars(clientSet clientSetV.Clientset, loadtestName string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), kubernetes.KubeTimeout)
 	defer cancel()
 
@@ -161,8 +161,8 @@ func GetLoadtestEnvVars(clientSet clientSetV.Clientset, loadtestName string) (st
 	return result.Spec.EnvVars, nil
 }
 
-// GetLoadtestNamespace returns a load test namespace
-func GetLoadtestNamespace(clientSet clientSetV.Clientset, loadtestName string) (string, error) {
+// GetLoadTestNamespace returns a load test namespace
+func GetLoadTestNamespace(clientSet clientSetV.Clientset, loadtestName string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), kubernetes.KubeTimeout)
 	defer cancel()
 
@@ -173,8 +173,8 @@ func GetLoadtestNamespace(clientSet clientSetV.Clientset, loadtestName string) (
 	return result.Status.Namespace, nil
 }
 
-// GetLoadtestPhase returns the current phase of given loadtest
-func GetLoadtestPhase(clientSet clientSetV.Clientset, loadtestName string) (string, error) {
+// GetLoadTestPhase returns the current phase of given loadtest
+func GetLoadTestPhase(clientSet clientSetV.Clientset, loadtestName string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), kubernetes.KubeTimeout)
 	defer cancel()
 

--- a/pkg/core/waitfor/waitfor.go
+++ b/pkg/core/waitfor/waitfor.go
@@ -2,7 +2,6 @@ package waitfor
 
 import (
 	"context"
-	"time"
 
 	coreV1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/watch"
@@ -63,9 +62,4 @@ func Resource(obj watch.Interface, condFunc watchtools.ConditionFunc) (*watch.Ev
 // ResourceWithContext is Resource with custom context when the default context is not suitable
 func ResourceWithContext(ctx context.Context, obj watch.Interface, condFunc watchtools.ConditionFunc) (*watch.Event, error) {
 	return watchtools.UntilWithoutRetry(ctx, obj, condFunc)
-}
-
-// Time sleeps to wait kubernetes resources to be created
-func Time(d time.Duration) {
-	time.Sleep(d * time.Second)
 }

--- a/pkg/core/waitfor/waitfor.go
+++ b/pkg/core/waitfor/waitfor.go
@@ -1,0 +1,71 @@
+package waitfor
+
+import (
+	"context"
+	"time"
+
+	coreV1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	watchtools "k8s.io/client-go/tools/watch"
+
+	"github.com/hellofresh/kangal/pkg/kubernetes"
+	apisLoadTestV1 "github.com/hellofresh/kangal/pkg/kubernetes/apis/loadtest/v1"
+)
+
+// Condition contains useful functions for watch conditions
+type Condition struct {
+}
+
+// Added waits until resources exists
+func (Condition) Added(event watch.Event) (bool, error) {
+	if watch.Added == event.Type {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// PodRunning waits until Pod are with status phase running
+func (Condition) PodRunning(event watch.Event) (bool, error) {
+	if coreV1.PodRunning == event.Object.(*coreV1.Pod).Status.Phase {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// LoadTestRunning waits until Loadtest are with status phase running
+func (Condition) LoadTestRunning(event watch.Event) (bool, error) {
+	if apisLoadTestV1.LoadTestRunning == event.Object.(*apisLoadTestV1.LoadTest).Status.Phase {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// LoadTestFinished waits until Loadtest are with status phase finished
+func (Condition) LoadTestFinished(event watch.Event) (bool, error) {
+	if apisLoadTestV1.LoadTestFinished == event.Object.(*apisLoadTestV1.LoadTest).Status.Phase {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// Resource waits until a kubernetes resources to match a condition
+func Resource(obj watch.Interface, condFunc watchtools.ConditionFunc) (*watch.Event, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), kubernetes.KubeTimeout)
+	defer cancel()
+
+	return watchtools.UntilWithoutRetry(ctx, obj, condFunc)
+}
+
+// ResourceWithContext is Resource with custom context when the default context is not suitable
+func ResourceWithContext(ctx context.Context, obj watch.Interface, condFunc watchtools.ConditionFunc) (*watch.Event, error) {
+	return watchtools.UntilWithoutRetry(ctx, obj, condFunc)
+}
+
+// Time sleeps to wait kubernetes resources to be created
+func Time(d time.Duration) {
+	time.Sleep(d * time.Second)
+}

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -22,14 +22,14 @@ import (
 var (
 	loadTestMasterLabelSelector = "app=loadtest-master"
 	loadTestWorkerLabelSelector = "app=loadtest-worker-pod"
-	// GracePeriod is duration in seconds before the object should be deleted.
+	// gracePeriod is duration in seconds before the object should be deleted.
 	// The value zero indicates delete immediately.
 	gracePeriod = int64(0)
 )
 
 const (
 	// KubeTimeout timeout for kubernetes methods
-	KubeTimeout = 15 * time.Second
+	KubeTimeout = 30 * time.Second
 )
 
 //Client manages calls to Kubernetes API

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -27,6 +27,11 @@ var (
 	gracePeriod = int64(0)
 )
 
+const (
+	// KubeTimeout timeout for kubernetes methods
+	KubeTimeout = 15 * time.Second
+)
+
 //Client manages calls to Kubernetes API
 type Client struct {
 	ltClient   loadTestV1.LoadTestInterface

--- a/pkg/kubernetes/client_test.go
+++ b/pkg/kubernetes/client_test.go
@@ -15,13 +15,12 @@ import (
 	restClient "k8s.io/client-go/rest"
 	k8stesting "k8s.io/client-go/testing"
 
-	"github.com/hellofresh/kangal/pkg/controller"
 	apisLoadTestV1 "github.com/hellofresh/kangal/pkg/kubernetes/apis/loadtest/v1"
 	fakeClientset "github.com/hellofresh/kangal/pkg/kubernetes/generated/clientset/versioned/fake"
 )
 
 func TestCreateLoadTest(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), controller.KubeTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
 	defer cancel()
 
 	var logger = zap.NewNop()
@@ -44,7 +43,7 @@ func TestCreateLoadTest(t *testing.T) {
 }
 
 func TestCreateLoadTestWithError(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), controller.KubeTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
 	defer cancel()
 
 	var logger = zap.NewNop()
@@ -64,7 +63,7 @@ func TestCreateLoadTestWithError(t *testing.T) {
 }
 
 func TestDeleteLoadTest(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), controller.KubeTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
 	defer cancel()
 
 	var logger = zap.NewNop()
@@ -83,7 +82,7 @@ func TestDeleteLoadTest(t *testing.T) {
 }
 
 func TestCreateLoadTestCRNoLoadTest(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), controller.KubeTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
 	defer cancel()
 
 	var logger = zap.NewNop()
@@ -133,7 +132,7 @@ func TestGetLoadTestsByLabel(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), controller.KubeTimeout)
+			ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
 			defer cancel()
 
 			var logger = zap.NewNop()
@@ -156,7 +155,7 @@ func TestGetLoadTestsByLabel(t *testing.T) {
 }
 
 func TestGetLoadTest(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), controller.KubeTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
 	defer cancel()
 
 	var logger = zap.NewNop()
@@ -267,7 +266,7 @@ func TestClient_ListLoadTest(t *testing.T) {
 		t.Run(tc.scenario, func(t *testing.T) {
 			t.Parallel()
 
-			ctx, cancel := context.WithTimeout(context.Background(), controller.KubeTimeout)
+			ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
 			defer cancel()
 
 			loadTestClientSet := fakeClientset.NewSimpleClientset()
@@ -364,7 +363,7 @@ func TestClient_filterLoadTestsByPhase(t *testing.T) {
 }
 
 func TestCountActiveLoadTests(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), controller.KubeTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
 	defer cancel()
 
 	loadtestClientset := fakeClientset.NewSimpleClientset()
@@ -400,7 +399,7 @@ func TestCountActiveLoadTests(t *testing.T) {
 }
 
 func TestGetLoadTestNoLoadTest(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), controller.KubeTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
 	defer cancel()
 
 	var logger = zap.NewNop()
@@ -419,7 +418,7 @@ func TestGetLoadTestNoLoadTest(t *testing.T) {
 }
 
 func TestGetMasterPodLogs(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), controller.KubeTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
 	defer cancel()
 
 	var logger = zap.NewNop()

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -15,7 +15,6 @@ import (
 	restClient "k8s.io/client-go/rest"
 
 	"github.com/hellofresh/kangal/pkg/backends"
-	loadtest "github.com/hellofresh/kangal/pkg/controller"
 	cHttp "github.com/hellofresh/kangal/pkg/core/http"
 	mPkg "github.com/hellofresh/kangal/pkg/core/middleware"
 	kube "github.com/hellofresh/kangal/pkg/kubernetes"
@@ -74,7 +73,7 @@ func getLoadTestType(r *http.Request) apisLoadTestV1.LoadTestType {
 func (p *Proxy) List(w http.ResponseWriter, r *http.Request) {
 	logger := mPkg.GetLogger(r.Context())
 
-	ctx, cancel := context.WithTimeout(r.Context(), loadtest.KubeTimeout)
+	ctx, cancel := context.WithTimeout(r.Context(), kube.KubeTimeout)
 	defer cancel()
 
 	opt, err := fromHTTPRequestToListOptions(r)
@@ -120,7 +119,7 @@ func (p *Proxy) List(w http.ResponseWriter, r *http.Request) {
 func (p *Proxy) Create(w http.ResponseWriter, r *http.Request) {
 	logger := mPkg.GetLogger(r.Context())
 
-	ctx, cancel := context.WithTimeout(r.Context(), loadtest.KubeTimeout)
+	ctx, cancel := context.WithTimeout(r.Context(), kube.KubeTimeout)
 	defer cancel()
 
 	// Making valid LoadTestSpec based on HTTP request
@@ -216,7 +215,7 @@ func (p *Proxy) Create(w http.ResponseWriter, r *http.Request) {
 func (p *Proxy) Delete(w http.ResponseWriter, r *http.Request) {
 	logger := mPkg.GetLogger(r.Context())
 
-	ctx, cancel := context.WithTimeout(r.Context(), loadtest.KubeTimeout)
+	ctx, cancel := context.WithTimeout(r.Context(), kube.KubeTimeout)
 	defer cancel()
 
 	ltID := chi.URLParam(r, loadTestID)
@@ -236,7 +235,7 @@ func (p *Proxy) Delete(w http.ResponseWriter, r *http.Request) {
 func (p *Proxy) Get(w http.ResponseWriter, r *http.Request) {
 	logger := mPkg.GetLogger(r.Context())
 
-	ctx, cancel := context.WithTimeout(r.Context(), loadtest.KubeTimeout)
+	ctx, cancel := context.WithTimeout(r.Context(), kube.KubeTimeout)
 	defer cancel()
 
 	ltID := chi.URLParam(r, loadTestID)
@@ -274,7 +273,7 @@ func (p *Proxy) GetLogs(w http.ResponseWriter, r *http.Request) {
 	var logsRequest *restClient.Request
 	logger.Info("Retrieving logs for loadtest", zap.String("ltID", ltID))
 
-	ctx, cancel := context.WithTimeout(r.Context(), loadtest.KubeTimeout)
+	ctx, cancel := context.WithTimeout(r.Context(), kube.KubeTimeout)
 	defer cancel()
 
 	loadTest, err := p.kubeClient.GetLoadTest(ctx, ltID)
@@ -291,7 +290,7 @@ func (p *Proxy) GetLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctxLogs, cancelLogs := context.WithTimeout(context.Background(), loadtest.KubeTimeout)
+	ctxLogs, cancelLogs := context.WithTimeout(context.Background(), kube.KubeTimeout)
 	defer cancelLogs()
 	if workerID == "" {
 		logger.Info("Returning master pod logs")

--- a/pkg/proxy/proxy_integration_test.go
+++ b/pkg/proxy/proxy_integration_test.go
@@ -70,12 +70,12 @@ func TestIntegrationCreateLoadtestFormPostAllFiles(t *testing.T) {
 	})
 
 	t.Run("Checking the loadtest is created", func(t *testing.T) {
-		err := testHelper.WaitLoadtest(clientSet, createdLoadTestName)
+		err := testHelper.WaitLoadTest(clientSet, createdLoadTestName)
 		require.NoError(t, err)
 	})
 
 	t.Run("Checking if the loadtest labels are correct", func(t *testing.T) {
-		labels, err := testHelper.GetLoadtestLabels(clientSet, createdLoadTestName)
+		labels, err := testHelper.GetLoadTestLabels(clientSet, createdLoadTestName)
 		require.NoError(t, err)
 
 		expected := map[string]string{
@@ -164,7 +164,7 @@ func TestIntegrationCreateLoadtestReachMaxLimit(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	err := testHelper.WaitLoadtest(clientSet, createdLoadTestName)
+	err := testHelper.WaitLoadTest(clientSet, createdLoadTestName)
 	require.NoError(t, err)
 
 	t.Run("Creates second loadtest, must fail", func(t *testing.T) {
@@ -208,18 +208,18 @@ func TestIntegrationCreateLoadtestFormPostOneFile(t *testing.T) {
 	})
 
 	t.Run("Checking the loadtest is created", func(t *testing.T) {
-		err := testHelper.WaitLoadtest(clientSet, createdLoadTestName)
+		err := testHelper.WaitLoadTest(clientSet, createdLoadTestName)
 		require.NoError(t, err)
 	})
 
 	t.Run("Checking if the loadtest testData is correct", func(t *testing.T) {
-		data, err := testHelper.GetLoadtestTestdata(clientSet, createdLoadTestName)
+		data, err := testHelper.GetLoadTestTestdata(clientSet, createdLoadTestName)
 		require.NoError(t, err)
 		assert.Equal(t, "", data)
 	})
 
 	t.Run("Checking if the loadtest envVars is correct", func(t *testing.T) {
-		envVars, err := testHelper.GetLoadtestEnvVars(clientSet, createdLoadTestName)
+		envVars, err := testHelper.GetLoadTestEnvVars(clientSet, createdLoadTestName)
 		require.NoError(t, err)
 		assert.Equal(t, "", envVars)
 	})
@@ -329,7 +329,7 @@ func TestIntegrationDeleteLoadtest(t *testing.T) {
 	expectedLoadtestName := "loadtest-for-deletetest"
 
 	t.Run("Creates the loadtest", func(t *testing.T) {
-		err := testHelper.CreateLoadtest(clientSet, distributedPods, expectedLoadtestName, testFile, "", "", loadtestType)
+		err := testHelper.CreateLoadTest(clientSet, distributedPods, expectedLoadtestName, testFile, "", "", loadtestType)
 		require.NoError(t, err)
 	})
 
@@ -352,7 +352,7 @@ func TestIntegrationDeleteLoadtest(t *testing.T) {
 		res, _ := http.DefaultClient.Do(req)
 		assert.Equal(t, http.StatusNoContent, res.StatusCode)
 
-		if _, err := testHelper.GetLoadtest(clientSet, expectedLoadtestName); err != nil {
+		if _, err := testHelper.GetLoadTest(clientSet, expectedLoadtestName); err != nil {
 			notFoundMessage := `loadtests.kangal.hellofresh.com "loadtest-for-deletetest" not found`
 			assert.Equal(t, notFoundMessage, err.Error())
 		}
@@ -373,7 +373,7 @@ func TestIntegrationGetLoadtest(t *testing.T) {
 	expectedLoadtestName := "loadtest-for-gettest"
 
 	t.Run("Creates the loadtest", func(t *testing.T) {
-		err := testHelper.CreateLoadtest(clientSet, distributedPods, expectedLoadtestName, testFile, testData, "", loadtestType)
+		err := testHelper.CreateLoadTest(clientSet, distributedPods, expectedLoadtestName, testFile, testData, "", loadtestType)
 		require.NoError(t, err)
 	})
 
@@ -383,7 +383,7 @@ func TestIntegrationGetLoadtest(t *testing.T) {
 	})
 
 	t.Run("Checking the loadtest is created", func(t *testing.T) {
-		err := testHelper.WaitLoadtest(clientSet, expectedLoadtestName)
+		err := testHelper.WaitLoadTest(clientSet, expectedLoadtestName)
 		require.NoError(t, err)
 	})
 
@@ -414,7 +414,7 @@ func TestIntegrationGetLoadtest(t *testing.T) {
 		require.NoError(t, unmarshalErr, "Could not unmarshal response body")
 		assert.NotEmpty(t, dat.Namespace, "Could not get namespace from GET request")
 
-		currentNamespace, err := testHelper.GetLoadtestNamespace(clientSet, expectedLoadtestName)
+		currentNamespace, err := testHelper.GetLoadTestNamespace(clientSet, expectedLoadtestName)
 		require.NoError(t, err, "Could not get load test information")
 
 		assert.Equal(t, currentNamespace, dat.Namespace)
@@ -439,7 +439,7 @@ func TestIntegrationGetLoadtestLogs(t *testing.T) {
 	client := kubeClient(t)
 
 	t.Run("Creates the loadtest", func(t *testing.T) {
-		err := testHelper.CreateLoadtest(clientSet, distributedPods, expectedLoadtestName, testFile, "", "", loadtestType)
+		err := testHelper.CreateLoadTest(clientSet, distributedPods, expectedLoadtestName, testFile, "", "", loadtestType)
 		require.NoError(t, err)
 	})
 
@@ -449,7 +449,7 @@ func TestIntegrationGetLoadtestLogs(t *testing.T) {
 	})
 
 	t.Run("Checking the loadtest is created", func(t *testing.T) {
-		err := testHelper.WaitLoadtest(clientSet, expectedLoadtestName)
+		err := testHelper.WaitLoadTest(clientSet, expectedLoadtestName)
 		require.NoError(t, err)
 	})
 

--- a/pkg/proxy/proxy_integration_test.go
+++ b/pkg/proxy/proxy_integration_test.go
@@ -18,6 +18,7 @@ import (
 
 	_ "github.com/hellofresh/kangal/pkg/backends/fake"
 	testHelper "github.com/hellofresh/kangal/pkg/controller"
+	"github.com/hellofresh/kangal/pkg/core/waitfor"
 	apisLoadTestV1 "github.com/hellofresh/kangal/pkg/kubernetes/apis/loadtest/v1"
 	clientSetV "github.com/hellofresh/kangal/pkg/kubernetes/generated/clientset/versioned"
 )
@@ -457,7 +458,7 @@ func TestIntegrationGetLoadtestLogs(t *testing.T) {
 			LabelSelector: "app=loadtest-master",
 		})
 
-		watchEvent, err := testHelper.WaitResource(watchObj, (testHelper.WaitCondition{}).PodRunning)
+		watchEvent, err := waitfor.Resource(watchObj, (waitfor.Condition{}).PodRunning)
 		require.NoError(t, err)
 
 		pod := watchEvent.Object.(*coreV1.Pod)

--- a/pkg/proxy/service.go
+++ b/pkg/proxy/service.go
@@ -17,7 +17,6 @@ import (
 	k8sAPIErrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/hellofresh/kangal/pkg/backends"
-	loadtest "github.com/hellofresh/kangal/pkg/controller"
 	kube "github.com/hellofresh/kangal/pkg/kubernetes"
 	apisLoadTestV1 "github.com/hellofresh/kangal/pkg/kubernetes/apis/loadtest/v1"
 	grpcProxyV2 "github.com/hellofresh/kangal/pkg/proxy/rpc/pb/grpc/proxy/v2"
@@ -51,7 +50,7 @@ func NewLoadTestServiceServer(kubeClient *kube.Client, registry backends.Registr
 func (s *implLoadTestServiceServer) Get(ctx context.Context, in *grpcProxyV2.GetRequest) (*grpcProxyV2.GetResponse, error) {
 	logger := ctxzap.Extract(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, loadtest.KubeTimeout)
+	ctx, cancel := context.WithTimeout(ctx, kube.KubeTimeout)
 	defer cancel()
 
 	logger.Debug("Retrieving info for loadtest", zap.String("name", in.GetName()))

--- a/pkg/proxy/service_integration_test.go
+++ b/pkg/proxy/service_integration_test.go
@@ -37,10 +37,10 @@ func TestImplLoadTestServiceServer_Create_PostAllFiles(t *testing.T) {
 
 	createdLoadTestName := createLoadtest(t, &rq)
 
-	err := testHelper.WaitLoadtest(clientSet, createdLoadTestName)
+	err := testHelper.WaitLoadTest(clientSet, createdLoadTestName)
 	require.NoError(t, err)
 
-	labels, err := testHelper.GetLoadtestLabels(clientSet, createdLoadTestName)
+	labels, err := testHelper.GetLoadTestLabels(clientSet, createdLoadTestName)
 	require.NoError(t, err)
 
 	expected := map[string]string{
@@ -101,7 +101,7 @@ func TestImplLoadTestServiceServer_Create_ReachMaxLimit(t *testing.T) {
 
 	createdLoadTestName := createLoadtest(t, &rq)
 
-	err := testHelper.WaitLoadtest(clientSet, createdLoadTestName)
+	err := testHelper.WaitLoadTest(clientSet, createdLoadTestName)
 	require.NoError(t, err)
 
 	rqJSON2, err := protojson.Marshal(&rq2)
@@ -126,14 +126,14 @@ func TestImplLoadTestServiceServer_Create_PostOneFile(t *testing.T) {
 
 	createdLoadTestName := createLoadtest(t, &rq)
 
-	err := testHelper.WaitLoadtest(clientSet, createdLoadTestName)
+	err := testHelper.WaitLoadTest(clientSet, createdLoadTestName)
 	require.NoError(t, err)
 
-	data, err := testHelper.GetLoadtestTestdata(clientSet, createdLoadTestName)
+	data, err := testHelper.GetLoadTestTestdata(clientSet, createdLoadTestName)
 	require.NoError(t, err)
 	assert.Equal(t, "", data)
 
-	envVars, err := testHelper.GetLoadtestEnvVars(clientSet, createdLoadTestName)
+	envVars, err := testHelper.GetLoadTestEnvVars(clientSet, createdLoadTestName)
 	require.NoError(t, err)
 	assert.Equal(t, "", envVars)
 }
@@ -189,7 +189,7 @@ func TestImplLoadTestServiceServer_Get_Simple(t *testing.T) {
 
 	createdLoadTestName := createLoadtest(t, &rq)
 
-	err := testHelper.WaitLoadtest(clientSet, createdLoadTestName)
+	err := testHelper.WaitLoadTest(clientSet, createdLoadTestName)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%d/v2/load-test/%s", restPort, createdLoadTestName), nil)


### PR DESCRIPTION
EES-4737
Some load tests are randomly failing due the JMeter master pod being ready before workers pods.
This PR is intended to mitigate this by waiting each worker pod be on running state before proceeding.