### PR TITLE
Docs: Mention how to get JMeter CSV results file

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,4 @@
+default: true
+
+# MD034/no-bare-urls - Bare URL used
+MD034: false

--- a/docs/jmeter/reporting.md
+++ b/docs/jmeter/reporting.md
@@ -15,3 +15,10 @@ You can use InfluxDB as a datasource for Grafana and create a set of useful grap
 JMeter also offers a functionality to generate HTML report dashboards after the end of the test. Read more about it [in official JMeter documentation](https://jmeter.apache.org/usermanual/generating-dashboard.html).
 
 The [hellofresh/kangal-jmeter](https://github.com/hellofresh/kangal-jmeter) docker image implements this functionality.
+
+### CSV Results
+The CSV file containing all requests will be persisted within the reports, you can get this file from the report using the following URL:
+
+> https://${KANGAL_PROXY_ADDRESS}/load-test/{loadtest-name}/report/results.csv
+
+To read more about the REST API, check [User Flow documentation](../user-flow.md)

--- a/docs/jmeter/reporting.md
+++ b/docs/jmeter/reporting.md
@@ -4,7 +4,7 @@
 
 ## Live metrics report
 JMeter offers a possibility to send live metrics from the running test to InfluxDB (see [details in the related JMeter documentation](writing-tests.md#metrics-collector)).
-This will help you to monitor current behaviour of your test and the service under the test. 
+This will help you to monitor current behaviour of your test and the service under the test.
 InfluxDB installed in your cluster is required to enable this functionality.
 > Note: InfluxDB is not the part of Kangal, read more about it in [InfluxDB official documentation](https://github.com/influxdata/influxdb).
 


### PR DESCRIPTION
It's confusing for users how to get the resulting JMeter CSV file containing the requests that were made.

This PR adds this information to the JMeter specific docs.