### PR TITLE
Add integration test for grpc-gateway list method with tags parameter

### DIFF
--- a/proto/grpc/proxy/v2/proxy.proto
+++ b/proto/grpc/proxy/v2/proxy.proto
@@ -70,6 +70,9 @@ message CreateResponse {
 message ListRequest {
     int64 page_size = 1;
     string page_token = 2;
+    // See openapi-v3 spec regarding deepObject style to describe objects as query string:
+    // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#style-examples
+    // Note: This works but will not be generated in the swagger.json file as it is not openapi-v2 compliant.
     map<string, string> tags = 3;
     LoadTestPhase phase = 4;
 }
@@ -97,6 +100,7 @@ service LoadTestService {
         };
     }
     // List searches and returns load tests by given filters
+    // Example: curl -X GET "http://localhost:8090/v2/load-test?page_size=5&tags[department]=platform&tags[team]=kangal"
     rpc List (ListRequest) returns (ListResponse) {
         option (google.api.http) = {
             get: "/v2/load-test"


### PR DESCRIPTION
This PR adds integration test to ensure that `tags` query string parameter passed to `LIST` `/v2/load-test` endpoint in the grpc gateway is working.