### PR TITLE
Loadtest syncHandler: Stop processing and updating after loadtest deletion

### DIFF
--- a/pkg/controller/loadtest.go
+++ b/pkg/controller/loadtest.go
@@ -323,12 +323,14 @@ func (c *Controller) syncHandler(key string) error {
 		// LoadTest has been deleted at this point, so we stop further processing.
 		return nil
 	}
-	
+
+	// get report url
 	var reportURL string
 	if c.cfg.KangalProxyURL != "" {
 		reportURL = fmt.Sprintf("%s/load-test/%s/report", c.cfg.KangalProxyURL, loadTest.GetName())
 	}
 
+	// get backend
 	backend, err := c.registry.GetBackend(loadTest.Spec.Type)
 	if err != nil {
 		return fmt.Errorf("failed to resolve backend: %w", err)
@@ -500,6 +502,8 @@ func newNamespace(loadtest *loadTestV1.LoadTest, namespaceAnnotations map[string
 	}, nil
 }
 
+// checkLoadTestLifeTimeExceeded returns true if the input loadtest has
+// existed for longer than certain threshold, and its status is Finished or Errorred
 func checkLoadTestLifeTimeExceeded(loadTest *loadTestV1.LoadTest, deleteThreshold time.Duration) bool {
 	if loadTest.Status.JobStatus.CompletionTime != nil {
 		if time.Since(loadTest.Status.JobStatus.CompletionTime.Time) > deleteThreshold &&

--- a/pkg/controller/loadtest.go
+++ b/pkg/controller/loadtest.go
@@ -306,7 +306,7 @@ func (c *Controller) syncHandler(key string) error {
 
 	// check and delete stale finished/errored loadtests
 	if checkLoadTestLifeTimeExceeded(loadTest, c.cfg.CleanUpThreshold) {
-		c.logger.Info("Deleting loadtest",
+		c.logger.Info("Deleting loadtest due to exceeded lifetime",
 			zap.String("loadtest", loadTest.Name),
 			zap.String("phase", string(loadTest.Status.Phase)),
 		)
@@ -314,7 +314,7 @@ func (c *Controller) syncHandler(key string) error {
 		if err != nil {
 			// The LoadTest resource may be conflicted, in which case we stop processing.
 			if errors.IsConflict(err) {
-				utilRuntime.HandleError(fmt.Errorf("there is a conflict with loadtest '%s' between datastore and cache. it might be because object has been removed or modified in the datastore", key))
+				utilRuntime.HandleError(fmt.Errorf("there is a conflict with loadtest %q between datastore and cache. it might be because object has been removed or modified in the datastore", key))
 				return nil
 			}
 			return err


### PR DESCRIPTION
**Current behavior:**  
After we delete a loadtest (due to staleness), we still attempt to update it, and then update its status (via deferred execution).  
This produces two error log lines as attempts to update the loadtest will fail (it has already been deleted).

**This PR:**  
Moves the check earlier, so we can stop further processing if a loadtest is to be deleted.