### PR TITLE
Add permission to get pods

### DIFF
--- a/charts/kangal/Chart.yaml
+++ b/charts/kangal/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - performance tests
   - tests runner
 name: kangal
-version: 1.4.6
+version: 1.4.7
 home: https://github.com/hellofresh/kangal
 icon: https://raw.githubusercontent.com/hellofresh/kangal/master/logo.svg
 maintainers:

--- a/charts/kangal/templates/clusterrole.yaml
+++ b/charts/kangal/templates/clusterrole.yaml
@@ -61,6 +61,7 @@ rules:
     resources:
       - pods
     verbs:
+      - get
       - create
       - list
       - watch


### PR DESCRIPTION
This PR changes the chart to add an extra permission to get the pods.
This is required now due the changes on #92 