### PR TITLE
Move WaitForResourceTimeout to envconfig and update the test

### DIFF
--- a/pkg/backends/jmeter/backend_test.go
+++ b/pkg/backends/jmeter/backend_test.go
@@ -3,6 +3,7 @@ package jmeter
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -120,6 +121,7 @@ func TestSync(t *testing.T) {
 
 	// Arbitrary test values
 	distributedPodsNum := int32(2)
+	waitForResourceTimeout := 3 * time.Second
 	namespace := "loadtest-namespace"
 	reportURL := "http://kangal-proxy.local/load-test/loadtest-name/report"
 
@@ -157,6 +159,9 @@ func TestSync(t *testing.T) {
 		kangalClientSet: client,
 		logger:          logger,
 		namespaceLister: namespaceLister,
+		config: &Config{
+			WaitForResourceTimeout: waitForResourceTimeout,
+		},
 	}
 
 	err := b.Sync(ctx, loadTest, reportURL)

--- a/pkg/backends/jmeter/config.go
+++ b/pkg/backends/jmeter/config.go
@@ -1,17 +1,22 @@
 package jmeter
 
+import (
+	"time"
+)
+
 // Config specific to JMeter backend
 type Config struct {
-	MasterImageName      string `envconfig:"JMETER_MASTER_IMAGE_NAME"`
-	MasterImageTag       string `envconfig:"JMETER_MASTER_IMAGE_TAG"`
-	MasterCPULimits      string `envconfig:"JMETER_MASTER_CPU_LIMITS"`
-	MasterCPURequests    string `envconfig:"JMETER_MASTER_CPU_REQUESTS"`
-	MasterMemoryLimits   string `envconfig:"JMETER_MASTER_MEMORY_LIMITS"`
-	MasterMemoryRequests string `envconfig:"JMETER_MASTER_MEMORY_REQUESTS"`
-	WorkerImageName      string `envconfig:"JMETER_WORKER_IMAGE_NAME"`
-	WorkerImageTag       string `envconfig:"JMETER_WORKER_IMAGE_TAG"`
-	WorkerCPULimits      string `envconfig:"JMETER_WORKER_CPU_LIMITS"`
-	WorkerCPURequests    string `envconfig:"JMETER_WORKER_CPU_REQUESTS"`
-	WorkerMemoryLimits   string `envconfig:"JMETER_WORKER_MEMORY_LIMITS"`
-	WorkerMemoryRequests string `envconfig:"JMETER_WORKER_MEMORY_REQUESTS"`
+	MasterImageName        string        `envconfig:"JMETER_MASTER_IMAGE_NAME"`
+	MasterImageTag         string        `envconfig:"JMETER_MASTER_IMAGE_TAG"`
+	MasterCPULimits        string        `envconfig:"JMETER_MASTER_CPU_LIMITS"`
+	MasterCPURequests      string        `envconfig:"JMETER_MASTER_CPU_REQUESTS"`
+	MasterMemoryLimits     string        `envconfig:"JMETER_MASTER_MEMORY_LIMITS"`
+	MasterMemoryRequests   string        `envconfig:"JMETER_MASTER_MEMORY_REQUESTS"`
+	WorkerImageName        string        `envconfig:"JMETER_WORKER_IMAGE_NAME"`
+	WorkerImageTag         string        `envconfig:"JMETER_WORKER_IMAGE_TAG"`
+	WorkerCPULimits        string        `envconfig:"JMETER_WORKER_CPU_LIMITS"`
+	WorkerCPURequests      string        `envconfig:"JMETER_WORKER_CPU_REQUESTS"`
+	WorkerMemoryLimits     string        `envconfig:"JMETER_WORKER_MEMORY_LIMITS"`
+	WorkerMemoryRequests   string        `envconfig:"JMETER_WORKER_MEMORY_REQUESTS"`
+	WaitForResourceTimeout time.Duration `envconfig:"WAIT_FOR_RESOURCE_TIMEOUT" default:"30s"`
 }

--- a/pkg/backends/jmeter/resources.go
+++ b/pkg/backends/jmeter/resources.go
@@ -50,7 +50,7 @@ var (
 	loadTestWorkerPodLabels = map[string]string{
 		loadTestWorkerPodLabelKey: loadTestWorkerPodLabelValue,
 	}
-	//loadTestSecretLabels is a labeles set for created secrets
+	//loadTestSecretLabels is a labels set for created secrets
 	loadTestSecretLabels = map[string]string{
 		loadTestSecretLabelKey: loadTestSecretLabel,
 	}
@@ -368,7 +368,7 @@ func (b *Backend) CreatePodsWithTestdata(ctx context.Context, configMaps []*core
 			logger.Warn("unable to watch pod state", zap.Error(err))
 			continue
 		}
-		waitfor.Resource(watchObj, (waitfor.Condition{}).PodRunning)
+		waitfor.Resource(watchObj, (waitfor.Condition{}).PodRunning, b.config.WaitForResourceTimeout)
 	}
 	logger.Info("Created pods with test data")
 	return nil

--- a/pkg/controller/controller_integration_test.go
+++ b/pkg/controller/controller_integration_test.go
@@ -26,6 +26,7 @@ func TestIntegrationKangalController(t *testing.T) {
 	}
 
 	expectedLoadtestName := "loadtest-fake-integration"
+	waitForResourceTimeout := 30 * time.Second
 
 	// TODO: those attributes should gone once we do improvements on proxy side and move kube_client to own kube package
 	distributedPods := int32(1)
@@ -58,7 +59,7 @@ func TestIntegrationKangalController(t *testing.T) {
 	watchObj, _ := client.CoreV1().Namespaces().Watch(context.Background(), metaV1.ListOptions{
 		FieldSelector: fmt.Sprintf("metadata.name=%s", expectedLoadtestName),
 	})
-	watchEvent, err := waitfor.Resource(watchObj, (waitfor.Condition{}).Added)
+	watchEvent, err := waitfor.Resource(watchObj, (waitfor.Condition{}).Added, waitForResourceTimeout)
 	require.NoError(t, err)
 	namespace := watchEvent.Object.(*coreV1.Namespace)
 	require.Equal(t, expectedLoadtestName, namespace.Name)
@@ -67,7 +68,7 @@ func TestIntegrationKangalController(t *testing.T) {
 	watchObj, _ = client.CoreV1().Pods(expectedLoadtestName).Watch(context.Background(), metaV1.ListOptions{
 		LabelSelector: "app=loadtest-master",
 	})
-	watchEvent, err = waitfor.Resource(watchObj, (waitfor.Condition{}).PodRunning)
+	watchEvent, err = waitfor.Resource(watchObj, (waitfor.Condition{}).PodRunning, waitForResourceTimeout)
 	require.NoError(t, err)
 	pod := watchEvent.Object.(*coreV1.Pod)
 	require.Equal(t, coreV1.PodRunning, pod.Status.Phase)
@@ -76,7 +77,7 @@ func TestIntegrationKangalController(t *testing.T) {
 	watchObj, _ = clientSet.KangalV1().LoadTests().Watch(context.Background(), metaV1.ListOptions{
 		FieldSelector: fmt.Sprintf("metadata.name=%s", expectedLoadtestName),
 	})
-	watchEvent, err = waitfor.Resource(watchObj, (waitfor.Condition{}).LoadTestRunning)
+	watchEvent, err = waitfor.Resource(watchObj, (waitfor.Condition{}).LoadTestRunning, waitForResourceTimeout)
 	require.NoError(t, err)
 	loadtest := watchEvent.Object.(*loadTestV1.LoadTest)
 	require.Equal(t, loadTestV1.LoadTestRunning, loadtest.Status.Phase)
@@ -86,7 +87,7 @@ func TestIntegrationKangalController(t *testing.T) {
 	watchObj, _ = clientSet.KangalV1().LoadTests().Watch(context.Background(), metaV1.ListOptions{
 		FieldSelector: fmt.Sprintf("metadata.name=%s", expectedLoadtestName),
 	})
-	watchEvent, err = waitfor.Resource(watchObj, (waitfor.Condition{}).LoadTestFinished)
+	watchEvent, err = waitfor.Resource(watchObj, (waitfor.Condition{}).LoadTestFinished, waitForResourceTimeout)
 	require.NoError(t, err)
 	loadtest = watchEvent.Object.(*loadTestV1.LoadTest)
 	require.Equal(t, loadTestV1.LoadTestFinished, loadtest.Status.Phase)

--- a/pkg/controller/test_helper.go
+++ b/pkg/controller/test_helper.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	kubeClientDefaultTimeout = 1 * time.Minute
-	waitForResourceTimeout   = 10 * time.Second
+	waitForResourceTimeout   = 30 * time.Second
 )
 
 // CreateLoadTest creates a load test CR

--- a/pkg/controller/test_helper.go
+++ b/pkg/controller/test_helper.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	kubeClientDefaultTimeout = 1 * time.Minute
-	waitForResourceTimeout = 10 * time.Second
+	waitForResourceTimeout   = 10 * time.Second
 )
 
 // CreateLoadTest creates a load test CR

--- a/pkg/controller/test_helper.go
+++ b/pkg/controller/test_helper.go
@@ -21,6 +21,7 @@ import (
 
 const (
 	kubeClientDefaultTimeout = 1 * time.Minute
+	waitForResourceTimeout = 10 * time.Second
 )
 
 // CreateLoadTest creates a load test CR
@@ -92,7 +93,7 @@ func WaitLoadTest(clientSet clientSetV.Clientset, loadtestName string) error {
 		return err
 	}
 
-	_, err = waitfor.Resource(watchObj, (waitfor.Condition{}).LoadTestRunning)
+	_, err = waitfor.Resource(watchObj, (waitfor.Condition{}).LoadTestRunning, waitForResourceTimeout)
 
 	return err
 }

--- a/pkg/core/waitfor/waitfor.go
+++ b/pkg/core/waitfor/waitfor.go
@@ -11,12 +11,6 @@ import (
 	apisLoadTestV1 "github.com/hellofresh/kangal/pkg/kubernetes/apis/loadtest/v1"
 )
 
-const (
-	// waitForResourceTimeout is the timeout used to wait until a resource reaches a desired state
-	// TODO: Move as envconfig?
-	waitForResourceTimeout = 30 * time.Second
-)
-
 // Condition contains useful functions for watch conditions
 type Condition struct {
 }
@@ -58,8 +52,8 @@ func (Condition) LoadTestFinished(event watch.Event) (bool, error) {
 }
 
 // Resource waits until a kubernetes resources to match a condition
-func Resource(obj watch.Interface, condFunc watchtools.ConditionFunc) (*watch.Event, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), waitForResourceTimeout)
+func Resource(obj watch.Interface, condFunc watchtools.ConditionFunc, timeout time.Duration) (*watch.Event, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	return watchtools.UntilWithoutRetry(ctx, obj, condFunc)

--- a/pkg/proxy/proxy_integration_test.go
+++ b/pkg/proxy/proxy_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -431,6 +432,7 @@ func TestIntegrationGetLoadtestLogs(t *testing.T) {
 
 	distributedPods := int32(1)
 	loadtestType := apisLoadTestV1.LoadTestTypeFake
+	waitForResourceTimeout := 10 * time.Second
 
 	testFile := "testdata/valid/loadtest.jmx"
 
@@ -458,7 +460,7 @@ func TestIntegrationGetLoadtestLogs(t *testing.T) {
 			LabelSelector: "app=loadtest-master",
 		})
 
-		watchEvent, err := waitfor.Resource(watchObj, (waitfor.Condition{}).PodRunning)
+		watchEvent, err := waitfor.Resource(watchObj, (waitfor.Condition{}).PodRunning, waitForResourceTimeout)
 		require.NoError(t, err)
 
 		pod := watchEvent.Object.(*coreV1.Pod)


### PR DESCRIPTION
This PR:
- removes hardcoded WaitForResourceTimeout used for JMeter backend and tests
- adds WaitForResourceTimeout to the backend config
- allows using custom WaitForResourceTimeout for different tests which is required for PR #141 