### PR TITLE
updating JMeter documentation with correct links to images

### DIFF
--- a/docs/jmeter/README.md
+++ b/docs/jmeter/README.md
@@ -23,8 +23,8 @@ Kangal requires a jmx testfile describing the test.
 To create and edit jmx files we recommend you to install JMeter locally.
 
 ## Installing JMeter for local test development
-1. Install Java 8+ from [official Java website](https://www.java.com/de/download/).
-2. Install JMeter v5.0 r1840935 from [official JMeter website](https://archive.apache.org/dist/jmeter/binaries/) or using [brew](https://stackoverflow.com/questions/22610316/how-do-i-install-jmeter-on-a-mac).
+1. Install Java 11+ from [official Java website](https://www.java.com/de/download/).
+2. Install JMeter v5.4.1 from [official JMeter website](https://archive.apache.org/dist/jmeter/binaries/) or using [brew](https://stackoverflow.com/questions/22610316/how-do-i-install-jmeter-on-a-mac).
 3. Run JMeter UI from your terminal by command `jmeter` or follow the [official documentation](https://jmeter.apache.org/usermanual/get-started.html#running).
 
 ## Required JMeter plugins

--- a/docs/jmeter/README.md
+++ b/docs/jmeter/README.md
@@ -19,7 +19,7 @@ Apache JMeter features include ability to create and run performance test for di
 * LDAP
 * and many more ...
 
-Kangal requires a jmx testfile describing the test. 
+Kangal requires a jmx testfile describing the test.
 To create and edit jmx files we recommend you to install JMeter locally.
 
 ## Installing JMeter for local test development
@@ -52,7 +52,7 @@ You can specify resource limits and requests for JMeter master and worker contai
 
 The following environment variables can be specified to configure this parameter:
 
-```
+```shell
 JMETER_MASTER_CPU_LIMITS
 JMETER_MASTER_CPU_REQUESTS
 JMETER_MASTER_MEMORY_LIMITS

--- a/docs/jmeter/reporting.md
+++ b/docs/jmeter/reporting.md
@@ -9,7 +9,7 @@ InfluxDB installed in your cluster is required to enable this functionality.
 > Note: InfluxDB is not the part of Kangal, read more about it in [InfluxDB official documentation](https://github.com/influxdata/influxdb).
 
 You can use InfluxDB as a datasource for Grafana and create a set of useful graphs.
-<p align="center"><img src="images/grafana_example.png" height="500"></p>
+![grafana_example dmg](images/grafana_example.png) { height=500 }
 
 ## Static report
 JMeter also offers a functionality to generate HTML report dashboards after the end of the test. Read more about it [in official JMeter documentation](https://jmeter.apache.org/usermanual/generating-dashboard.html).

--- a/docs/jmeter/writing-tests.md
+++ b/docs/jmeter/writing-tests.md
@@ -1,5 +1,5 @@
 # How to write and understand a JMeter test
-## Quick links
+
 - [Introduction](#introduction)
 - [General recommendations](#general-recommendations)
     - [Tests with test data](#tests-with-test-data)
@@ -180,9 +180,8 @@ Kangal allows you to use a file with env vars saved in CSV format. Please config
 
 ### Test Plan
 Test Plan element is the root of the test. Inside it you can find all the nested required elements for test configuration.
-<p align="center">
-<img src="images/linear_test_plan.png" height="500">
-</p>
+
+![linear_test_plan dmg](images/linear_test_plan.png){ height=500 }
 
 ### Create load profile with Throughput Shaping Timer
 The first important element in the configuration is a **Throughput Shaping Timer**. More information about this element can be found in the [official docs](https://jmeter-plugins.org/wiki/ThroughputShapingTimer/?utm_source=jmeter&utm_medium=helplink&utm_campaign=ThroughputShapingTimer)
@@ -205,9 +204,7 @@ With this two values you can regulate the number of the threads created during t
 
 In this example we advise to use thread count growing up to 20 threads during the test time (same time specified in Throughput Shaping Timer element).
 
-<p align="center">
-<img src="images/linear_thread_group.png" height="500">
-</p>
+![linear_thread_group dmg](images/linear_thread_group.png){ height=500 }
 
 ### Where to shoot
 Next important element is [HTTP request](https://jmeter.apache.org/usermanual/component_reference.html#HTTP_Request_Defaults) itself.
@@ -365,14 +362,14 @@ Values to manipulate:
 
 With the values given in example test, you will get 2000 threads / 200 seconds = 10 threads/sec. With the loop count = 1 it will give us 10 RPS.
 
-<p align="center"><img src="images/constant_thread_group.png" height="500"></p>
+![constant_thread_group dmg](images/constant_thread_group.png){ height=500 }
 
 ## Test with CSV data
 Some test scenarios require unique request or at least some amount of varied data in requests. For this purposes JMeter allows you to use external data sets in a CSV format.
 
 This config element should be nested under HTTP request sampler. Read more about [CSV DataSetConfig](https://jmeter.apache.org/usermanual/component_reference.html#CSV_Data_Set_Config) in official JMeter documentation.
 
-<p align="center"><img src="images/dataset_config.png" height="500"></p>
+![dataset_config dmg](images/dataset_config.png){ height=500 }
 
 > **Important note!** In Kangal the path to the test data file is always the same **/testdata/testdata.csv**. Please specify this path in Filename field of your CSV Data Set Config. Otherwise the test run by Kangal will not see the the provided data.
 
@@ -381,6 +378,6 @@ Some tests may contain sensitive information like DB connection parameters, auth
 
 You don't need any special configuration elements to use environment variables in test. You only need to have the plugin [Custom JMeter Functions](https://jmeter-plugins.org/wiki/Functions/#envsupfont-color-gray-size-1-since-1-2-0-font-sup) installed. Check [Required JMeter plugins](README.md##required-jmeter-plugins) for details.
 
-<p align="center"><img src="images/http_auth_manager.png" height="500"></p>
+![http_auth_manager dmg](images/http_auth_manager.png){ height=500 }
 
 In the example above the environment variable AUTH_CLIENT_ID used in HTTP Authorization Manager.

--- a/docs/jmeter/writing-tests.md
+++ b/docs/jmeter/writing-tests.md
@@ -2,21 +2,22 @@
 
 - [Introduction](#introduction)
 - [General recommendations](#general-recommendations)
-    - [Tests with test data](#tests-with-test-data)
-    - [Tests with environment variables](#tests-with-environment-variables)
+  - [Tests with test data](#tests-with-test-data)
+  - [Tests with environment variables](#tests-with-environment-variables)
 - [Example Test 1: Linearly growing load](#example-test-1-linearly-growing-load)
-    - [Test Plan](#test-plan)
-    - [Create load profile with Throughput Shaping Timer](#create-load-profile-with-throughput-shaping-timer)
-    - [Add enough threads](#add-enough-threads)
-    - [Where to shoot](#where-to-shoot)
-    - [Request headers](#request-headers)
-    - [Metrics collector](#metrics-collector)
+  - [Test Plan](#test-plan)
+  - [Create load profile with Throughput Shaping Timer](#create-load-profile-with-throughput-shaping-timer)
+  - [Add enough threads](#add-enough-threads)
+  - [Where to shoot](#where-to-shoot)
+  - [Request headers](#request-headers)
+  - [Metrics collector](#metrics-collector)
 - [Example Test 2: Constant load](#example-test-2-constant-load)
-    - [Thread group](#thread-group)
+  - [Thread group](#thread-group)
 - [Test with CSV data](#test-with-csv-data)
 - [Test with environment variables](#test-with-environment-variables)
 
 ## Introduction
+
 Before starting with creation of JMeter tests for Kangal, you need to install JMeter locally following the [Quickstart guide](/README.md).
 
 [Kangal repository](https://github.com/hellofresh/kangal) has some simple tests examples that can help you with a quick start.


### PR DESCRIPTION
This PR contains the following documentation updates:
- updating links to images to be correctly represented in HelloDev docs
- updating information about the latest version of JMeter used in kangal-jmeter docker image