### PR TITLE
Apply timeout to kubeclient and remove KubeTimeout

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -8,7 +8,6 @@ import (
 	"github.com/kelseyhightower/envconfig"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/hellofresh/kangal/pkg/core/observability"
 	kube "github.com/hellofresh/kangal/pkg/kubernetes"
@@ -48,7 +47,7 @@ func NewAPICmd(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("could not initialise Prometheus exporter: %w", err)
 			}
 
-			k8sConfig, err := clientcmd.BuildConfigFromFlags(opts.masterURL, opts.kubeConfig)
+			k8sConfig, err := buildKubeClientConfig(cfg.MasterURL, opts.kubeConfig, cfg.KubeClientTimeout)
 			if err != nil {
 				return fmt.Errorf("building config from flags: %w", err)
 			}

--- a/cmd/api.go
+++ b/cmd/api.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/spf13/cobra"
-	kubeClient "k8s.io/client-go/kubernetes"
+	kubernetesClient "k8s.io/client-go/kubernetes"
 
 	"github.com/hellofresh/kangal/pkg/core/observability"
 	"github.com/hellofresh/kangal/pkg/kubernetes"
@@ -57,7 +57,7 @@ func NewAPICmd(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("building kangal clientset: %w", err)
 			}
 
-			kubeClientSet, err := kubeClient.NewForConfig(k8sConfig)
+			kubeClientSet, err := kubernetesClient.NewForConfig(k8sConfig)
 			if err != nil {
 				return fmt.Errorf("building kubernetes clientset: %w", err)
 			}

--- a/cmd/api.go
+++ b/cmd/api.go
@@ -47,7 +47,7 @@ func NewAPICmd(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("could not initialise Prometheus exporter: %w", err)
 			}
 
-			k8sConfig, err := kubernetes.BuildClientConfig(cfg.MasterURL, opts.kubeConfig, cfg.KubeClientTimeout)
+			k8sConfig, err := kubernetes.BuildClientConfig(opts.masterURL, opts.kubeConfig, cfg.KubeClientTimeout)
 			if err != nil {
 				return fmt.Errorf("building config from flags: %w", err)
 			}

--- a/cmd/api.go
+++ b/cmd/api.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/kubernetes"
+	kubeClient "k8s.io/client-go/kubernetes"
 
 	"github.com/hellofresh/kangal/pkg/core/observability"
-	kube "github.com/hellofresh/kangal/pkg/kubernetes"
+	"github.com/hellofresh/kangal/pkg/kubernetes"
 	loadTestV1 "github.com/hellofresh/kangal/pkg/kubernetes/generated/clientset/versioned/typed/loadtest/v1"
 	"github.com/hellofresh/kangal/pkg/proxy"
 	"github.com/hellofresh/kangal/pkg/report"
@@ -47,7 +47,7 @@ func NewAPICmd(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("could not initialise Prometheus exporter: %w", err)
 			}
 
-			k8sConfig, err := buildKubeClientConfig(cfg.MasterURL, opts.kubeConfig, cfg.KubeClientTimeout)
+			k8sConfig, err := kubernetes.BuildKubeClientConfig(cfg.MasterURL, opts.kubeConfig, cfg.KubeClientTimeout)
 			if err != nil {
 				return fmt.Errorf("building config from flags: %w", err)
 			}
@@ -57,13 +57,13 @@ func NewAPICmd(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("building kangal clientset: %w", err)
 			}
 
-			kubeClientSet, err := kubernetes.NewForConfig(k8sConfig)
+			kubeClientSet, err := kubeClient.NewForConfig(k8sConfig)
 			if err != nil {
 				return fmt.Errorf("building kubernetes clientset: %w", err)
 			}
 
 			loadTestClient := kangalClientSet.LoadTests()
-			kubeClient := kube.NewClient(loadTestClient, kubeClientSet, logger)
+			kubeClient := kubernetes.NewClient(loadTestClient, kubeClientSet, logger)
 
 			err = report.InitObjectStorageClient(cfg.Report)
 			if err != nil {

--- a/cmd/api.go
+++ b/cmd/api.go
@@ -47,7 +47,7 @@ func NewAPICmd(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("could not initialise Prometheus exporter: %w", err)
 			}
 
-			k8sConfig, err := kubernetes.BuildKubeClientConfig(cfg.MasterURL, opts.kubeConfig, cfg.KubeClientTimeout)
+			k8sConfig, err := kubernetes.BuildClientConfig(cfg.MasterURL, opts.kubeConfig, cfg.KubeClientTimeout)
 			if err != nil {
 				return fmt.Errorf("building config from flags: %w", err)
 			}

--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -54,7 +54,7 @@ func NewControllerCmd() *cobra.Command {
 				return err
 			}
 
-			kubeCfg, err := kubernetes.BuildKubeClientConfig(cfg.MasterURL, cfg.KubeConfig, cfg.KubeClientTimeout)
+			kubeCfg, err := kubernetes.BuildClientConfig(cfg.MasterURL, cfg.KubeConfig, cfg.KubeClientTimeout)
 			if err != nil {
 				return fmt.Errorf("error building kubeConfig: %w", err)
 			}

--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -58,7 +58,7 @@ func NewControllerCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("error building kubeConfig: %w", err)
 			}
-			kubeCfg.Timeout = time.Duration(cfg.KubeClientTimeoutSeconds) * time.Second
+			kubeCfg.Timeout = cfg.KubeClientTimeout
 
 			kubeClient, err := kubernetes.NewForConfig(kubeCfg)
 			if err != nil {

--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -8,7 +8,7 @@ import (
 	"github.com/kelseyhightower/envconfig"
 	"github.com/spf13/cobra"
 	kubeInformers "k8s.io/client-go/informers"
-	kubeClient "k8s.io/client-go/kubernetes"
+	kubernetesClient "k8s.io/client-go/kubernetes"
 
 	"github.com/hellofresh/kangal/pkg/controller"
 	"github.com/hellofresh/kangal/pkg/core/observability"
@@ -59,7 +59,7 @@ func NewControllerCmd() *cobra.Command {
 				return fmt.Errorf("error building kubeConfig: %w", err)
 			}
 
-			kubeClient, err := kubeClient.NewForConfig(kubeCfg)
+			kubeClient, err := kubernetesClient.NewForConfig(kubeCfg)
 			if err != nil {
 				return fmt.Errorf("error building kubernetes clientSet: %w", err)
 			}

--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -5,16 +5,14 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/client-go/rest"
-
 	"github.com/kelseyhightower/envconfig"
 	"github.com/spf13/cobra"
 	kubeInformers "k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
+	kubeClient "k8s.io/client-go/kubernetes"
 
 	"github.com/hellofresh/kangal/pkg/controller"
 	"github.com/hellofresh/kangal/pkg/core/observability"
+	"github.com/hellofresh/kangal/pkg/kubernetes"
 	clientSet "github.com/hellofresh/kangal/pkg/kubernetes/generated/clientset/versioned"
 	informers "github.com/hellofresh/kangal/pkg/kubernetes/generated/informers/externalversions"
 )
@@ -56,12 +54,12 @@ func NewControllerCmd() *cobra.Command {
 				return err
 			}
 
-			kubeCfg, err := buildKubeClientConfig(cfg.MasterURL, cfg.KubeConfig, cfg.KubeClientTimeout)
+			kubeCfg, err := kubernetes.BuildKubeClientConfig(cfg.MasterURL, cfg.KubeConfig, cfg.KubeClientTimeout)
 			if err != nil {
 				return fmt.Errorf("error building kubeConfig: %w", err)
 			}
 
-			kubeClient, err := kubernetes.NewForConfig(kubeCfg)
+			kubeClient, err := kubeClient.NewForConfig(kubeCfg)
 			if err != nil {
 				return fmt.Errorf("error building kubernetes clientSet: %w", err)
 			}
@@ -132,14 +130,4 @@ func convertAnnotationToMap(s []string) (map[string]string, error) {
 		m[key] = value
 	}
 	return m, nil
-}
-
-func buildKubeClientConfig(masterURL string, kubeConfigPath string, timeout time.Duration) (*rest.Config, error) {
-	kubeCfg, err := clientcmd.BuildConfigFromFlags(masterURL, kubeConfigPath)
-	if err != nil {
-		return nil, err
-	}
-
-	kubeCfg.Timeout = timeout
-	return kubeCfg, nil
 }

--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -58,6 +58,7 @@ func NewControllerCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("error building kubeConfig: %w", err)
 			}
