### PR TITLE
Feature/ees 5842 remove jmeter properties

### DIFF
--- a/pkg/backends/jmeter/backend.go
+++ b/pkg/backends/jmeter/backend.go
@@ -68,13 +68,17 @@ func (b *Backend) GetEnvConfig() interface{} {
 
 // SetDefaults must set default values
 func (b *Backend) SetDefaults() {
-	if b.config.MasterImageName == "" || b.config.MasterImageTag == "" {
+	if b.config.MasterImageName == "" {
 		b.config.MasterImageName = defaultMasterImageName
+	}
+	if b.config.MasterImageTag == "" {
 		b.config.MasterImageTag = defaultMasterImageTag
 	}
 
-	if b.config.WorkerImageName == "" || b.config.WorkerImageTag == "" {
+	if b.config.WorkerImageName == "" {
 		b.config.WorkerImageName = defaultWorkerImageName
+	}
+	if b.config.WorkerImageTag == "" {
 		b.config.WorkerImageTag = defaultWorkerImageTag
 	}
 
@@ -169,11 +173,6 @@ func (b *Backend) Sync(ctx context.Context, loadTest loadTestV1.LoadTest, report
 		_, err = b.kubeClientSet.CoreV1().ConfigMaps(loadTest.Status.Namespace).Create(ctx, b.NewConfigMap(loadTest), metaV1.CreateOptions{})
 		if err != nil && !kerrors.IsAlreadyExists(err) {
 			logger.Error("Error on creating testfile configmap", zap.Error(err))
-			return err
-		}
-
-		_, err = b.kubeClientSet.CoreV1().ConfigMaps(loadTest.Status.Namespace).Create(ctx, b.NewJMeterSettingsConfigMap(), metaV1.CreateOptions{})
-		if err != nil && !kerrors.IsAlreadyExists(err) {
 			return err
 		}
 

--- a/pkg/backends/jmeter/resources.go
+++ b/pkg/backends/jmeter/resources.go
@@ -142,7 +142,7 @@ func (b *Backend) NewPod(loadTest loadTestV1.LoadTest, i int, configMap *coreV1.
 	imageRef := fmt.Sprintf("%s:%s", loadTest.Spec.WorkerConfig.Image, loadTest.Spec.WorkerConfig.Tag)
 	if "" == loadTest.Spec.WorkerConfig.Image || "" == loadTest.Spec.WorkerConfig.Tag {
 		imageRef = fmt.Sprintf("%s:%s", b.workerConfig.Image, b.workerConfig.Tag)
-		logger.Warn("Loadtest.Spec.WorkerConfig is empty; using default worker image", zap.String("imageRef", imageRef))
+		logger.Debug("Loadtest.Spec.WorkerConfig is empty; using worker image from config", zap.String("imageRef", imageRef))
 	}
 
 	return &coreV1.Pod{
@@ -211,7 +211,7 @@ func (b *Backend) NewJMeterMasterJob(loadTest loadTestV1.LoadTest, reportURL str
 	imageRef := fmt.Sprintf("%s:%s", loadTest.Spec.MasterConfig.Image, loadTest.Spec.MasterConfig.Tag)
 	if "" == loadTest.Spec.MasterConfig.Image || "" == loadTest.Spec.MasterConfig.Tag {
 		imageRef = fmt.Sprintf("%s:%s", b.masterConfig.Image, b.masterConfig.Tag)
-		logger.Warn("Loadtest.Spec.MasterConfig is empty; using default master image", zap.String("imageRef", imageRef))
+		logger.Debug("Loadtest.Spec.MasterConfig is empty; using master image from config", zap.String("imageRef", imageRef))
 	}
 
 	jMeterEnvVars := []coreV1.EnvVar{

--- a/pkg/backends/jmeter/resources.go
+++ b/pkg/backends/jmeter/resources.go
@@ -56,44 +56,6 @@ var (
 	}
 )
 
-// NewJMeterSettingsConfigMap creates a new configmap which holds jmeter config
-func (b *Backend) NewJMeterSettingsConfigMap() *coreV1.ConfigMap {
-	data := map[string]string{
-		"jmeter.properties": `num_sample_threshold=5
-time_threshold=1000
-#---------------------------------------------------------------------------
-# Results file configuration
-#---------------------------------------------------------------------------
-jmeter.save.saveservice.output_format=csv
-jmeter.save.saveservice.response_data=true
-jmeter.save.saveservice.response_data.on_error=true
-jmeter.save.saveservice.response_message=true
-#---------------------------------------------------------------------------
-# Additional property files to load
-#---------------------------------------------------------------------------
-user.properties=user.properties
-system.properties=system.properties
-#---------------------------------------------------------------------------
-# Reporting configuration
-#---------------------------------------------------------------------------
-jmeter.reportgenerator.apdex_satisfied_threshold=200
-jmeter.reportgenerator.apdex_tolerated_threshold=500
-jmeter.reportgenerator.report_title=Kangal JMeter Dashboard
-jmeter.reportgenerator.overall_granularity=10000
-jmeter.save.saveservice.timestamp_format = yyyy/MM/dd HH:mm:ss zzz`,
-	}
-
-	return &coreV1.ConfigMap{
-		ObjectMeta: metaV1.ObjectMeta{
-			Name: LoadTestLabel,
-			Labels: map[string]string{
-				"app": "hf-jmeter",
-			},
-		},
-		Data: data,
-	}
-}
-
 // NewConfigMap creates a new configMap containing loadtest script
 func (b *Backend) NewConfigMap(loadTest loadTestV1.LoadTest) *coreV1.ConfigMap {
 	testfile := loadTest.Spec.TestFile
@@ -304,11 +266,6 @@ func (b *Backend) NewJMeterMasterJob(loadTest loadTestV1.LoadTest, reportURL str
 									Name:      "tests",
 									MountPath: "/tests",
 								},
-								{
-									Name:      "config",
-									MountPath: "/opt/apache-jmeter-5.0/bin/jmeter.properties",
-									SubPath:   "jmeter.properties",
-								},
 							},
 							Resources: backends.BuildResourceRequirements(b.masterResources),
 						},
@@ -320,16 +277,6 @@ func (b *Backend) NewJMeterMasterJob(loadTest loadTestV1.LoadTest, reportURL str
 								ConfigMap: &coreV1.ConfigMapVolumeSource{
 									LocalObjectReference: coreV1.LocalObjectReference{
 										Name: loadTestFile,
-									},
-								},
-							},
-						},
-						{
-							Name: "config",
-							VolumeSource: coreV1.VolumeSource{
-								ConfigMap: &coreV1.ConfigMapVolumeSource{
-									LocalObjectReference: coreV1.LocalObjectReference{
-										Name: LoadTestLabel,
 									},
 								},
 							},

--- a/pkg/backends/jmeter/resources.go
+++ b/pkg/backends/jmeter/resources.go
@@ -67,6 +67,9 @@ func (b *Backend) NewConfigMap(loadTest loadTestV1.LoadTest) *coreV1.ConfigMap {
 	return &coreV1.ConfigMap{
 		ObjectMeta: metaV1.ObjectMeta{
 			Name: loadTestFile,
+			Labels: map[string]string{
+				"app": "hf-jmeter",
+			},
 		},
 		Data: data,
 	}


### PR DESCRIPTION
This PR:
- removes the creation of jmeter.properties configmap, since it's now included in kangal-jmeter image [in this PR](https://github.com/hellofresh/kangal-jmeter/pull/17)
- updates logs level and the message in case of empty loadtest.spec.MasterConfig and loadtest.spec.WorkerConfig
- refactor SetDefaults() to set Image and Tag defaults separately