### PR TITLE
Fix non tar static report serving

### DIFF
--- a/pkg/report/handler_test.go
+++ b/pkg/report/handler_test.go
@@ -38,13 +38,18 @@ func (fakeFS) Open(name string) (http.File, error) {
 }
 
 func TestShowHandler(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
 	req, err := http.NewRequest("GET", "/load-test/loadtest-name/report/", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// init dependencies for report package
-	minioClient, _ = minio.New("localhost:80", "access-key", "secret-access-key", false)
+	minioClient, _ = minio.New(srv.Listener.Addr().String(), "access-key", "secret-access-key", false)
 	bucketName = "bucket-name"
 	fs = &fakeFS{}
 


### PR DESCRIPTION
closes #117

Non-tar static files were unable to be served because they didn't have a dedicated condition for those kinds of files.
This PR adds a condition to handle non-tar files.