### PR TITLE
Removed /openapi from OPEN_API_SERVER_URL for swagger to work without…

### DIFF
--- a/charts/kangal/Chart.yaml
+++ b/charts/kangal/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - performance tests
   - tests runner
 name: kangal
-version: 2.0.7
+version: 2.0.8
 home: https://github.com/hellofresh/kangal
 icon: https://raw.githubusercontent.com/hellofresh/kangal/master/logo.svg
 maintainers:

--- a/charts/kangal/values.yaml
+++ b/charts/kangal/values.yaml
@@ -76,7 +76,7 @@ proxy:
   env:
     # OpenAPI specification specific parameters
     OPEN_API_SERVER_DESCRIPTION: Kangal proxy default value
-    OPEN_API_SERVER_URL: https://kangal-proxy.example.com/openapi
+    OPEN_API_SERVER_URL: https://kangal-proxy.example.com
     OPEN_API_UI_URL: https://kangal-openapi-ui.example.com
 
 controller:


### PR DESCRIPTION
Removed `/openapi` from default helm chart values in order to prevent 404 errors in swagger UI when creating fresh install through helm install command without manually updating variables.

Relates to: https://github.com/hellofresh/kangal/issues/152