### PR TITLE
fixing the logic of Locust loadtest delition and adding more tests

### DIFF
--- a/pkg/backends/locust/backend.go
+++ b/pkg/backends/locust/backend.go
@@ -206,8 +206,7 @@ func (b *Backend) SyncStatus(ctx context.Context, loadTest loadTestV1.LoadTest, 
 		loadTestStatus.Phase = loadTestV1.LoadTestCreating
 	}
 
-	if loadTestStatus.Phase == loadTestV1.LoadTestErrored ||
-		loadTestStatus.Phase == loadTestV1.LoadTestFinished {
+	if loadTestStatus.Phase == loadTestV1.LoadTestErrored {
 		return nil
 	}
 
@@ -240,6 +239,7 @@ func (b *Backend) SyncStatus(ctx context.Context, loadTest loadTestV1.LoadTest, 
 	}
 
 	loadTestStatus.Phase = determineLoadTestStatusFromJobs(masterJob, workerJob)
+	loadTestStatus.JobStatus = masterJob.Status
 
 	return nil
 }

--- a/pkg/backends/locust/backend_test.go
+++ b/pkg/backends/locust/backend_test.go
@@ -2,6 +2,7 @@ package locust
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -10,10 +11,22 @@ import (
 	"go.uber.org/zap/zaptest"
 	batchV1 "k8s.io/api/batch/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	loadTestV1 "github.com/hellofresh/kangal/pkg/kubernetes/apis/loadtest/v1"
 )
