### PR TITLE
fix(openapi): fix typo in expected enum for backends in OpenApi

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -408,7 +408,7 @@
 		"schemas": {
 			"LoadTestType": {
 				"type": "string",
-				"enum": ["jMeter", "Fake", "Locust"]
+				"enum": ["JMeter", "Fake", "Locust"]
 			},
 			"LoadTestPhase": {
 				"type": "string",


### PR DESCRIPTION
This PR fixes a Typo currently in the OpenApi definition that can lead to some confusion:

Request using the "jMeter" `type` leads to "no backend registered error":
![image](https://user-images.githubusercontent.com/13805078/117066012-95cf6600-acfe-11eb-87a6-8b96721fa227.png)

Changing to `"JMeter"` (capital `J`) ([as expected in LoadTestTypeJMeter](https://github.com/hellofresh/kangal/blob/bcecba0938990191b6b97b0d1fc5146976764aaa/pkg/kubernetes/apis/loadtest/v1/types.go#L114)) and everything is ok:

![image](https://user-images.githubusercontent.com/13805078/117066529-37ef4e00-acff-11eb-8b33-3f25a96e8877.png)


:)
