### PR TITLE
Add support for protoset file in ghz backend

### DIFF
--- a/docs/ghz/README.md
+++ b/docs/ghz/README.md
@@ -7,9 +7,6 @@ Kangal supports `ghz` as a loadtest backend using a custom docker image: [`hello
 For more information, please check [ghz official website][`ghz`].
 
 ## Usage
-To start using `ghz`, you need to ensure that server reflection enabled on your grpc server.  
-_While `ghz` itself can work when a protobuf schema is supplied, Kangal currently only supports server reflection method._
-
 To create a loadtest, simply send a request to Kangal proxy with the `ghz` configuration in the `testFile` field in JSON:
 
 ```shell
@@ -41,7 +38,20 @@ Example `config.json`:
 }
 ```
 
-For the complete list of configuration parameter, please check [ghz documentation][ghz params].
+### Providing protobuf schema
+
+While `ghz` accepts `.proto` files to not depend on server reflection, Kangal currently only supports `.protoset` files.
+
+To do so, use the `testData` form field to provide the `.protoset` file and add the following key to your JSON configuration file:
+
+```json
+{
+  "protoset": "/data/testdata.protoset",
+  ...
+}
+```
+
+For information about how to create `.protoset` files and the complete list of configuration parameter, please check [ghz documentation][ghz params].
 
 Since `ghz` does not use master-worker pattern, `distributedPods` simply creates replicas of the load-generating pod.  
 This means `distributedPods` value of `5` would mean that it creates 5 identical pods, generating 5x the load with 5x concurrency, etc.
@@ -69,9 +79,8 @@ More information regarding resource limits and requests can be found in the foll
 
 
 ## Notes
-1. `ghz` can work without server reflection when protobuf schema is supplied, but this is currently not supported by Kangal
-2. `ghz` supports configuration file in `toml` format, but this is also currently not supported
-3. Kangal overrides the following options:
+1. `ghz` supports configuration file in `toml` format, but this is also currently not supported
+2. Kangal overrides the following options:
   * The output format is always set to html
   * Output directory is always set to `/results`
   * This is done so Kangal is able to pick up the results and persist the results.  

--- a/docs/ghz/README.md
+++ b/docs/ghz/README.md
@@ -51,7 +51,7 @@ To do so, use the `testData` form field to provide the `.protoset` file and add 
 }
 ```
 
-For information about how to create `.protoset` files and the complete list of configuration parameter, please check [ghz documentation][ghz params].
+For information about how to [create `.protoset` files][ghz protoset-example] and the complete list of configuration parameter, please check [ghz documentation][ghz params].
 
 Since `ghz` does not use master-worker pattern, `distributedPods` simply creates replicas of the load-generating pod.  
 This means `distributedPods` value of `5` would mean that it creates 5 identical pods, generating 5x the load with 5x concurrency, etc.
@@ -89,5 +89,6 @@ More information regarding resource limits and requests can be found in the foll
 
 [`ghz`]: https://ghz.sh/
 [ghz params]: https://ghz.sh/docs/options
+[ghz protoset-example]: https://ghz.sh/docs/options#--protoset
 [kangal-ghz]: https://github.com/hellofresh/kangal-ghz
 [dockerhub]: hub.docker.com/r/hellofresh/kangal-ghz/

--- a/pkg/backends/ghz/backend.go
+++ b/pkg/backends/ghz/backend.go
@@ -140,7 +140,7 @@ func (b *Backend) Sync(ctx context.Context, loadTest loadTestV1.LoadTest, report
 	}
 	configMaps[0] = tfCfgMap
 
