### PR TITLE
Wrong path for required field, 'hosts' missing

### DIFF
--- a/charts/kangal/Chart.yaml
+++ b/charts/kangal/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - performance tests
   - tests runner
 name: kangal
-version: 2.0.3
+version: 2.0.4
 home: https://github.com/hellofresh/kangal
 icon: https://raw.githubusercontent.com/hellofresh/kangal/master/logo.svg
 maintainers:

--- a/charts/kangal/README.md
+++ b/charts/kangal/README.md
@@ -1,4 +1,4 @@
-t@github.com:jdani/kangal.git# Kangal Chart
+# Kangal Chart
 [Kangal](https://github.com/hellofresh/kangal) is a tool to spin up an isolated environment in a Kubernetes cluster to run performance tests using different load test providers.
 
 ## Introduction

--- a/charts/kangal/README.md
+++ b/charts/kangal/README.md
@@ -1,4 +1,4 @@
-# Kangal Chart
+t@github.com:jdani/kangal.git# Kangal Chart
 [Kangal](https://github.com/hellofresh/kangal) is a tool to spin up an isolated environment in a Kubernetes cluster to run performance tests using different load test providers.
 
 ## Introduction
@@ -127,7 +127,7 @@ Deployment specific configurations:
 | `openapi-ui.ingress.enabled`          | Ingress enabled flag                            | `true`                                     |
 | `openapi-ui.ingress.annotations`      | Ingress annotations                             | `kubernetes.io/ingress.class: nginx`       |
 | `openapi-ui.ingress.path`             | Ingress path                                    | `/`                                        |
-| `openapi-ui.ingress.hosts`            | Ingress hosts. *Required* if ingress is enabled | `kangal-openapi-ui.example.com`            |
+| `openapi-ui.ingress.hosts.http`       | Ingress hosts. *Required* if ingress is enabled | `kangal-openapi-ui.example.com`            |
 | `openapi-ui.resources`                | CPU/Memory resource requests/limits             | Default values of the cluster              |
 | `openapi-ui.nodeSelector`             | Node labels for pod assignment                  | `{}`                                       |
 | `openapi-ui.tolerations`              | Tolerations for nodes that have taints on them  | `[]`                                       |


### PR DESCRIPTION
Simple fix for helm chart documentation README.md. Wrong yaml path `openapi-ui.ingress.hosts`. Fixed with `openapi-ui.ingress.hosts.http`