### PR TITLE
Add AWS secure env

### DIFF
--- a/charts/kangal/Chart.yaml
+++ b/charts/kangal/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - performance tests
   - tests runner
 name: kangal
-version: 2.0.1
+version: 2.0.2
 home: https://github.com/hellofresh/kangal
 icon: https://raw.githubusercontent.com/hellofresh/kangal/master/logo.svg
 maintainers:

--- a/charts/kangal/README.md
+++ b/charts/kangal/README.md
@@ -75,6 +75,8 @@ The following table lists the common configurable parameters for `Kangal` chart:
 | `configmap.AWS_BUCKET_NAME`          | The name of the bucket for saving reports                                                           | `my-bucket`                           |
 | `configmap.AWS_ENDPOINT_URL`         | Storage connection parameter                                                                        | `s3.us-east-1.amazonaws.com`          |
 | `configmap.AWS_DEFAULT_REGION`       | Storage connection parameter                                                                        | `us-east-1`                           |
+| `configmap.AWS_USE_HTTPS`            | Set to "true" to use HTTPS                                                                          | `false`                               |
+| `configmap.AWS_PRESIGNED_EXPIRES`    | Expiration time for Presigned URLs                                                                  | `30m`                                 |
 | `configmap.JMETER_MASTER_IMAGE_NAME` | Default JMeter master image name/repository if none is provided when creating a new loadtest        | `hellofresh/kangal-jmeter-master`     |
 | `configmap.JMETER_MASTER_IMAGE_TAG`  | Tag of the JMeter master image above                                                                | `latest`                              |
 | `configmap.JMETER_WORKER_IMAGE_NAME` | Default JMeter worker image name/repository if none is provided when creating a new loadtest        | `hellofresh/kangal-jmeter-worker`     |

--- a/pkg/report/config.go
+++ b/pkg/report/config.go
@@ -8,6 +8,6 @@ type Config struct {
 	AWSRegion           string `envconfig:"AWS_DEFAULT_REGION" default:""`
 	AWSEndpointURL      string `envconfig:"AWS_ENDPOINT_URL" default:""`
 	AWSBucketName       string `envconfig:"AWS_BUCKET_NAME" default:""`
-	AWSUseHTTPS         string `envconfig:"AWS_USE_HTTPS" default:""`
+	AWSUseHTTPS         bool   `envconfig:"AWS_USE_HTTPS" default:"false"`
 	AWSPresignedExpires string `envconfig:"AWS_PRESIGNED_EXPIRES" default:""`
 }

--- a/pkg/report/config.go
+++ b/pkg/report/config.go
@@ -8,5 +8,6 @@ type Config struct {
 	AWSRegion           string `envconfig:"AWS_DEFAULT_REGION" default:""`
 	AWSEndpointURL      string `envconfig:"AWS_ENDPOINT_URL" default:""`
 	AWSBucketName       string `envconfig:"AWS_BUCKET_NAME" default:""`
+	AWSUseHTTPS         string `envconfig:"AWS_USE_HTTPS" default:""`
 	AWSPresignedExpires string `envconfig:"AWS_PRESIGNED_EXPIRES" default:""`
 }

--- a/pkg/report/handler.go
+++ b/pkg/report/handler.go
@@ -170,14 +170,14 @@ func PersistHandler(kubeClient *kk8s.Client, logger *zap.Logger) func(w http.Res
 		}
 		defer proxyResp.Body.Close()
 
-		body := "Report persisted"
-
 		if http.StatusOK != proxyResp.StatusCode {
 			b, _ := ioutil.ReadAll(proxyResp.Body)
-			body = string(b)
+			logger.Error("Failed to persist report", zap.ByteString("error", b), zap.String("loadtest", loadTestName))
+			render.Render(w, r, khttp.ErrResponse(proxyResp.StatusCode, string(b)))
+			return
 		}
 
 		render.Status(r, proxyResp.StatusCode)
-		render.JSON(w, r, body)
+		render.JSON(w, r, "Report persisted")
 	}
 }

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -3,7 +3,6 @@ package report
 import (
 	"errors"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -56,16 +55,8 @@ func InitObjectStorageClient(cfg Config) error {
 	}
 	creds := credentials.NewChainCredentials(awsCredProviders)
 
-	secure := false
-	if cfg.AWSUseHTTPS != "" {
-		secure, err = strconv.ParseBool(cfg.AWSUseHTTPS)
-		if nil != err {
-			return err
-		}
-	}
-
 	// Init object storage (S3 compatible) client
-	minioClient, err = minio.NewWithCredentials(endpoint, creds, secure, cfg.AWSRegion)
+	minioClient, err = minio.NewWithCredentials(endpoint, creds, cfg.AWSUseHTTPS, cfg.AWSRegion)
 	if err != nil {
 		return err
 	}

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -3,6 +3,7 @@ package report
 import (
 	"errors"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -55,8 +56,16 @@ func InitObjectStorageClient(cfg Config) error {
 	}
 	creds := credentials.NewChainCredentials(awsCredProviders)
 
+	secure := false
+	if cfg.AWSUseHTTPS != "" {
+		secure, err = strconv.ParseBool(cfg.AWSUseHTTPS)
+		if nil != err {
+			return err
+		}
+	}
+
 	// Init object storage (S3 compatible) client
-	minioClient, err = minio.NewWithCredentials(endpoint, creds, false, cfg.AWSRegion)
+	minioClient, err = minio.NewWithCredentials(endpoint, creds, secure, cfg.AWSRegion)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
fixes #126

This PR adds a new ENV called `AWS_USE_HTTPS` that allows controlling the use of HTTPS.