### PR TITLE
Fixing the process of loadtests deletion 

### DIFF
--- a/ci/integration-tests.sh
+++ b/ci/integration-tests.sh
@@ -17,7 +17,7 @@ fi
 
 echo "Proxy is running"
 echo "Starting kangal controller"
-WEB_HTTP_PORT=8888 CLEANUP_THRESHOLD=30s SYNC_HANDLER_TIMEOUT=30s ./bin/kangal controller --kubeconfig="$HOME/.kube/config" >/tmp/kangal_controller.log 2>&1 &
+WEB_HTTP_PORT=8888 CLEANUP_THRESHOLD=10s SYNC_HANDLER_TIMEOUT=10s ./bin/kangal controller --kubeconfig="$HOME/.kube/config" >/tmp/kangal_controller.log 2>&1 &
 PID_CONTROLLER=$!
 sleep 1
 echo "Check if controller is running"

--- a/ci/integration-tests.sh
+++ b/ci/integration-tests.sh
@@ -17,7 +17,7 @@ fi
 
 echo "Proxy is running"
 echo "Starting kangal controller"
-WEB_HTTP_PORT=8888 CLEANUP_THRESHOLD=1m ./bin/kangal controller --kubeconfig="$HOME/.kube/config" >/tmp/kangal_controller.log 2>&1 &
+WEB_HTTP_PORT=8888 CLEANUP_THRESHOLD=30s ./bin/kangal controller --kubeconfig="$HOME/.kube/config" >/tmp/kangal_controller.log 2>&1 &
 PID_CONTROLLER=$!
 sleep 1
 echo "Check if controller is running"

--- a/ci/integration-tests.sh
+++ b/ci/integration-tests.sh
@@ -17,7 +17,7 @@ fi
 
 echo "Proxy is running"
 echo "Starting kangal controller"
-WEB_HTTP_PORT=8888 CLEANUP_THRESHOLD=30s ./bin/kangal controller --kubeconfig="$HOME/.kube/config" >/tmp/kangal_controller.log 2>&1 &
+WEB_HTTP_PORT=8888 CLEANUP_THRESHOLD=30s SYNC_HANDLER_TIMEOUT=30s ./bin/kangal controller --kubeconfig="$HOME/.kube/config" >/tmp/kangal_controller.log 2>&1 &
 PID_CONTROLLER=$!
 sleep 1
 echo "Check if controller is running"

--- a/ci/integration-tests.sh
+++ b/ci/integration-tests.sh
@@ -17,7 +17,7 @@ fi
 
 echo "Proxy is running"
 echo "Starting kangal controller"
-WEB_HTTP_PORT=8888 ./bin/kangal controller --kubeconfig="$HOME/.kube/config" >/tmp/kangal_controller.log 2>&1 &
+WEB_HTTP_PORT=8888 CLEANUP_THRESHOLD=1m ./bin/kangal controller --kubeconfig="$HOME/.kube/config" >/tmp/kangal_controller.log 2>&1 &
 PID_CONTROLLER=$!
 sleep 1
 echo "Check if controller is running"

