### PR TITLE
Integration Test: Print logs after completed

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -119,6 +119,18 @@ jobs:
         run: |
           ./ci/integration-tests.sh
 
+      - name: Print Kangal Proxy Logs
+        run: |
+          cat /tmp/kangal_proxy.log
+
+      - name: Print Kangal gRPC/Rest Proxy Logs
+        run: |
+          cat /tmp/kangal_api.log
+
+      - name: Print Kangal Controller Logs
+        run: |
+          cat /tmp/kangal_controller.log
+
       - name: Upload codecov
         uses: codecov/codecov-action@v1
         if: success()

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -122,11 +122,11 @@ jobs:
       - name: Print Logs on Failure
         if: failure()
         run: |
-          echo Printing Kangal Proxy Logs
+          echo "==> Printing Kangal Proxy Logs\n"
           cat /tmp/kangal_proxy.log
-          echo Printing Kangal gRPC/REST Proxy Logs
+          echo "\n\n==> Printing Kangal gRPC/REST Proxy Logs\n"
           cat /tmp/kangal_api.log
-          echo Printing Kangal Controller Logs
+          echo "\n\n==> Printing Kangal Controller Logs\n"
           cat /tmp/kangal_controller.log
 
       - name: Upload codecov

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -119,16 +119,14 @@ jobs:
         run: |
           ./ci/integration-tests.sh
 
-      - name: Print Kangal Proxy Logs
+      - name: Print Logs on Failure
+        if: failure()
         run: |
+          echo Printing Kangal Proxy Logs
           cat /tmp/kangal_proxy.log
-
-      - name: Print Kangal gRPC/Rest Proxy Logs
-        run: |
+          echo Printing Kangal gRPC/REST Proxy Logs
           cat /tmp/kangal_api.log
-
-      - name: Print Kangal Controller Logs
-        run: |
+          echo Printing Kangal Controller Logs
           cat /tmp/kangal_controller.log
 
       - name: Upload codecov


### PR DESCRIPTION
This PR updates integration test to print kangal proxy, grpc/rest proxy, and controller logs after integration test is finished.