+
+type StatusError struct{}
+
+func (e *StatusError) Error() string {
+	return ""
+}
+
+func (e *StatusError) Status() metaV1.Status {
+	return metaV1.Status{Reason: metaV1.StatusReasonNotFound}
+}
 
 func TestSync(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -68,32 +81,193 @@ func TestSyncStatus(t *testing.T) {
 	kubeClient := k8sfake.NewSimpleClientset()
 	logger := zaptest.NewLogger(t)
 
-	namespace := "test"
-	distributedPods := int32(1)
-
-	loadTest := loadTestV1.LoadTest{
-		ObjectMeta: metaV1.ObjectMeta{
-			Name: "loadtest-name",
-		},
-		Spec: loadTestV1.LoadTestSpec{
-			DistributedPods: &distributedPods,
-		},
-		Status: loadTestV1.LoadTestStatus{
-			Phase:     "running",
-			Namespace: namespace,
-			JobStatus: batchV1.JobStatus{},
-			Pods:      loadTestV1.LoadTestPodsStatus{},
-		},
-	}
-
 	b := Backend{
 		logger:        logger,
 		kubeClientSet: kubeClient,
 	}
 
-	err := b.SyncStatus(ctx, loadTest, &loadTest.Status)
-	require.NoError(t, err, "Error when CheckOrUpdateStatus")
-	assert.Equal(t, loadTestV1.LoadTestFinished, loadTest.Status.Phase)
+	namespace := "test"
+	distributedPods := int32(1)
+	now := time.Now()
+	metav1TimeNow := metaV1.NewTime(now)
+	metav1TimeDayAgo := metaV1.NewTime(now.AddDate(0, 0, -1))
+
+	var tests = []struct {
+		Name           string
+		LoadTest       loadTestV1.LoadTest
+		ExpectedPhase  loadTestV1.LoadTestPhase
+		ConfigMapError error
+		Job            batchV1.Job
+		JobsError      error
+	}{
+		{
+			Name:          "test with no phase to creating phase",
+			ExpectedPhase: loadTestV1.LoadTestCreating,
+			LoadTest: loadTestV1.LoadTest{
+				Spec: loadTestV1.LoadTestSpec{
+					DistributedPods: &distributedPods,
+				},
+				Status: loadTestV1.LoadTestStatus{
+					Phase: "",
+				},
+			},
+			ConfigMapError: nil,
+			JobsError:      errors.New("not found"),
+		},
+		{
+			Name:          "errored test stays in errored phase",
+			ExpectedPhase: loadTestV1.LoadTestErrored,
+			LoadTest: loadTestV1.LoadTest{
+				Spec: loadTestV1.LoadTestSpec{
+					DistributedPods: &distributedPods,
+				},
+				Status: loadTestV1.LoadTestStatus{
+					Phase: "errored",
+				},
+			},
+		},
+		{
+			Name:          "creating test with running job goes to running",
+			ExpectedPhase: loadTestV1.LoadTestRunning,
+			LoadTest: loadTestV1.LoadTest{
+				ObjectMeta: metaV1.ObjectMeta{
+					Name: "loadtest-name",
+				},
+				Spec: loadTestV1.LoadTestSpec{
+					DistributedPods: &distributedPods,
+				},
+				Status: loadTestV1.LoadTestStatus{
+					Phase:     "creating",
+					Namespace: namespace,
+				},
+			},
+			ConfigMapError: nil,
+			Job: batchV1.Job{
+				TypeMeta:   metaV1.TypeMeta{},
+				ObjectMeta: metaV1.ObjectMeta{},
+				Spec:       batchV1.JobSpec{},
+				Status: batchV1.JobStatus{
+					StartTime: &metav1TimeDayAgo,
+					Active:    1,
+				},
+			},
+		},
+		{
+			Name:          "running test with no configmap goes to finished phase",
+			ExpectedPhase: loadTestV1.LoadTestFinished,
+			LoadTest: loadTestV1.LoadTest{
+				ObjectMeta: metaV1.ObjectMeta{
+					Name: "loadtest-name",
+				},
+				Spec: loadTestV1.LoadTestSpec{
+					DistributedPods: &distributedPods,
+				},
+				Status: loadTestV1.LoadTestStatus{
+					Phase:     "running",
+					Namespace: namespace,
+				},
+			},
+			ConfigMapError: &StatusError{},
+		},
+		{
+			Name:          "running test with running job stays running",
+			ExpectedPhase: loadTestV1.LoadTestRunning,
+			LoadTest: loadTestV1.LoadTest{
+				ObjectMeta: metaV1.ObjectMeta{
+					Name: "loadtest-name",
+				},
+				Spec: loadTestV1.LoadTestSpec{
+					DistributedPods: &distributedPods,
+				},
+				Status: loadTestV1.LoadTestStatus{
+					Phase:     "running",
+					Namespace: namespace,
+				},
+			},
+			ConfigMapError: nil,
+			Job: batchV1.Job{
+				TypeMeta:   metaV1.TypeMeta{},
+				ObjectMeta: metaV1.ObjectMeta{},
+				Spec:       batchV1.JobSpec{},
+				Status: batchV1.JobStatus{
+					StartTime: &metav1TimeDayAgo,
+					Active:    1,
+				},
+			},
+		},
+		{
+			Name:          "running test with finished job goes to finished",
+			ExpectedPhase: loadTestV1.LoadTestFinished,
+			LoadTest: loadTestV1.LoadTest{
+				ObjectMeta: metaV1.ObjectMeta{
+					Name: "loadtest-name",
+				},
+				Spec: loadTestV1.LoadTestSpec{
+					DistributedPods: &distributedPods,
+				},
+				Status: loadTestV1.LoadTestStatus{
+					Phase:     "running",
+					Namespace: namespace,
+				},
+			},
+			ConfigMapError: nil,
+			Job: batchV1.Job{
+				TypeMeta:   metaV1.TypeMeta{},
+				ObjectMeta: metaV1.ObjectMeta{},
+				Spec:       batchV1.JobSpec{},
+				Status: batchV1.JobStatus{
+					StartTime:      &metav1TimeDayAgo,
+					CompletionTime: &metav1TimeNow,
+					Active:         0,
+					Succeeded:      1,
+				},
+			},
+		},
+		{
+			Name:          "running test with failed job goes to errored",
+			ExpectedPhase: loadTestV1.LoadTestErrored,
+			LoadTest: loadTestV1.LoadTest{
+				ObjectMeta: metaV1.ObjectMeta{
+					Name: "loadtest-name",
+				},
+				Spec: loadTestV1.LoadTestSpec{
+					DistributedPods: &distributedPods,
+				},
+				Status: loadTestV1.LoadTestStatus{
+					Phase:     "running",
+					Namespace: namespace,
+				},
+			},
+			ConfigMapError: nil,
+			Job: batchV1.Job{
+				TypeMeta:   metaV1.TypeMeta{},
+				ObjectMeta: metaV1.ObjectMeta{},
+				Spec:       batchV1.JobSpec{},
+				Status: batchV1.JobStatus{
+					StartTime:      &metav1TimeDayAgo,
+					CompletionTime: &metav1TimeNow,
+					Active:         0,
+					Succeeded:      0,
+					Failed:         1,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			kubeClient.Fake.PrependReactor("get", "configmaps", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+				return true, nil, test.ConfigMapError
+			})
+
+			kubeClient.Fake.PrependReactor("get", "jobs", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+				return true, &test.Job, test.JobsError
+			})
+
+			b.SyncStatus(ctx, test.LoadTest, &test.LoadTest.Status)
+			assert.Equal(t, test.ExpectedPhase, test.LoadTest.Status.Phase)
+		})
+	}
 }
 
 func TestTransformLoadTestSpec(t *testing.T) {


### PR DESCRIPTION
This PR:
- updates the Locust backend to improve the logic of updating loadtest state 
- adds more unit tests for Locust backend