--- a/pkg/controller/controller_integration_test.go
+++ b/pkg/controller/controller_integration_test.go
@@ -17,9 +17,10 @@ import (
 )
 
 func TestIntegrationKangalController(t *testing.T) {
-	// This integration test cover main idea and logic about Kangal controller
-	// First of all it creates new LoadTest resource, then it expects that Kangal Controller created resources
-	// and changed LoadTest status to "finished".
+	// This integration test covers main workflow of Kangal controller.
+	// First of all test_helper creates a new LoadTest object.
+	// After this Kangal controller creates all associated resources
+	// and updates LoadTest statuses from "created" to "finished".
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
@@ -41,73 +42,61 @@ func TestIntegrationKangalController(t *testing.T) {
 	err = WaitLoadTest(clientSet, expectedLoadtestName)
 	require.NoError(t, err)
 
-	//t.Cleanup(func() {
-	//	err := DeleteLoadTest(clientSet, expectedLoadtestName, t.Name())
-	//	assert.NoError(t, err)
-	//})
-
-	t.Run("Checking the name of created loadtest", func(t *testing.T) {
-		createdName, err := GetLoadTest(clientSet, expectedLoadtestName)
-		require.NoError(t, err)
-		assert.Equal(t, expectedLoadtestName, createdName)
+	t.Cleanup(func() {
+		if t.Failed() {
+			err := DeleteLoadTest(clientSet, expectedLoadtestName, t.Name())
+			assert.NoError(t, err)
+		}
 	})
 
-	t.Run("Checking namespace is created", func(t *testing.T) {
-		watchObj, _ := client.CoreV1().Namespaces().Watch(context.Background(), metaV1.ListOptions{
-			FieldSelector: fmt.Sprintf("metadata.name=%s", expectedLoadtestName),
-		})
+	// Checking the name of created loadtest
+	createdName, err := GetLoadTest(clientSet, expectedLoadtestName)
+	require.NoError(t, err)
+	require.Equal(t, expectedLoadtestName, createdName)
 
-		watchEvent, err := waitfor.Resource(watchObj, (waitfor.Condition{}).Added)
-		require.NoError(t, err)
-
-		namespace := watchEvent.Object.(*coreV1.Namespace)
-		require.Equal(t, expectedLoadtestName, namespace.Name)
+	// Checking namespace is created
+	watchObj, _ := client.CoreV1().Namespaces().Watch(context.Background(), metaV1.ListOptions{
+		FieldSelector: fmt.Sprintf("metadata.name=%s", expectedLoadtestName),
 	})
+	watchEvent, err := waitfor.Resource(watchObj, (waitfor.Condition{}).Added)
+	require.NoError(t, err)
+	namespace := watchEvent.Object.(*coreV1.Namespace)
+	require.Equal(t, expectedLoadtestName, namespace.Name)
 
-	t.Run("Checking master pod is created", func(t *testing.T) {
-		watchObj, _ := client.CoreV1().Pods(expectedLoadtestName).Watch(context.Background(), metaV1.ListOptions{
-			LabelSelector: "app=loadtest-master",
-		})
-
-		watchEvent, err := waitfor.Resource(watchObj, (waitfor.Condition{}).PodRunning)
-		require.NoError(t, err)
-
-		pod := watchEvent.Object.(*coreV1.Pod)
-		assert.Equal(t, coreV1.PodRunning, pod.Status.Phase)
+	// Checking master pod is created
+	watchObj, _ = client.CoreV1().Pods(expectedLoadtestName).Watch(context.Background(), metaV1.ListOptions{
+		LabelSelector: "app=loadtest-master",
 	})
+	watchEvent, err = waitfor.Resource(watchObj, (waitfor.Condition{}).PodRunning)
+	require.NoError(t, err)
+	pod := watchEvent.Object.(*coreV1.Pod)
+	require.Equal(t, coreV1.PodRunning, pod.Status.Phase)
 
-	t.Run("Checking loadtest is in Running state", func(t *testing.T) {
-		watchObj, _ := clientSet.KangalV1().LoadTests().Watch(context.Background(), metaV1.ListOptions{
-			FieldSelector: fmt.Sprintf("metadata.name=%s", expectedLoadtestName),
-		})
-
-		watchEvent, err := waitfor.Resource(watchObj, (waitfor.Condition{}).LoadTestRunning)
-		require.NoError(t, err)
-
-		loadtest := watchEvent.Object.(*loadTestV1.LoadTest)
-		assert.Equal(t, loadTestV1.LoadTestRunning, loadtest.Status.Phase)
+	// Checking loadtest is in Running state
+	watchObj, _ = clientSet.KangalV1().LoadTests().Watch(context.Background(), metaV1.ListOptions{
+		FieldSelector: fmt.Sprintf("metadata.name=%s", expectedLoadtestName),
 	})
+	watchEvent, err = waitfor.Resource(watchObj, (waitfor.Condition{}).LoadTestRunning)
+	require.NoError(t, err)
+	loadtest := watchEvent.Object.(*loadTestV1.LoadTest)
+	require.Equal(t, loadTestV1.LoadTestRunning, loadtest.Status.Phase)
 
-	t.Run("Checking loadtest is in Finished state", func(t *testing.T) {
-		// We do run fake provider which has 10 sec sleep before finishing job
-		watchObj, _ := clientSet.KangalV1().LoadTests().Watch(context.Background(), metaV1.ListOptions{
-			FieldSelector: fmt.Sprintf("metadata.name=%s", expectedLoadtestName),
-		})
-
-		watchEvent, err := waitfor.Resource(watchObj, (waitfor.Condition{}).LoadTestFinished)
-		require.NoError(t, err)
-
-		loadtest := watchEvent.Object.(*loadTestV1.LoadTest)
-		assert.Equal(t, loadTestV1.LoadTestFinished, loadtest.Status.Phase)
+	// Checking loadtest is in Finished state
+	// We use loadtests with fake provider which only runs for 10 sec and then finishes the job
+	watchObj, _ = clientSet.KangalV1().LoadTests().Watch(context.Background(), metaV1.ListOptions{
+		FieldSelector: fmt.Sprintf("metadata.name=%s", expectedLoadtestName),
 	})
+	watchEvent, err = waitfor.Resource(watchObj, (waitfor.Condition{}).LoadTestFinished)
+	require.NoError(t, err)
+	loadtest = watchEvent.Object.(*loadTestV1.LoadTest)
+	require.Equal(t, loadTestV1.LoadTestFinished, loadtest.Status.Phase)
 
-	t.Run("Checking loadtest is deleted", func(t *testing.T) {
-		// We expect the loadtest will be deleted after 1 min after it finished
-		time.Sleep(30 * time.Second)
-		lt, _ := clientSet.KangalV1().LoadTests().Get(context.Background(), expectedLoadtestName, metaV1.GetOptions{})
-
-		// assert that the returned object is empty which means lt "loadtest-fake-integration" was deleted
-		assert.Equal(t, "", lt.Name)
-		assert.Equal(t, "", lt.Namespace)
-	})
+	// Checking finished loadtest is deleted
+	// SyncHandler runs every 10s for integration test.
+	// We expect SyncHandler to delete finished loadtest after 10s but wait 30s to be sure
+	time.Sleep(30 * time.Second)
+	lt, _ := clientSet.KangalV1().LoadTests().Get(context.Background(), expectedLoadtestName, metaV1.GetOptions{})
+	// assert that the returned object is empty which means lt "loadtest-fake-integration" was deleted
+	assert.Equal(t, "", lt.Name)
+	assert.Equal(t, "", lt.Namespace)
 }

--- a/pkg/controller/controller_integration_test.go
+++ b/pkg/controller/controller_integration_test.go
@@ -40,10 +40,10 @@ func TestIntegrationKangalController(t *testing.T) {
 	err = WaitLoadTest(clientSet, expectedLoadtestName)
 	require.NoError(t, err)
 
-	t.Cleanup(func() {
-		err := DeleteLoadTest(clientSet, expectedLoadtestName, t.Name())
-		assert.NoError(t, err)
-	})
+	//t.Cleanup(func() {
+	//	err := DeleteLoadTest(clientSet, expectedLoadtestName, t.Name())
+	//	assert.NoError(t, err)
+	//})
 
 	t.Run("Checking the name of created loadtest", func(t *testing.T) {
 		createdName, err := GetLoadTest(clientSet, expectedLoadtestName)
@@ -98,5 +98,12 @@ func TestIntegrationKangalController(t *testing.T) {
 
 		loadtest := watchEvent.Object.(*loadTestV1.LoadTest)
 		assert.Equal(t, loadTestV1.LoadTestFinished, loadtest.Status.Phase)
+	})
+
+	t.Run("Checking loadtest is deleted", func(t *testing.T) {
+		// We expect the loadtest will be deleted after it finished
+		lt, _ := clientSet.KangalV1().LoadTests().Get(context.Background(), expectedLoadtestName, metaV1.GetOptions{})
+
+		assert.Equal(t, nil, lt)
 	})
 }

--- a/pkg/controller/controller_integration_test.go
+++ b/pkg/controller/controller_integration_test.go
@@ -93,10 +93,16 @@ func TestIntegrationKangalController(t *testing.T) {
 
 	// Checking finished loadtest is deleted
 	// SyncHandler runs every 10s for integration test.
-	// We expect SyncHandler to delete finished loadtest after 10s but wait 30s to be sure
-	time.Sleep(30 * time.Second)
-	lt, _ := clientSet.KangalV1().LoadTests().Get(context.Background(), expectedLoadtestName, metaV1.GetOptions{})
-	// assert that the returned object is empty which means lt "loadtest-fake-integration" was deleted
-	assert.Equal(t, "", lt.Name)
-	assert.Equal(t, "", lt.Namespace)
+	// We expect SyncHandler to delete finished loadtest after 10s but wait 30s and check every 5s
+	var deleted = false
+	for i := 0; i < 6; i++ {
+		time.Sleep(5 * time.Second)
+		lt, _ := clientSet.KangalV1().LoadTests().Get(context.Background(), expectedLoadtestName, metaV1.GetOptions{})
+		// assert that the returned object is empty which means lt "loadtest-fake-integration" was deleted
+		if lt.Name == "" && lt.Namespace == "" {
+			deleted = true
+			break
+		}
+	}
+	assert.True(t, deleted)
 }

--- a/pkg/controller/controller_integration_test.go
+++ b/pkg/controller/controller_integration_test.go
@@ -103,9 +103,11 @@ func TestIntegrationKangalController(t *testing.T) {
 
 	t.Run("Checking loadtest is deleted", func(t *testing.T) {
 		// We expect the loadtest will be deleted after 1 min after it finished
-		time.Sleep(60 * time.Second)
+		time.Sleep(30 * time.Second)
 		lt, _ := clientSet.KangalV1().LoadTests().Get(context.Background(), expectedLoadtestName, metaV1.GetOptions{})
 
-		assert.Equal(t, nil, lt)
+		// assert that the returned object is empty which means lt "loadtest-fake-integration" was deleted
+		assert.Equal(t, "", lt.Name)
+		assert.Equal(t, "", lt.Namespace)
 	})
 }

--- a/pkg/controller/controller_integration_test.go
+++ b/pkg/controller/controller_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -101,7 +102,8 @@ func TestIntegrationKangalController(t *testing.T) {
 	})
 
 	t.Run("Checking loadtest is deleted", func(t *testing.T) {
-		// We expect the loadtest will be deleted after it finished
+		// We expect the loadtest will be deleted after 1 min after it finished
+		time.Sleep(30)
 		lt, _ := clientSet.KangalV1().LoadTests().Get(context.Background(), expectedLoadtestName, metaV1.GetOptions{})
 
 		assert.Equal(t, nil, lt)

--- a/pkg/controller/controller_integration_test.go
+++ b/pkg/controller/controller_integration_test.go
@@ -103,7 +103,7 @@ func TestIntegrationKangalController(t *testing.T) {
 
 	t.Run("Checking loadtest is deleted", func(t *testing.T) {
 		// We expect the loadtest will be deleted after 1 min after it finished
-		time.Sleep(30)
+		time.Sleep(60 * time.Second)
 		lt, _ := clientSet.KangalV1().LoadTests().Get(context.Background(), expectedLoadtestName, metaV1.GetOptions{})
 
 		assert.Equal(t, nil, lt)

--- a/pkg/controller/controller_integration_test.go
+++ b/pkg/controller/controller_integration_test.go
@@ -93,9 +93,9 @@ func TestIntegrationKangalController(t *testing.T) {
 
 	// Checking finished loadtest is deleted
 	// SyncHandler runs every 10s for integration test.
-	// We expect SyncHandler to delete finished loadtest after 10s but wait 30s and check every 5s
-	var deleted = false
-	for i := 0; i < 6; i++ {
+	// We expect SyncHandler to delete finished loadtest after 10s but wait 40s and check every 5s
+	var deleted bool
+	for i := 0; i < 8; i++ {
 		time.Sleep(5 * time.Second)
 		lt, _ := clientSet.KangalV1().LoadTests().Get(context.Background(), expectedLoadtestName, metaV1.GetOptions{})
 		// assert that the returned object is empty which means lt "loadtest-fake-integration" was deleted
@@ -104,5 +104,5 @@ func TestIntegrationKangalController(t *testing.T) {
 			break
 		}
 	}
-	assert.True(t, deleted)
+	assert.True(t, deleted, "Looks like test was not deleted during expected time frame")
 }

--- a/pkg/controller/loadtest.go
+++ b/pkg/controller/loadtest.go
@@ -513,14 +513,14 @@ func checkLoadTestLifeTimeExceeded(loadTest *loadTestV1.LoadTest, deleteThreshol
 
 func (c *Controller) deleteLoadTest(ctx context.Context, key string, loadTest *loadTestV1.LoadTest) {
 	err := c.kangalClientSet.KangalV1().LoadTests().Delete(ctx, loadTest.Name, metaV1.DeleteOptions{})
-	if err != nil {
-		// The LoadTest resource may be conflicted, in which case we stop processing.
-		if errors.IsConflict(err) {
-			c.logger.Error("There is a conflict while deleting the loadtest", zap.Error(err))
-			utilRuntime.HandleError(fmt.Errorf("there is a conflict with loadtest %q between datastore and cache. it might be because object has been removed or modified in the datastore", key))
-			return
-		}
-		c.logger.Error("Failed to delete loadtest:", zap.Error(err))
+	if err == nil {
 		return
 	}
+
+	// The LoadTest resource may be conflicted, in which case we stop processing.
+	if errors.IsConflict(err) {
+		c.logger.Error("There is a conflict while deleting the loadtest", zap.Error(err))
+		utilRuntime.HandleError(fmt.Errorf("there is a conflict with loadtest %q between datastore and cache. It might be because object has been removed or modified in the datastore", key))
+	}
+	c.logger.Error("Failed to delete loadtest:", zap.Error(err))
 }


### PR DESCRIPTION
This PR: 
1. Updating controller integration test with a check if loadtest was deleted after finished. Setting `CLEANUP_THRESHOLD=10s` and `SYNC_HANDLER_TIMEOUT=10s` for test env to run Sync every 10s and delete the loadtest quickly.
2. Refactor controller integration test since all the checks depends on each other and it doesn't make sense to run it in subtest.
2. We need to run `checkLoadTestLifeTimeExceeded()` after `backend.SyncStatus()`. `SyncStatus` updates the loadtest status from jobs statuses. LoadTestStatus.JobStatus is empty until we run SyncStatus and can't be compared with `CleanUpThreshold` time. 