-	// Create testdata ConfigMap
+	// Prepare testdata ConfigMap
 	if loadTest.Spec.TestData != "" {
 		tdCfgMap, err = NewFileConfigMap(loadTestFileConfigMapName, configFileName, loadTest.Spec.TestData)
 		if err != nil {

--- a/pkg/backends/ghz/backend.go
+++ b/pkg/backends/ghz/backend.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hellofresh/kangal/pkg/backends"
 	loadTestV1 "github.com/hellofresh/kangal/pkg/kubernetes/apis/loadtest/v1"
 	"go.uber.org/zap"
+	coreV1 "k8s.io/api/core/v1"
 	k8sAPIErrors "k8s.io/apimachinery/pkg/api/errors"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -126,19 +127,55 @@ func (b *Backend) Sync(ctx context.Context, loadTest loadTestV1.LoadTest, report
 		return nil
 	}
 
+	var (
+		tdCfgMap   *coreV1.ConfigMap
+		configMaps = make([]*coreV1.ConfigMap, 1)
+	)
+
 	// Create testfile ConfigMap
-	testFileConfigMap := b.NewTestFileConfigMap(loadTest)
-	_, err = b.kubeClientSet.
-		CoreV1().
-		ConfigMaps(loadTest.Status.Namespace).
-		Create(ctx, testFileConfigMap, metaV1.CreateOptions{})
-	if err != nil && !k8sAPIErrors.IsAlreadyExists(err) {
-		b.logger.Error("Error on creating testfile configmap", zap.Error(err))
+	tfCfgMap, err := NewFileConfigMap(loadTestFileConfigMapName, configFileName, loadTest.Spec.TestFile)
+	if err != nil {
+		b.logger.Error("Error creating testfile configmap resource", zap.Error(err))
 		return err
+	}
+	configMaps[0] = tfCfgMap
+
+	// Create testdata ConfigMap
+	if loadTest.Spec.TestData != "" {
+		tdCfgMap, err = NewFileConfigMap(loadTestFileConfigMapName, configFileName, loadTest.Spec.TestData)
+		if err != nil {
+			b.logger.Error("Error creating testdata configmap resource", zap.Error(err))
+			return err
+		}
+		configMaps = append(configMaps, tdCfgMap)
+	}
+
+	for _, cfg := range configMaps {
+		_, err = b.kubeClientSet.
+			CoreV1().
+			ConfigMaps(loadTest.Status.Namespace).
+			Create(ctx, cfg, metaV1.CreateOptions{})
+		if err != nil && !k8sAPIErrors.IsAlreadyExists(err) {
+			b.logger.Error("Error creating configmap", zap.String("configmap", cfg.GetName()), zap.Error(err))
+			return err
+		}
+	}
+
+	var (
+		volumes = make([]coreV1.Volume, 1)
+		mounts  = make([]coreV1.VolumeMount, 1)
+	)
+
+	volumes[0], mounts[0] = NewFileVolumeAndMount("testfile", tfCfgMap.Name, configFileName)
+
+	if tdCfgMap != nil {
+		v, m := NewFileVolumeAndMount("testdata", tdCfgMap.Name, testdataFileName)
+		volumes = append(volumes, v)
+		mounts = append(mounts, m)
 	}
 
 	// Create Job
-	job := b.NewJob(loadTest, testFileConfigMap, reportURL)
+	job := b.NewJob(loadTest, volumes, mounts, reportURL)
 	_, err = b.kubeClientSet.
 		BatchV1().
 		Jobs(loadTest.Status.Namespace).

--- a/pkg/backends/ghz/backend.go
+++ b/pkg/backends/ghz/backend.go
@@ -150,6 +150,7 @@ func (b *Backend) Sync(ctx context.Context, loadTest loadTestV1.LoadTest, report
 		configMaps = append(configMaps, tdCfgMap)
 	}
 
+	// Create testfile and testdata configmaps
 	for _, cfg := range configMaps {
 		_, err = b.kubeClientSet.
 			CoreV1().

--- a/pkg/backends/ghz/backend.go
+++ b/pkg/backends/ghz/backend.go
@@ -162,6 +162,7 @@ func (b *Backend) Sync(ctx context.Context, loadTest loadTestV1.LoadTest, report
 		}
 	}
 
+	// Prepare Volume and VolumeMount for job creation
 	var (
 		volumes = make([]coreV1.Volume, 1)
 		mounts  = make([]coreV1.VolumeMount, 1)

--- a/pkg/backends/ghz/resources_test.go
+++ b/pkg/backends/ghz/resources_test.go
@@ -6,6 +6,8 @@ import (
 	loadTestV1 "github.com/hellofresh/kangal/pkg/kubernetes/apis/loadtest/v1"
 	"github.com/stretchr/testify/assert"
 	batchV1 "k8s.io/api/batch/v1"
+	coreV1 "k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGetLoadTestStatusFromJobs(t *testing.T) {
@@ -38,5 +40,67 @@ func TestGetLoadTestStatusFromJobs(t *testing.T) {
 		}
 		actual := determineLoadTestStatusFromJobs(job)
 		assert.Equal(t, scenario.ExpectedPhase, actual)
+	}
+}
+
+func TestNewFileConfigMap(t *testing.T) {
+	for _, ti := range []struct {
+		tag         string
+		cfgName     string
+		filename    string
+		content     string
+		expected    *coreV1.ConfigMap
+		expectError bool
+	}{
+		{
+			tag:         "no configmap name",
+			cfgName:     "",
+			filename:    "file",
+			content:     "file content",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			tag:         "no filename",
+			cfgName:     "test",
+			filename:    "",
+			content:     "file content",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			tag:         "no content",
+			cfgName:     "test",
+			filename:    "file",
+			content:     "",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			tag:      "valid args",
+			cfgName:  "test",
+			filename: "file",
+			content:  "file content",
+			expected: &coreV1.ConfigMap{
+				ObjectMeta: metaV1.ObjectMeta{
+					Name: "test",
+				},
+				Data: map[string]string{
+					"file": "file content",
+				},
+			},
+			expectError: false,
+		},
+	} {
+		t.Run(ti.tag, func(t *testing.T) {
+			cfgmap, err := NewFileConfigMap(ti.cfgName, ti.filename, ti.content)
+
+			assert.Equal(t, ti.expected, cfgmap)
+			if ti.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
 	}
 }

--- a/pkg/backends/ghz/resources_test.go
+++ b/pkg/backends/ghz/resources_test.go
@@ -104,3 +104,42 @@ func TestNewFileConfigMap(t *testing.T) {
 		})
 	}
 }
+
+func TestNewFileVolumeAndMount(t *testing.T) {
+	for _, tt := range []struct {
+		tag           string
+		name          string
+		cfg           string
+		filename      string
+		expectedVol   coreV1.Volume
+		expectedMount coreV1.VolumeMount
+	}{
+		{
+			tag:      "volume and mount are created with specified name, file and /data mount path",
+			name:     "load-test-volume",
+			cfg:      "test-configmap",
+			filename: "testfile.json",
+			expectedVol: coreV1.Volume{
+				Name: "load-test-volume",
+				VolumeSource: coreV1.VolumeSource{
+					ConfigMap: &coreV1.ConfigMapVolumeSource{
+						LocalObjectReference: coreV1.LocalObjectReference{
+							Name: "test-configmap",
+						},
+					},
+				},
+			},
+			expectedMount: coreV1.VolumeMount{
+				Name:      "load-test-volume",
+				MountPath: "/data/testfile.json",
+				SubPath:   "testfile.json",
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			v, m := NewFileVolumeAndMount(tt.name, tt.cfg, tt.filename)
+			assert.Equal(t, tt.expectedVol, v)
+			assert.Equal(t, tt.expectedMount, m)
+		})
+	}
+}

--- a/pkg/proxy/request_test.go
+++ b/pkg/proxy/request_test.go
@@ -636,3 +636,37 @@ func TestCustomImageFeatureFlag(t *testing.T) {
 
 	}
 }
+
+func Test_getTypeFromName(t *testing.T) {
+	for _, ti := range []struct {
+		tag          string
+		filename     string
+		expectedType string
+	}{
+		{
+			tag:          "no filename provided",
+			filename:     "",
+			expectedType: "",
+		},
+		{
+			tag:          "filename with no extension",
+			filename:     "somefile",
+			expectedType: "",
+		},
+		{
+			tag:          "filename with extension",
+			filename:     "somefile.ext",
+			expectedType: "ext",
+		},
+		{
+			tag:          "filename with multiple extensions",
+			filename:     "somefile.tar.gz",
+			expectedType: "gz",
+		},
+	} {
+		t.Run(ti.tag, func(t *testing.T) {
+			ext := getTypeFromName(ti.filename)
+			assert.Equal(t, ti.expectedType, ext)
+		})
+	}
+}


### PR DESCRIPTION
This change will allow Ghz backend to receive `.protoset` files as test data and remove server reflection dependency