### PR TITLE
EES-4392 Add created and finished loadtest metric

### DIFF
--- a/pkg/backends/fake/backend.go
+++ b/pkg/backends/fake/backend.go
@@ -115,7 +115,7 @@ func (b *Backend) SyncStatus(ctx context.Context, _ loadTestV1.LoadTest, loadTes
 
 	// Get Fake job in namespace and update the LoadTest status with
 	// the Job status
-	loadTestStatus.Phase = getLoadTestPhaseFromJob(job.Status)
+	loadTestStatus.Phase = determineLoadTestPhaseFromJob(job.Status)
 	loadTestStatus.JobStatus = job.Status
 
 	return nil
@@ -165,7 +165,8 @@ func (b *Backend) newMasterJob(loadTest loadTestV1.LoadTest) *batchV1.Job {
 	}
 }
 
-func getLoadTestPhaseFromJob(status batchV1.JobStatus) loadTestV1.LoadTestPhase {
+// determineLoadTestPhaseFromJob reads existing job statuses and determines what the loadtest phase should be
+func determineLoadTestPhaseFromJob(status batchV1.JobStatus) loadTestV1.LoadTestPhase {
 	if status.Active > 0 {
 		return loadTestV1.LoadTestRunning
 	}

--- a/pkg/backends/jmeter/backend.go
+++ b/pkg/backends/jmeter/backend.go
@@ -283,7 +283,7 @@ func (b *Backend) SyncStatus(ctx context.Context, loadTest loadTestV1.LoadTest, 
 
 	// Get jmeter job in namespace and update the LoadTest status with
 	// the Job status
-	loadTestStatus.Phase = getLoadTestPhaseFromJob(job.Status)
+	loadTestStatus.Phase = determineLoadTestPhaseFromJob(job.Status)
 	loadTestStatus.JobStatus = job.Status
 
 	return nil
@@ -312,7 +312,8 @@ func workerPodHasTimeout(startTime *metaV1.Time, loadtestStatus loadTestV1.LoadT
 		loadtestStatus.Phase == loadTestV1.LoadTestCreating
 }
 
-func getLoadTestPhaseFromJob(status batchV1.JobStatus) loadTestV1.LoadTestPhase {
+// determineLoadTestPhaseFromJob
+func determineLoadTestPhaseFromJob(status batchV1.JobStatus) loadTestV1.LoadTestPhase {
 	if status.Active > 0 {
 		return loadTestV1.LoadTestRunning
 	}

--- a/pkg/backends/jmeter/backend_test.go
+++ b/pkg/backends/jmeter/backend_test.go
@@ -109,7 +109,7 @@ func TestGetLoadTestPhaseFromJob(t *testing.T) {
 	}
 
 	for _, test := range testPhases {
-		phase := getLoadTestPhaseFromJob(test.JobStatus)
+		phase := determineLoadTestPhaseFromJob(test.JobStatus)
 		assert.Equal(t, test.ExpectedPhase, phase)
 	}
 }

--- a/pkg/backends/locust/backend.go
+++ b/pkg/backends/locust/backend.go
@@ -246,7 +246,7 @@ func (b *Backend) SyncStatus(ctx context.Context, loadTest loadTestV1.LoadTest, 
 		return err
 	}
 
-	loadTestStatus.Phase = getLoadTestStatusFromJobs(masterJob, workerJob)
+	loadTestStatus.Phase = determineLoadTestStatusFromJobs(masterJob, workerJob)
 
 	return nil
 }

--- a/pkg/backends/locust/resources.go
+++ b/pkg/backends/locust/resources.go
@@ -305,7 +305,8 @@ func newWorkerJob(
 	}
 }
 
-func getLoadTestStatusFromJobs(masterJob *batchV1.Job, workerJob *batchV1.Job) loadTestV1.LoadTestPhase {
+// determineLoadTestStatusFromJobs reads existing job statuses and determines what the loadtest status should be
+func determineLoadTestStatusFromJobs(masterJob *batchV1.Job, workerJob *batchV1.Job) loadTestV1.LoadTestPhase {
 	if workerJob.Status.Failed > int32(0) || masterJob.Status.Failed > int32(0) {
 		return loadTestV1.LoadTestErrored
 	}

--- a/pkg/backends/locust/resources_test.go
+++ b/pkg/backends/locust/resources_test.go
@@ -102,7 +102,7 @@ func TestGetLoadTestStatusFromJobs(t *testing.T) {
 	}
 
 	for _, scenario := range scenarios {
-		actual := getLoadTestStatusFromJobs(scenario.MasterJob, scenario.WorkerJob)
+		actual := determineLoadTestStatusFromJobs(scenario.MasterJob, scenario.WorkerJob)
 		assert.Equal(t, scenario.Expected, actual)
 	}
 }

--- a/pkg/controller/loadtest.go
+++ b/pkg/controller/loadtest.go
@@ -457,6 +457,7 @@ func (c *Controller) checkOrCreateNamespace(ctx context.Context, loadtest *loadt
 		}
 		namespaceName = namespaceObj.GetName()
 		c.logger.Info("Created new namespace", zap.String("namespace", namespaceName), zap.String("LoadTest", loadtest.GetName()))
+		stats.Record(ctx, observability.MCreatedLoadtestCountStat.M(1))
 	} else {
 		namespaceName = namespaces.Items[0].Name
 	}

--- a/pkg/core/observability/controller.go
+++ b/pkg/core/observability/controller.go
@@ -15,6 +15,12 @@ var (
 	reconcileCountStat   = stats.Int64("reconcile_count", "Number of reconcile operations", stats.UnitDimensionless)
 	reconcileLatencyStat = stats.Int64("reconcile_latency", "Latency of reconcile operations", stats.UnitMilliseconds)
 
+	// MCreatedLoadtestCountStat counts the number of loadtests created
+	MCreatedLoadtestCountStat = stats.Int64("created_loadtests_count", "Number of loadtests created", stats.UnitDimensionless)
+
+	// MFinishedLoadtestCountStat counts the number of finished loadtests
+	MFinishedLoadtestCountStat = stats.Int64("finished_loadtests_count", "Number of finished loadtests", stats.UnitDimensionless)
+
 	// reconcileDistribution defines the bucket boundaries for the histogram of reconcile latency metric.
 	// Bucket boundaries are 10ms, 100ms, 1s, 10s, 30s and 60s.
 	reconcileDistribution = view.Distribution(10, 100, 1000, 10000, 30000, 60000)
@@ -45,6 +51,16 @@ var ControllerViews = []*view.View{
 		Measure:     reconcileLatencyStat,
 		Aggregation: reconcileDistribution,
 		TagKeys:     []tag.Key{reconcilerTagKey, keyTagKey, successTagKey},
+	},
+	{
+		Description: MCreatedLoadtestCountStat.Description(),
+		Measure:     MCreatedLoadtestCountStat,
+		Aggregation: view.Count(),
+	},
+	{
+		Description: MFinishedLoadtestCountStat.Description(),
+		Measure:     MFinishedLoadtestCountStat,
+		Aggregation: view.Count(),
 	},
 }
 


### PR DESCRIPTION
This PR:
- Adds two new metrics: `created_loadtests_count` and `finished_loadtests_count`
  - `created_loadtests_count` is incremented when a new loadtest is created
  - `finished_loadtests_count` is incremented when a loadtest phase is set to finished
- Adds error handling to `updateLoadTestStatus` in `syncHandler`
  - Errors here were returned, but ignored as it's only called with `defer` in `syncHandler`
- Renames `getLoadTestStatusFromJobs` to `determineLoadTestStatusFromJobs`