### PR TITLE
Loadtest syncHandler: Don't update loadtest status with stale loadtest object

### DIFF
--- a/pkg/controller/loadtest.go
+++ b/pkg/controller/loadtest.go
@@ -303,7 +303,11 @@ func (c *Controller) syncHandler(key string) error {
 	}
 	// copy object before mutate it
 	loadTest := loadTestFromCache.DeepCopy()
-	defer c.updateLoadTestStatus(ctx, key, loadTest, loadTestFromCache)
+
+	// ensure that status is updated if any of the following fails
+	defer func() {
+		c.updateLoadTestStatus(ctx, key, loadTest, loadTestFromCache)
+	}()
 
 	var reportURL string
 	if c.cfg.KangalProxyURL != "" {


### PR DESCRIPTION
**Current behavior:**  
Kangal controller updates the loadtest resource, then updates its status again via a deferred call using an outdated loadtest object.  
This almost always produces an error since they're conflicted.

**This PR:**  
Updates deferred status update to use loadtest object with actually updated status.  
[This snippet](https://play.golang.org/p/lyhUp24cC54) showcases the difference between function-wrapped deferred calls.