+			kubeCfg.Timeout = time.Duration(cfg.KubeClientTimeoutSeconds) * time.Second
 
 			kubeClient, err := kubernetes.NewForConfig(kubeCfg)
 			if err != nil {

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/spf13/cobra"
-	kubeClient "k8s.io/client-go/kubernetes"
+	kubernetesClient "k8s.io/client-go/kubernetes"
 
 	"github.com/hellofresh/kangal/pkg/core/observability"
 	"github.com/hellofresh/kangal/pkg/kubernetes"
@@ -57,7 +57,7 @@ func NewProxyCmd() *cobra.Command {
 				return fmt.Errorf("building kangal clientset: %w", err)
 			}
 
-			kubeClientSet, err := kubeClient.NewForConfig(k8sConfig)
+			kubeClientSet, err := kubernetesClient.NewForConfig(k8sConfig)
 			if err != nil {
 				return fmt.Errorf("building kubernetes clientset: %w", err)
 			}

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/kubernetes"
+	kubeClient "k8s.io/client-go/kubernetes"
 
 	"github.com/hellofresh/kangal/pkg/core/observability"
-	kube "github.com/hellofresh/kangal/pkg/kubernetes"
+	"github.com/hellofresh/kangal/pkg/kubernetes"
 	loadTestV1 "github.com/hellofresh/kangal/pkg/kubernetes/generated/clientset/versioned/typed/loadtest/v1"
 	"github.com/hellofresh/kangal/pkg/proxy"
 	"github.com/hellofresh/kangal/pkg/report"
@@ -47,7 +47,7 @@ func NewProxyCmd() *cobra.Command {
 				return fmt.Errorf("could not initialise Prometheus exporter: %w", err)
 			}
 
-			k8sConfig, err := buildKubeClientConfig(cfg.MasterURL, opts.kubeConfig, cfg.KubeClientTimeout)
+			k8sConfig, err := kubernetes.BuildKubeClientConfig(cfg.MasterURL, opts.kubeConfig, cfg.KubeClientTimeout)
 			if err != nil {
 				return fmt.Errorf("building config from flags: %w", err)
 			}
@@ -57,13 +57,13 @@ func NewProxyCmd() *cobra.Command {
 				return fmt.Errorf("building kangal clientset: %w", err)
 			}
 
-			kubeClientSet, err := kubernetes.NewForConfig(k8sConfig)
+			kubeClientSet, err := kubeClient.NewForConfig(k8sConfig)
 			if err != nil {
 				return fmt.Errorf("building kubernetes clientset: %w", err)
 			}
 
 			loadTestClient := kangalClientSet.LoadTests()
-			kubeClient := kube.NewClient(loadTestClient, kubeClientSet, logger)
+			kubeClient := kubernetes.NewClient(loadTestClient, kubeClientSet, logger)
 
 			err = report.InitObjectStorageClient(cfg.Report)
 			if err != nil {

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -47,7 +47,7 @@ func NewProxyCmd() *cobra.Command {
 				return fmt.Errorf("could not initialise Prometheus exporter: %w", err)
 			}
 
-			k8sConfig, err := kubernetes.BuildClientConfig(cfg.MasterURL, opts.kubeConfig, cfg.KubeClientTimeout)
+			k8sConfig, err := kubernetes.BuildClientConfig(opts.masterURL, opts.kubeConfig, cfg.KubeClientTimeout)
 			if err != nil {
 				return fmt.Errorf("building config from flags: %w", err)
 			}

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -47,7 +47,7 @@ func NewProxyCmd() *cobra.Command {
 				return fmt.Errorf("could not initialise Prometheus exporter: %w", err)
 			}
 
-			k8sConfig, err := kubernetes.BuildKubeClientConfig(cfg.MasterURL, opts.kubeConfig, cfg.KubeClientTimeout)
+			k8sConfig, err := kubernetes.BuildClientConfig(cfg.MasterURL, opts.kubeConfig, cfg.KubeClientTimeout)
 			if err != nil {
 				return fmt.Errorf("building config from flags: %w", err)
 			}

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -7,7 +7,6 @@ import (
 	"github.com/kelseyhightower/envconfig"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/hellofresh/kangal/pkg/core/observability"
 	kube "github.com/hellofresh/kangal/pkg/kubernetes"
@@ -48,11 +47,10 @@ func NewProxyCmd() *cobra.Command {
 				return fmt.Errorf("could not initialise Prometheus exporter: %w", err)
 			}
 
-			k8sConfig, err := clientcmd.BuildConfigFromFlags(opts.masterURL, opts.kubeConfig)
+			k8sConfig, err := buildKubeClientConfig(cfg.MasterURL, opts.kubeConfig, cfg.KubeClientTimeout)
 			if err != nil {
 				return fmt.Errorf("building config from flags: %w", err)
 			}
-			k8sConfig.Timeout = cfg.KubeClientTimeout
 
 			kangalClientSet, err := loadTestV1.NewForConfig(k8sConfig)
 			if err != nil {

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"flag"
 	"fmt"
-	"time"
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/spf13/cobra"
@@ -53,7 +52,7 @@ func NewProxyCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("building config from flags: %w", err)
 			}
-			k8sConfig.Timeout = time.Duration(cfg.KubeClientTimeoutSeconds) * time.Second
+			k8sConfig.Timeout = cfg.KubeClientTimeout
 
 			kangalClientSet, err := loadTestV1.NewForConfig(k8sConfig)
 			if err != nil {

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"flag"
 	"fmt"
+	"time"
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/spf13/cobra"
@@ -52,6 +53,7 @@ func NewProxyCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("building config from flags: %w", err)
 			}
+			k8sConfig.Timeout = time.Duration(cfg.KubeClientTimeoutSeconds) * time.Second
 
 			kangalClientSet, err := loadTestV1.NewForConfig(k8sConfig)
 			if err != nil {

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -19,8 +19,8 @@ type Config struct {
 	// S3 compatible configuration access keys and endpoints needed to store load test reports
 	KangalProxyURL string `envconfig:"KANGAL_PROXY_URL" default:""`
 
-	// KubeClientTimeoutSeconds specifies timeout for each operation done by kube client
-	KubeClientTimeoutSeconds uint `envconfig:"KUBE_CLIENT_TIMEOUT_SECONDS" default:"5"`
+	// KubeClientTimeout specifies timeout for each operation done by kube client
+	KubeClientTimeout time.Duration `envconfig:"KUBE_CLIENT_TIMEOUT" default:"5s"`
 
 	MasterURL            string
 	KubeConfig           string

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -11,11 +11,16 @@ type Config struct {
 	Debug    bool `envconfig:"DEBUG"`
 	HTTPPort int  `envconfig:"WEB_HTTP_PORT" default:"8080"`
 	Logger   observability.LoggerConfig
+
 	// CleanUpThresholdEnvVar is used if we want to increase the amount of time a
 	// load test lives for, the default is 1 hour. (ex. 5h)
 	CleanUpThreshold time.Duration `envconfig:"CLEANUP_THRESHOLD" default:"1h"`
+
 	// S3 compatible configuration access keys and endpoints needed to store load test reports
 	KangalProxyURL string `envconfig:"KANGAL_PROXY_URL" default:""`
+
+	// KubeClientTimeoutSeconds specifies timeout for each operation done by kube client
+	KubeClientTimeoutSeconds uint `envconfig:"KUBE_CLIENT_TIMEOUT_SECONDS" default:"5"`
 
 	MasterURL            string
 	KubeConfig           string

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -22,6 +22,9 @@ type Config struct {
 	// KubeClientTimeout specifies timeout for each operation done by kube client
 	KubeClientTimeout time.Duration `envconfig:"KUBE_CLIENT_TIMEOUT" default:"5s"`
 
+	// SyncHandlerTimeout specifies the time limit for each sync operation
+	SyncHandlerTimeout time.Duration `envconfig:"SYNC_HANDLER_TIMEOUT" default:"60s"`
+
 	MasterURL            string
 	KubeConfig           string
 	NamespaceAnnotations map[string]string

--- a/pkg/controller/jmeter_integration_test.go
+++ b/pkg/controller/jmeter_integration_test.go
@@ -162,6 +162,7 @@ func kubeTestClient() clientSetV.Clientset {
 	}
 
 	config, err := BuildConfig()
+	config.Timeout = 15 * time.Second
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -178,6 +179,7 @@ func kubeClient(t *testing.T) *kubernetes.Clientset {
 
 	config, err := BuildConfig()
 	require.NoError(t, err)
+	config.Timeout = 15 * time.Second
 
 	cSet, err := kubernetes.NewForConfig(config)
 	require.NoError(t, err)

--- a/pkg/controller/jmeter_integration_test.go
+++ b/pkg/controller/jmeter_integration_test.go
@@ -162,7 +162,6 @@ func kubeTestClient() clientSetV.Clientset {
 	}
 
 	config, err := BuildConfig()
-	config.Timeout = 60 * time.Second
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -179,7 +178,6 @@ func kubeClient(t *testing.T) *kubernetes.Clientset {
 
 	config, err := BuildConfig()
 	require.NoError(t, err)
-	config.Timeout = 60 * time.Second
 
 	cSet, err := kubernetes.NewForConfig(config)
 	require.NoError(t, err)

--- a/pkg/controller/jmeter_integration_test.go
+++ b/pkg/controller/jmeter_integration_test.go
@@ -162,7 +162,7 @@ func kubeTestClient() clientSetV.Clientset {
 	}
 
 	config, err := BuildConfig()
-	config.Timeout = 15 * time.Second
+	config.Timeout = 60 * time.Second
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -179,7 +179,7 @@ func kubeClient(t *testing.T) *kubernetes.Clientset {
 
 	config, err := BuildConfig()
 	require.NoError(t, err)
-	config.Timeout = 15 * time.Second
+	config.Timeout = 60 * time.Second
 
 	cSet, err := kubernetes.NewForConfig(config)
 	require.NoError(t, err)

--- a/pkg/controller/loadtest.go
+++ b/pkg/controller/loadtest.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/hellofresh/kangal/pkg/backends"
 	"github.com/hellofresh/kangal/pkg/core/observability"
-	kubekangal "github.com/hellofresh/kangal/pkg/kubernetes"
 	loadTestV1 "github.com/hellofresh/kangal/pkg/kubernetes/apis/loadtest/v1"
 	clientSetV "github.com/hellofresh/kangal/pkg/kubernetes/generated/clientset/versioned"
 	sampleScheme "github.com/hellofresh/kangal/pkg/kubernetes/generated/clientset/versioned/scheme"
@@ -275,7 +274,7 @@ func (c *Controller) processNextWorkItem() bool {
 // converge the two. It then updates the Status block of the LoadTest resource
 // with the current status of the resource.
 func (c *Controller) syncHandler(key string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), kubekangal.KubeTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	_, name, err := cache.SplitMetaNamespaceKey(key)

--- a/pkg/controller/loadtest.go
+++ b/pkg/controller/loadtest.go
@@ -35,6 +35,7 @@ const (
 	controllerAgentName = "kangal"
 	falseString         = "false"
 	trueString          = "true"
+	syncHandlerTimeout  = time.Minute
 )
 
 // Controller is the controller implementation for LoadTest resources
@@ -274,7 +275,7 @@ func (c *Controller) processNextWorkItem() bool {
 // converge the two. It then updates the Status block of the LoadTest resource
 // with the current status of the resource.
 func (c *Controller) syncHandler(key string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), syncHandlerTimeout)
 	defer cancel()
 
 	_, name, err := cache.SplitMetaNamespaceKey(key)

--- a/pkg/controller/loadtest.go
+++ b/pkg/controller/loadtest.go
@@ -35,7 +35,6 @@ const (
 	controllerAgentName = "kangal"
 	falseString         = "false"
 	trueString          = "true"
-	syncHandlerTimeout  = time.Minute
 )
 
 // Controller is the controller implementation for LoadTest resources
@@ -275,7 +274,7 @@ func (c *Controller) processNextWorkItem() bool {
 // converge the two. It then updates the Status block of the LoadTest resource
 // with the current status of the resource.
 func (c *Controller) syncHandler(key string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), syncHandlerTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), c.cfg.SyncHandlerTimeout)
 	defer cancel()
 
 	_, name, err := cache.SplitMetaNamespaceKey(key)

--- a/pkg/controller/test_helper.go
+++ b/pkg/controller/test_helper.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"time"
 
 	coreV1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -215,5 +216,6 @@ func BuildConfig() (*rest.Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	config.Timeout = 15 * time.Second
 	return config, nil
 }

--- a/pkg/controller/test_helper.go
+++ b/pkg/controller/test_helper.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/hellofresh/kangal/pkg/backends"
 	"github.com/hellofresh/kangal/pkg/core/waitfor"
-	"github.com/hellofresh/kangal/pkg/kubernetes"
 	apisLoadTestV1 "github.com/hellofresh/kangal/pkg/kubernetes/apis/loadtest/v1"
 	clientSetV "github.com/hellofresh/kangal/pkg/kubernetes/generated/clientset/versioned"
 )
@@ -62,8 +61,7 @@ func CreateLoadTest(clientSet clientSetV.Clientset, pods int32, name, testFile, 
 	ltObj.Name = name
 	ltObj.Spec = loadTestSpec
 
-	ctx, cancel := context.WithTimeout(context.Background(), kubernetes.KubeTimeout)
-	defer cancel()
+	ctx := context.Background()
 
 	_, err = clientSet.KangalV1().LoadTests().Create(ctx, ltObj, metaV1.CreateOptions{})
 	if err != nil {
@@ -98,8 +96,7 @@ func WaitLoadTest(clientSet clientSetV.Clientset, loadtestName string) error {
 // DeleteLoadTest deletes a load test CR
 func DeleteLoadTest(clientSet clientSetV.Clientset, loadtestName string, testname string) error {
 	fmt.Printf("Deleting object %v for the test %v \n", loadtestName, testname)
-	ctx, cancel := context.WithTimeout(context.Background(), kubernetes.KubeTimeout)
-	defer cancel()
+	ctx := context.Background()
 
 	if err := clientSet.KangalV1().LoadTests().Delete(ctx, loadtestName, metaV1.DeleteOptions{}); err != nil {
 		return err
@@ -109,8 +106,7 @@ func DeleteLoadTest(clientSet clientSetV.Clientset, loadtestName string, testnam
 
 // GetLoadTest returns a load test name
 func GetLoadTest(clientSet clientSetV.Clientset, loadtestName string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), kubernetes.KubeTimeout)
-	defer cancel()
+	ctx := context.Background()
 
 	result, err := clientSet.KangalV1().LoadTests().Get(ctx, loadtestName, metaV1.GetOptions{})
 	if err != nil {
@@ -121,8 +117,7 @@ func GetLoadTest(clientSet clientSetV.Clientset, loadtestName string) (string, e
 
 // GetLoadTestTestdata returns a load test name
 func GetLoadTestTestdata(clientSet clientSetV.Clientset, loadtestName string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), kubernetes.KubeTimeout)
-	defer cancel()
+	ctx := context.Background()
 
 	result, err := clientSet.KangalV1().LoadTests().Get(ctx, loadtestName, metaV1.GetOptions{})
 	if err != nil {
@@ -133,8 +128,7 @@ func GetLoadTestTestdata(clientSet clientSetV.Clientset, loadtestName string) (s
 
 // GetLoadTestLabels returns load test labels.
 func GetLoadTestLabels(clientSet clientSetV.Clientset, loadtestName string) (map[string]string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), kubernetes.KubeTimeout)
-	defer cancel()
+	ctx := context.Background()
 
 	result, err := clientSet.KangalV1().LoadTests().Get(ctx, loadtestName, metaV1.GetOptions{})
 	if err != nil {
@@ -145,8 +139,7 @@ func GetLoadTestLabels(clientSet clientSetV.Clientset, loadtestName string) (map
 
 // GetLoadTestEnvVars returns a load test name
 func GetLoadTestEnvVars(clientSet clientSetV.Clientset, loadtestName string) (map[string]string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), kubernetes.KubeTimeout)
-	defer cancel()
+	ctx := context.Background()
 
 	result, err := clientSet.KangalV1().LoadTests().Get(ctx, loadtestName, metaV1.GetOptions{})
 	if err != nil {
@@ -157,8 +150,7 @@ func GetLoadTestEnvVars(clientSet clientSetV.Clientset, loadtestName string) (ma
 
 // GetLoadTestNamespace returns a load test namespace
 func GetLoadTestNamespace(clientSet clientSetV.Clientset, loadtestName string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), kubernetes.KubeTimeout)
-	defer cancel()
+	ctx := context.Background()
 
 	result, err := clientSet.KangalV1().LoadTests().Get(ctx, loadtestName, metaV1.GetOptions{})
 	if err != nil {
@@ -169,8 +161,7 @@ func GetLoadTestNamespace(clientSet clientSetV.Clientset, loadtestName string) (
 
 // GetLoadTestPhase returns the current phase of given loadtest
 func GetLoadTestPhase(clientSet clientSetV.Clientset, loadtestName string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), kubernetes.KubeTimeout)
-	defer cancel()
+	ctx := context.Background()
 
 	result, err := clientSet.KangalV1().LoadTests().Get(ctx, loadtestName, metaV1.GetOptions{})
 	if err != nil {
@@ -181,8 +172,7 @@ func GetLoadTestPhase(clientSet clientSetV.Clientset, loadtestName string) (stri
 
 // GetDistributedPods returns a number of distributed pods in load test namespace
 func GetDistributedPods(clientSet typeV1.CoreV1Interface, namespace string) (coreV1.PodList, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), kubernetes.KubeTimeout)
-	defer cancel()
+	ctx := context.Background()
 
 	opts := metaV1.ListOptions{
 		LabelSelector: "app=loadtest-worker-pod",
@@ -196,8 +186,7 @@ func GetDistributedPods(clientSet typeV1.CoreV1Interface, namespace string) (cor
 
 // GetSecret returns a list of created secrets according to the given label
 func GetSecret(clientSet typeV1.CoreV1Interface, namespace string) (coreV1.SecretList, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), kubernetes.KubeTimeout)
-	defer cancel()
+	ctx := context.Background()
 
 	opts := metaV1.ListOptions{
 		LabelSelector: "secret-source=env-vars-from-file",

--- a/pkg/controller/test_helper.go
+++ b/pkg/controller/test_helper.go
@@ -19,6 +19,10 @@ import (
 	clientSetV "github.com/hellofresh/kangal/pkg/kubernetes/generated/clientset/versioned"
 )
 
+const (
+	kubeClientDefaultTimeout = 1 * time.Minute
+)
+
 // CreateLoadTest creates a load test CR
 func CreateLoadTest(clientSet clientSetV.Clientset, pods int32, name, testFile, testData string, envVars map[string]string, loadTestType apisLoadTestV1.LoadTestType) error {
 	var td = ""
@@ -205,6 +209,6 @@ func BuildConfig() (*rest.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	config.Timeout = 30 * time.Second
+	config.Timeout = kubeClientDefaultTimeout
 	return config, nil
 }

--- a/pkg/controller/test_helper.go
+++ b/pkg/controller/test_helper.go
@@ -205,6 +205,6 @@ func BuildConfig() (*rest.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	config.Timeout = 15 * time.Second
+	config.Timeout = 30 * time.Second
 	return config, nil
 }

--- a/pkg/core/waitfor/waitfor.go
+++ b/pkg/core/waitfor/waitfor.go
@@ -2,12 +2,12 @@ package waitfor
 
 import (
 	"context"
+	"time"
 
 	coreV1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	watchtools "k8s.io/client-go/tools/watch"
 
-	"github.com/hellofresh/kangal/pkg/kubernetes"
 	apisLoadTestV1 "github.com/hellofresh/kangal/pkg/kubernetes/apis/loadtest/v1"
 )
 
@@ -53,7 +53,7 @@ func (Condition) LoadTestFinished(event watch.Event) (bool, error) {
 
 // Resource waits until a kubernetes resources to match a condition
 func Resource(obj watch.Interface, condFunc watchtools.ConditionFunc) (*watch.Event, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), kubernetes.KubeTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	return watchtools.UntilWithoutRetry(ctx, obj, condFunc)

--- a/pkg/core/waitfor/waitfor.go
+++ b/pkg/core/waitfor/waitfor.go
@@ -11,6 +11,12 @@ import (
 	apisLoadTestV1 "github.com/hellofresh/kangal/pkg/kubernetes/apis/loadtest/v1"
 )
 
+const (
+	// waitForResourceTimeout is the timeout used to wait until a resource reaches a desired state
+	// TODO: Move as envconfig?
+	waitForResourceTimeout = 30 * time.Second
+)
+
 // Condition contains useful functions for watch conditions
 type Condition struct {
 }
@@ -53,7 +59,7 @@ func (Condition) LoadTestFinished(event watch.Event) (bool, error) {
 
 // Resource waits until a kubernetes resources to match a condition
 func Resource(obj watch.Interface, condFunc watchtools.ConditionFunc) (*watch.Event, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), waitForResourceTimeout)
 	defer cancel()
 
 	return watchtools.UntilWithoutRetry(ctx, obj, condFunc)

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -14,6 +14,7 @@ import (
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	restClient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 
 	apisLoadTestV1 "github.com/hellofresh/kangal/pkg/kubernetes/apis/loadtest/v1"
 	loadTestV1 "github.com/hellofresh/kangal/pkg/kubernetes/generated/clientset/versioned/typed/loadtest/v1"
@@ -234,4 +235,15 @@ func sortWorkerPods(pods *coreV1.PodList) {
 	sort.Slice(pods.Items, func(i, j int) bool {
 		return strings.Compare(pods.Items[i].ObjectMeta.Name, pods.Items[j].ObjectMeta.Name) < 0
 	})
+}
+
+// BuildKubeClientConfig is used in cmd package
+func BuildKubeClientConfig(masterURL string, kubeConfigPath string, timeout time.Duration) (*restClient.Config, error) {
+	kubeCfg, err := clientcmd.BuildConfigFromFlags(masterURL, kubeConfigPath)
+	if err != nil {
+		return nil, err
+	}
+
+	kubeCfg.Timeout = timeout
+	return kubeCfg, nil
 }

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -237,8 +237,8 @@ func sortWorkerPods(pods *coreV1.PodList) {
 	})
 }
 
-// BuildKubeClientConfig is used in cmd package
-func BuildKubeClientConfig(masterURL string, kubeConfigPath string, timeout time.Duration) (*restClient.Config, error) {
+// BuildClientConfig is used in cmd package
+func BuildClientConfig(masterURL string, kubeConfigPath string, timeout time.Duration) (*restClient.Config, error) {
 	kubeCfg, err := clientcmd.BuildConfigFromFlags(masterURL, kubeConfigPath)
 	if err != nil {
 		return nil, err

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -27,11 +27,6 @@ var (
 	gracePeriod = int64(0)
 )
 
-const (
-	// KubeTimeout timeout for kubernetes methods
-	KubeTimeout = 30 * time.Second
-)
-
 //Client manages calls to Kubernetes API
 type Client struct {
 	ltClient   loadTestV1.LoadTestInterface

--- a/pkg/kubernetes/client_test.go
+++ b/pkg/kubernetes/client_test.go
@@ -20,8 +20,7 @@ import (
 )
 
 func TestCreateLoadTest(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
-	defer cancel()
+	ctx := context.Background()
 
 	var logger = zap.NewNop()
 	loadtestClientSet := fakeClientset.NewSimpleClientset()
@@ -43,8 +42,7 @@ func TestCreateLoadTest(t *testing.T) {
 }
 
 func TestCreateLoadTestWithError(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
-	defer cancel()
+	ctx := context.Background()
 
 	var logger = zap.NewNop()
 	loadtestClientset := fakeClientset.NewSimpleClientset()
@@ -63,8 +61,7 @@ func TestCreateLoadTestWithError(t *testing.T) {
 }
 
 func TestDeleteLoadTest(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
-	defer cancel()
+	ctx := context.Background()
 
 	var logger = zap.NewNop()
 	loadtestClientset := fakeClientset.NewSimpleClientset()
@@ -82,8 +79,7 @@ func TestDeleteLoadTest(t *testing.T) {
 }
 
 func TestCreateLoadTestCRNoLoadTest(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
-	defer cancel()
+	ctx := context.Background()
 
 	var logger = zap.NewNop()
 	loadtestClientset := fakeClientset.NewSimpleClientset()
@@ -132,8 +128,7 @@ func TestGetLoadTestsByLabel(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
-			defer cancel()
+			ctx := context.Background()
 
 			var logger = zap.NewNop()
 			loadtestClientset := fakeClientset.NewSimpleClientset()
@@ -155,8 +150,7 @@ func TestGetLoadTestsByLabel(t *testing.T) {
 }
 
 func TestGetLoadTest(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
-	defer cancel()
+	ctx := context.Background()
 
 	var logger = zap.NewNop()
 	loadtestClientset := fakeClientset.NewSimpleClientset()
@@ -266,8 +260,7 @@ func TestClient_ListLoadTest(t *testing.T) {
 		t.Run(tc.scenario, func(t *testing.T) {
 			t.Parallel()
 
-			ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
-			defer cancel()
+			ctx := context.Background()
 
 			loadTestClientSet := fakeClientset.NewSimpleClientset()
 			kubeClientSet := fake.NewSimpleClientset()
@@ -363,8 +356,7 @@ func TestClient_filterLoadTestsByPhase(t *testing.T) {
 }
 
 func TestCountActiveLoadTests(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
-	defer cancel()
+	ctx := context.Background()
 
 	loadtestClientset := fakeClientset.NewSimpleClientset()
 	kubeClientSet := fake.NewSimpleClientset()
@@ -399,8 +391,7 @@ func TestCountActiveLoadTests(t *testing.T) {
 }
 
 func TestGetLoadTestNoLoadTest(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
-	defer cancel()
+	ctx := context.Background()
 
 	var logger = zap.NewNop()
 	loadtestClientset := fakeClientset.NewSimpleClientset()
@@ -418,8 +409,7 @@ func TestGetLoadTestNoLoadTest(t *testing.T) {
 }
 
 func TestGetMasterPodLogs(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), KubeTimeout)
-	defer cancel()
+	ctx := context.Background()
 
 	var logger = zap.NewNop()
 	loadtestClientset := fakeClientset.NewSimpleClientset()

--- a/pkg/proxy/config.go
+++ b/pkg/proxy/config.go
@@ -1,6 +1,8 @@
 package proxy
 
 import (
+	"time"
+
 	"github.com/hellofresh/kangal/pkg/core/observability"
 	"github.com/hellofresh/kangal/pkg/report"
 )
@@ -17,8 +19,8 @@ type Config struct {
 	MaxListLimit    int64 `envconfig:"MAX_LIST_LIMIT" required:"true" default:"50"`
 	MasterURL       string
 
-	// KubeClientTimeoutSeconds specifies timeout for each operation done by kube client
-	KubeClientTimeoutSeconds uint `envconfig:"KUBE_CLIENT_TIMEOUT_SECONDS" default:"5"`
+	// KubeClientTimeout specifies timeout for each operation done by kube client
+	KubeClientTimeout time.Duration `envconfig:"KUBE_CLIENT_TIMEOUT" default:"5s"`
 }
 
 // OpenAPIConfig is the OpenAPI specification-specific parameters

--- a/pkg/proxy/config.go
+++ b/pkg/proxy/config.go
@@ -16,6 +16,9 @@ type Config struct {
 	MaxLoadTestsRun int
 	MaxListLimit    int64 `envconfig:"MAX_LIST_LIMIT" required:"true" default:"50"`
 	MasterURL       string
+
+	// KubeClientTimeoutSeconds specifies timeout for each operation done by kube client
+	KubeClientTimeoutSeconds uint `envconfig:"KUBE_CLIENT_TIMEOUT_SECONDS" default:"5"`
 }
 
 // OpenAPIConfig is the OpenAPI specification-specific parameters

--- a/pkg/proxy/service.go
+++ b/pkg/proxy/service.go
@@ -51,10 +51,6 @@ func NewLoadTestServiceServer(kubeClient *kube.Client, registry backends.Registr
 // Get returns load test by given name
 func (s *implLoadTestServiceServer) Get(ctx context.Context, in *grpcProxyV2.GetRequest) (*grpcProxyV2.GetResponse, error) {
 	logger := ctxzap.Extract(ctx)
-
-	ctx, cancel := context.WithTimeout(ctx, kube.KubeTimeout)
-	defer cancel()
-
 	logger.Debug("Retrieving info for loadtest", zap.String("name", in.GetName()))
 
 	result, err := s.kubeClient.GetLoadTest(ctx, in.GetName())
@@ -197,10 +193,6 @@ func (s *implLoadTestServiceServer) Create(ctx context.Context, in *grpcProxyV2.
 // List searches and returns load tests by given filters
 func (s *implLoadTestServiceServer) List(ctx context.Context, in *grpcProxyV2.ListRequest) (*grpcProxyV2.ListResponse, error) {
 	logger := ctxzap.Extract(ctx)
-
-	ctx, cancel := context.WithTimeout(ctx, kube.KubeTimeout)
-	defer cancel()
-
 	logger.Debug("Retrieving list of load tests", zap.Any("in", in))
 
 	opt := kube.ListOptions{
@@ -251,10 +243,6 @@ func (s *implLoadTestServiceServer) List(ctx context.Context, in *grpcProxyV2.Li
 // Delete deletes a load test
 func (s *implLoadTestServiceServer) Delete(ctx context.Context, in *grpcProxyV2.DeleteRequest) (*grpcProxyV2.DeleteResponse, error) {
 	logger := ctxzap.Extract(ctx)
-
-	ctx, cancel := context.WithTimeout(ctx, kube.KubeTimeout)
-	defer cancel()
-
 	logger.Debug("Deleting loadtest", zap.String("name", in.GetName()))
 
 	err := s.kubeClient.DeleteLoadTest(ctx, in.GetName())


### PR DESCRIPTION
This PR:
- Sets a default 5 seconds timeout to controller and proxy kubeClient 
  - Adds `KUBE_CLIENT_TIMEOUT` environment variable to configure this
- Sets a default 15 seconds timeout to kubeClients in integration tests
- Removes all uses of `KubeTimeout`
- Adds 60 seconds timeout to controller syncHandler
- Retains 30 seconds timeout (from `KubeTimeout`) when waiting for kube resources to appear