### PR TITLE
Make install text a bit clearer

### DIFF
--- a/charts/kangal/Chart.yaml
+++ b/charts/kangal/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - performance tests
   - tests runner
 name: kangal
-version: 2.0.1
+version: 2.0.2
 home: https://github.com/hellofresh/kangal
 icon: https://raw.githubusercontent.com/hellofresh/kangal/master/logo.svg
 maintainers:

--- a/charts/kangal/README.md
+++ b/charts/kangal/README.md
@@ -19,21 +19,25 @@ To install the chart with the release name `kangal`:
 $ helm install kangal kangal/kangal
 ```
 
-> **Tip**: You can provide values on the command line with `--set` or using the `values` file with `-f my-values-file.yaml`. Eg.:
-To set AWS credentials using command line you can use the following flags:
-
-```
-  --set secrets.AWS_ACCESS_KEY_ID="my-aws-key-id" \
-  --set secrets.AWS_SECRET_ACCESS_KEY="my-aws-secret-access-key" \
-```
-
-or using setting this into your `values` file:
-
-```yaml
-secrets:
-  AWS_ACCESS_KEY_ID: my-aws-key-id
-  AWS_SECRET_ACCESS_KEY: my-aws-secret-access-key
-```
+> **Tip**: You can provide custom installation parameters, so, for example, to set AWS credentials you can use this command:
+> ```shell
+> helm install \
+>   --set secrets.AWS_ACCESS_KEY_ID="my-aws-key-id" \
+>   --set secrets.AWS_SECRET_ACCESS_KEY="my-aws-secret-access-key" \
+>   kangal kangal/kangal
+> ```
+> 
+> Alternatively, you can create a `values` file to provide those parameters, so, create a `my-values.yaml` file with the following content:
+> ```yaml
+> secrets:
+>   AWS_ACCESS_KEY_ID: my-aws-key-id
+>   AWS_SECRET_ACCESS_KEY: my-aws-secret-access-key
+> ```
+> and then use this command:
+> ```shell
+> helm install -f my-values.yaml kangal kangal/kangal
+> ```
+> See the default chart values file at [charts/kangal/values.yaml](/charts/kangal/values.yaml)
 
 To install the chart with the release name `kangal` and use an specific version:
 ```shell

--- a/charts/kangal/README.md
+++ b/charts/kangal/README.md
@@ -19,6 +19,9 @@ To install the chart with the release name `kangal`:
 $ helm install kangal kangal/kangal
 ```
 
+The command deploys Kangal on the Kubernetes cluster in the default configuration.
+It also creates the Custom Resource Definition (CRD) if not exists.
+
 > **Tip**: You can provide custom installation parameters, so, for example, to set AWS credentials you can use this command:
 > ```shell
 > helm install \
@@ -46,9 +49,6 @@ $ helm install \
   --set controller.image.tag=1.0.3 \
   kangal kangal/kangal
 ```
-
-The command deploys Kangal on the Kubernetes cluster in the default configuration.
-It also applies the latest version of Custom Resource Definition (CRD) to the cluster.
 
 > **Tip**: List all releases using `helm list`
 

--- a/charts/kangal/values.yaml
+++ b/charts/kangal/values.yaml
@@ -2,6 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+version: &version latest
 environment: dev
 nameOverride: ""
 fullnameOverride: ""
@@ -12,7 +13,7 @@ proxy:
 
   image:
     repository: hellofresh/kangal
-    tag: latest
+    tag: *version
     pullPolicy: Always
 
   # Arguments for kangal command
@@ -85,7 +86,7 @@ controller:
 
   image:
     repository: hellofresh/kangal
-    tag: latest
+    tag: *version
     pullPolicy: Always
 
   # Arguments for kangal command


### PR DESCRIPTION
Improves the install docs text and make it clear, also adds a link to `values.yaml`.