### PR TITLE
Add ca-certificates on image to allow SSL connections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:20.10
 
-RUN mkdir -p /etc/kangal
+RUN apt-get update && \
+    apt-get install -y ca-certificates && \
+    mkdir -p /etc/kangal
 
 ADD kangal /bin/kangal
 ADD openapi.json /etc/kangal/

--- a/charts/kangal/Chart.yaml
+++ b/charts/kangal/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - performance tests
   - tests runner
 name: kangal
-version: 2.0.2
+version: 2.0.3
 home: https://github.com/hellofresh/kangal
 icon: https://raw.githubusercontent.com/hellofresh/kangal/master/logo.svg
 maintainers:

--- a/charts/kangal/values.yaml
+++ b/charts/kangal/values.yaml
@@ -171,6 +171,7 @@ configMap:
   AWS_DEFAULT_REGION: us-east-1
   AWS_ENDPOINT_URL: s3.us-east-1.amazonaws.com
   AWS_BUCKET_NAME: my-bucket
+  AWS_USE_HTTPS: "false"
   JMETER_MASTER_IMAGE_NAME: hellofresh/kangal-jmeter-master
   JMETER_MASTER_IMAGE_TAG: latest
   JMETER_WORKER_IMAGE_NAME: hellofresh/kangal-jmeter-worker


### PR DESCRIPTION
Currently, the docker image is unable to stablish HTTPS connections due to the lack of CA certificates.
This PR installs ca-certificates to allow HTTPS to work.