### PR TITLE
Push docker images to hellofresh org

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,8 +21,8 @@ dockers:
     binaries:
       - kangal
     image_templates:
-      - "hellofreshtech/kangal:latest"
-      - "hellofreshtech/kangal:{{.Tag}}"
+      - "hellofresh/kangal:latest"
+      - "hellofresh/kangal:{{.Tag}}"
     dockerfile: Dockerfile
     extra_files:
       - openapi.json

--- a/charts/kangal/Chart.yaml
+++ b/charts/kangal/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - performance tests
   - tests runner
 name: kangal
-version: 1.4.8
+version: 1.4.9
 home: https://github.com/hellofresh/kangal
 icon: https://raw.githubusercontent.com/hellofresh/kangal/master/logo.svg
 maintainers:

--- a/charts/kangal/README.md
+++ b/charts/kangal/README.md
@@ -78,9 +78,9 @@ The following table lists the common configurable parameters for `Kangal` chart:
 | `configmap.AWS_BUCKET_NAME`          | The name of the bucket for saving reports                                                           | `my-bucket`                           |
 | `configmap.AWS_ENDPOINT_URL`         | Storage connection parameter                                                                        | `s3.us-east-1.amazonaws.com`          |
 | `configmap.AWS_DEFAULT_REGION`       | Storage connection parameter                                                                        | `us-east-1`                           |
-| `configmap.JMETER_MASTER_IMAGE_NAME` | Default JMeter master image name/repository if none is provided when creating a new loadtest        | `hellofreshtech/kangal-jmeter-master` |
+| `configmap.JMETER_MASTER_IMAGE_NAME` | Default JMeter master image name/repository if none is provided when creating a new loadtest        | `hellofresh/kangal-jmeter-master` |
 | `configmap.JMETER_MASTER_IMAGE_TAG`  | Tag of the JMeter master image above                                                                | `latest`                              |
-| `configmap.JMETER_WORKER_IMAGE_NAME` | Default JMeter worker image name/repository if none is provided when creating a new loadtest        | `hellofreshtech/kangal-jmeter-worker` |
+| `configmap.JMETER_WORKER_IMAGE_NAME` | Default JMeter worker image name/repository if none is provided when creating a new loadtest        | `hellofresh/kangal-jmeter-worker` |
 | `configmap.JMETER_WORKER_IMAGE_TAG`  | Tag of the JMeter worker image above                                                                | `latest`                              |
 | `configmap.LOCUST_IMAGE_NAME`        | Default Locust image name/repository if none is provided when creating a new loadtest               | `locustio/locust`                     |
 | `configmap.LOCUST_IMAGE_TAG`         | Tag of the Locust image above                                                                       | `1.3.0`                               |
@@ -90,7 +90,7 @@ Deployment specific configurations:
 ### Kangal Proxy
 | Parameter                               | Description                                           | Default                                |
 |-----------------------------------------|-------------------------------------------------------|----------------------------------------|
-| `proxy.image.repository`                | Repository of the image                               | `hellofreshtech/kangal`                |
+| `proxy.image.repository`                | Repository of the image                               | `hellofresh/kangal`                |
 | `proxy.image.tag`                       | Tag of the image                                      | `latest`                               |
 | `proxy.image.pullPolicy`                | Pull policy of the image                              | `Always`                               |
 | `proxy.args`                            | Argument for `kangal` command                         | `["proxy"]`                            |
@@ -142,7 +142,7 @@ Deployment specific configurations:
 ### Kangal Controller
 | Parameter                             | Description                                | Default                      |
 |---------------------------------------|--------------------------------------------|------------------------------|
-| `controller.image.repository`         | Repository of the image                    | `hellofreshtech/kangal`      |
+| `controller.image.repository`         | Repository of the image                    | `hellofresh/kangal`      |
 | `controller.image.tag`                | Tag of the image                           | `latest`                     |
 | `controller.image.pullPolicy`         | Pull policy of the image                   | `Always`                     |
 | `controller.args`                     | Argument for `kangal` command              | `["controller"]`             |

--- a/charts/kangal/values.yaml
+++ b/charts/kangal/values.yaml
@@ -10,7 +10,7 @@ proxy:
   replicaCount: 2
 
   image:
-    repository: hellofreshtech/kangal
+    repository: hellofresh/kangal
     tag: latest
     pullPolicy: Always
 
@@ -83,7 +83,7 @@ controller:
   replicaCount: 1
 
   image:
-    repository: hellofreshtech/kangal
+    repository: hellofresh/kangal
     tag: latest
     pullPolicy: Always
 
@@ -172,9 +172,9 @@ configMap:
   AWS_ENDPOINT_URL: "s3.us-east-1.amazonaws.com"
   AWS_BUCKET_NAME: "my-bucket"
   AWS_DEFAULT_REGION: "us-east-1"
-  JMETER_MASTER_IMAGE_NAME: "hellofreshtech/kangal-jmeter-master"
+  JMETER_MASTER_IMAGE_NAME: "hellofresh/kangal-jmeter-master"
   JMETER_MASTER_IMAGE_TAG: "latest"
-  JMETER_WORKER_IMAGE_NAME: "hellofreshtech/kangal-jmeter-worker"
+  JMETER_WORKER_IMAGE_NAME: "hellofresh/kangal-jmeter-worker"
   JMETER_WORKER_IMAGE_TAG: "latest"
   LOCUST_IMAGE_NAME: "locustio/locust"
   LOCUST_IMAGE_TAG: "1.3.0"

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ In this section you can find information about load generators and how to write 
 Currently, there are the following load generator types implemented for Kangal:
 
 - **Fake** - Mock up provider used for testing purpouses, not generating any load.
-- **JMeter** - Kangal creates JMeter load test environments based on [hellofreshtech/kangal-jmeter](https://github.com/hellofresh/kangal-jmeter) docker image.
+- **JMeter** - Kangal creates JMeter load test environments based on [hellofresh/kangal-jmeter](https://github.com/hellofresh/kangal-jmeter) docker image.
 - **Locust** - Kangal creates Locust load test environments based on official docker image [locustio/locust](https://hub.docker.com/r/locustio/locust).
 
 ### JMeter

--- a/docs/jmeter/README.md
+++ b/docs/jmeter/README.md
@@ -9,7 +9,7 @@
 
 JMeter is one of the load generators used in Kangal. A powerful tool which can be used for different performance testing tasks.
 
-Currently Kangal uses the docker image [hellofreshtech/kangal-jmeter](https://github.com/hellofresh/kangal-jmeter) based on JMeter v5.0 r1840935.
+Currently Kangal uses the docker image [hellofresh/kangal-jmeter](https://github.com/hellofresh/kangal-jmeter) based on JMeter v5.0 r1840935.
 
 Apache JMeter features include ability to create and run performance test for different applications/server/protocol types:
 

--- a/pkg/backends/jmeter/backend.go
+++ b/pkg/backends/jmeter/backend.go
@@ -31,8 +31,8 @@ var (
 )
 
 const (
-	defaultMasterImageName = "hellofreshtech/kangal-jmeter-master"
-	defaultWorkerImageName = "hellofreshtech/kangal-jmeter-worker"
+	defaultMasterImageName = "hellofresh/kangal-jmeter-master"
+	defaultWorkerImageName = "hellofresh/kangal-jmeter-worker"
 	defaultMasterImageTag  = "latest"
 	defaultWorkerImageTag  = "latest"
 )


### PR DESCRIPTION
This PR changes DockerHub account target to Hellofresh [official](https://hub.docker.com/u/hellofresh).