### PR TITLE
EES-4642 Allow more than one test in gRPC integration tests

### DIFF
--- a/ci/integration-tests.sh
+++ b/ci/integration-tests.sh
@@ -16,7 +16,7 @@ if ! kill -s 0 "${PID_PROXY}"; then
 fi
 
 echo "Starting kangal gRPC/REST proxy"
-./bin/kangal api --kubeconfig="$HOME/.kube/config" --max-load-tests 1 >/tmp/kangal_api.log 2>&1 &
+./bin/kangal api --kubeconfig="$HOME/.kube/config" --max-load-tests 3 >/tmp/kangal_api.log 2>&1 &
 PID_API=$!
 sleep 1
 echo "Check if gRPC/REST proxy is running"

--- a/pkg/proxy/service_test.go
+++ b/pkg/proxy/service_test.go
@@ -261,6 +261,12 @@ func readFileContents(t *testing.T, path string, base64Encoded bool) []byte {
 		return contents
 	}
 
+	return encodeContents(t, contents)
+}
+
+func encodeContents(t *testing.T, contents []byte) []byte {
+	t.Helper()
+
 	encoded := make([]byte, base64.StdEncoding.EncodedLen(len(contents)))
 	base64.StdEncoding.Encode(encoded, contents)
 	return encoded


### PR DESCRIPTION
Increase of allowed tests will be used for `List` method tests as more than one test is required to cover pagination.