### PR TITLE
EES-4738 - Document all the environment variables used in Kangal

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -32,7 +32,7 @@ jobs:
           VALIDATE_GITHUB_ACTIONS: false
           VALIDATE_NATURAL_LANGUAGE: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          KUBERNETES_KUBEVAL_OPTIONS: "--ignore-missing-schemas"
+          VALIDATE_KUBERNETES_KUBEVAL: false
 
       - name: Get tag
         id: get_tag

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -32,6 +32,7 @@ jobs:
           VALIDATE_GITHUB_ACTIONS: false
           VALIDATE_NATURAL_LANGUAGE: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KUBERNETES_KUBEVAL_OPTIONS: "--ignore-missing-schemas"
 
       - name: Get tag
         id: get_tag

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -24,7 +24,7 @@ jobs:
           version: v1.42.1
 
       - name: Run General Linting
-        uses: docker://ghcr.io/github/super-linter:slim-v4
+        uses: docker://ghcr.io/github/super-linter:slim-v4.8.5
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_GO: false

--- a/charts/kangal/Chart.yaml
+++ b/charts/kangal/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - performance tests
   - tests runner
 name: kangal
-version: 2.0.8
+version: 2.0.9
 home: https://github.com/hellofresh/kangal
 icon: https://raw.githubusercontent.com/hellofresh/kangal/master/logo.svg
 maintainers:

--- a/charts/kangal/README.md
+++ b/charts/kangal/README.md
@@ -9,7 +9,7 @@ This chart bootstraps a [kangal](https://github.com/hellofresh/kangal) deploymen
 - Kubernetes 1.12+
 
 ## Installing the Chart
-To add the the repository to Helm:
+To add the repository to Helm:
 ```shell
 $ helm repo add kangal https://hellofresh.github.io/kangal
 ```

--- a/charts/kangal/README.md
+++ b/charts/kangal/README.md
@@ -11,18 +11,18 @@ This chart bootstraps a [kangal](https://github.com/hellofresh/kangal) deploymen
 ## Installing the Chart
 To add the repository to Helm:
 ```shell
-$ helm repo add kangal https://hellofresh.github.io/kangal
+ helm repo add kangal https://hellofresh.github.io/kangal
 ```
 
 To install the chart with the release name `kangal`:
 ```shell
-$ helm install kangal kangal/kangal
+ helm install kangal kangal/kangal
 ```
 
 > **Tip**: You can provide values on the command line with `--set` or using the `values` file with `-f my-values-file.yaml`. Eg.:
 To set AWS credentials using command line you can use the following flags:
 
-```
+```shell
   --set secrets.AWS_ACCESS_KEY_ID="my-aws-key-id" \
   --set secrets.AWS_SECRET_ACCESS_KEY="my-aws-secret-access-key" \
 ```
@@ -37,7 +37,7 @@ secrets:
 
 To install the chart with the release name `kangal` and use an specific version:
 ```shell
-$ helm install \
+ helm install \
   --set proxy.image.tag=1.0.3 \
   --set controller.image.tag=1.0.3 \
   kangal kangal/kangal
@@ -52,7 +52,7 @@ It also applies the latest version of Custom Resource Definition (CRD) to the cl
 To uninstall/delete the `kangal` deployment:
 
 ```shell
-$ helm delete kangal
+ helm delete kangal
 ```
 
 > **Note:** Helm does not handle CRD deletion, so you have to manually remove it by running:
@@ -68,8 +68,8 @@ The following table lists the common configurable parameters for `Kangal` chart:
 | Parameter                            | Description                                                                                         | Default                               |
 |--------------------------------------|-----------------------------------------------------------------------------------------------------|---------------------------------------|
 | `environment`                        | The name that identifies the environment installation                                               | `dev`                                 |
-| `fullnameOverride`                   | String to fully override kangal.fullname template with a string                                     | ``                                    |
-| `nameOverride`                       | String to partially override kangal.fullname template with a string (will prepend the release name) | ``                                    |
+| `fullnameOverride`                   | String to fully override kangal.fullname template with a string                                     |                                       |
+| `nameOverride`                       | String to partially override kangal.fullname template with a string (will prepend the release name) |                                       |
 | `secrets.AWS_ACCESS_KEY_ID`          | AWS access key ID. If not defined report will not be stored                                         | `my-access-key-id`                    |
 | `secrets.AWS_SECRET_ACCESS_KEY`      | AWS secret access key                                                                               | `my-secret-access-key`                |
 | `configMap.AWS_BUCKET_NAME`          | The name of the bucket for saving reports                                                           | `my-bucket`                           |
@@ -158,31 +158,31 @@ Deployment specific configurations:
 ### Kangal Controller (JMeter specific)
 | Parameter                                      | Description                 | Default           |
 |------------------------------------------------|-----------------------------|-------------------|
-| `controller.env.JMETER_MASTER_CPU_LIMITS`      | Master container CPU limits | ``                |
-| `controller.env.JMETER_MASTER_CPU_REQUESTS`    | Master CPU requests         | ``                |
-| `controller.env.JMETER_MASTER_MEMORY_LIMITS`   | Master memory limits        | ``                |
-| `controller.env.JMETER_MASTER_MEMORY_REQUESTS` | Master memory requests      | ``                |
-| `controller.env.JMETER_WORKER_CPU_LIMITS`      | Master container CPU limits | ``                |
-| `controller.env.JMETER_WORKER_CPU_REQUESTS`    | Master CPU requests         | ``                |
-| `controller.env.JMETER_WORKER_MEMORY_LIMITS`   | Master memory limits        | ``                |
-| `controller.env.JMETER_WORKER_MEMORY_REQUESTS` | Master memory requests      | ``                |
+| `controller.env.JMETER_MASTER_CPU_LIMITS`      | Master container CPU limits |                   |
+| `controller.env.JMETER_MASTER_CPU_REQUESTS`    | Master CPU requests         |                   |
+| `controller.env.JMETER_MASTER_MEMORY_LIMITS`   | Master memory limits        |                   |
+| `controller.env.JMETER_MASTER_MEMORY_REQUESTS` | Master memory requests      |                   |
+| `controller.env.JMETER_WORKER_CPU_LIMITS`      | Master container CPU limits |                   |
+| `controller.env.JMETER_WORKER_CPU_REQUESTS`    | Master CPU requests         |                   |
+| `controller.env.JMETER_WORKER_MEMORY_LIMITS`   | Master memory limits        |                   |
+| `controller.env.JMETER_WORKER_MEMORY_REQUESTS` | Master memory requests      |                   |
 
 ### Kangal Controller (Locust specific)
 | Parameter                                      | Description                 | Default           |
 |------------------------------------------------|-----------------------------|-------------------|
-| `controller.env.LOCUST_MASTER_CPU_LIMITS`      | Master container CPU limits | ``                |
-| `controller.env.LOCUST_MASTER_CPU_REQUESTS`    | Master CPU requests         | ``                |
-| `controller.env.LOCUST_MASTER_MEMORY_LIMITS`   | Master memory limits        | ``                |
-| `controller.env.LOCUST_MASTER_MEMORY_REQUESTS` | Master memory requests      | ``                |
-| `controller.env.LOCUST_WORKER_CPU_LIMITS`      | Master container CPU limits | ``                |
-| `controller.env.LOCUST_WORKER_CPU_REQUESTS`    | Master CPU requests         | ``                |
-| `controller.env.LOCUST_WORKER_MEMORY_LIMITS`   | Master memory limits        | ``                |
-| `controller.env.LOCUST_WORKER_MEMORY_REQUESTS` | Master memory requests      | ``                |
+| `controller.env.LOCUST_MASTER_CPU_LIMITS`      | Master container CPU limits |                   |
+| `controller.env.LOCUST_MASTER_CPU_REQUESTS`    | Master CPU requests         |                   |
+| `controller.env.LOCUST_MASTER_MEMORY_LIMITS`   | Master memory limits        |                   |
+| `controller.env.LOCUST_MASTER_MEMORY_REQUESTS` | Master memory requests      |                   |
+| `controller.env.LOCUST_WORKER_CPU_LIMITS`      | Master container CPU limits |                   |
+| `controller.env.LOCUST_WORKER_CPU_REQUESTS`    | Master CPU requests         |                   |
+| `controller.env.LOCUST_WORKER_MEMORY_LIMITS`   | Master memory limits        |                   |
+| `controller.env.LOCUST_WORKER_MEMORY_REQUESTS` | Master memory requests      |                   |
 
 ### Kangal Controller (`ghz` specific)
 | Parameter                                   | Description     | Default           |
 |---------------------------------------------|-----------------|-------------------|
-| `controller.env.GHZ_MASTER_CPU_LIMITS`      | CPU limits      | ``                |
-| `controller.env.GHZ_MASTER_CPU_REQUESTS`    | CPU requests    | ``                |
-| `controller.env.GHZ_MASTER_MEMORY_LIMITS`   | Memory limits   | ``                |
-| `controller.env.GHZ_MASTER_MEMORY_REQUESTS` | Memory requests | ``                |
+| `controller.env.GHZ_MASTER_CPU_LIMITS`      | CPU limits      |                   |
+| `controller.env.GHZ_MASTER_CPU_REQUESTS`    | CPU requests    |                   |
+| `controller.env.GHZ_MASTER_MEMORY_LIMITS`   | Memory limits   |                   |
+| `controller.env.GHZ_MASTER_MEMORY_REQUESTS` | Memory requests |                   |

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,20 +6,12 @@ import (
 
 // GlobalConfig holds the config values that are common to all applications
 type GlobalConfig struct {
-	Log   LogConfig
-
 	// S3 compatible configuration access keys and endpoints needed to store load test reports
 	AWSAccessKeyID     string `envconfig:"AWS_ACCESS_KEY_ID" default:""`
 	AWSSecretAccessKey string `envconfig:"AWS_SECRET_ACCESS_KEY" default:""`
 	AWSRegion          string `envconfig:"AWS_DEFAULT_REGION" default:""`
 	AWSEndpointURL     string `envconfig:"AWS_ENDPOINT_URL" default:""`
 	AWSBucketName      string `envconfig:"AWS_BUCKET_NAME" default:""`
-}
-
-// LogConfig is logging basic config
-type LogConfig struct {
-	Level string `envconfig:"LOG_LEVEL" default:"info"`
-	Type  string `envconfig:"LOG_TYPE" default:"kangal"`
 }
 
 // NewRootCmd creates a new instance of the root command

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,7 +6,6 @@ import (
 
 // GlobalConfig holds the config values that are common to all applications
 type GlobalConfig struct {
-	Debug bool `envconfig:"DEBUG"`
 	Log   LogConfig
 
 	// S3 compatible configuration access keys and endpoints needed to store load test reports

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,16 +4,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// GlobalConfig holds the config values that are common to all applications
-type GlobalConfig struct {
-	// S3 compatible configuration access keys and endpoints needed to store load test reports
-	AWSAccessKeyID     string `envconfig:"AWS_ACCESS_KEY_ID" default:""`
-	AWSSecretAccessKey string `envconfig:"AWS_SECRET_ACCESS_KEY" default:""`
-	AWSRegion          string `envconfig:"AWS_DEFAULT_REGION" default:""`
-	AWSEndpointURL     string `envconfig:"AWS_ENDPOINT_URL" default:""`
-	AWSBucketName      string `envconfig:"AWS_BUCKET_NAME" default:""`
-}
-
 // NewRootCmd creates a new instance of the root command
 func NewRootCmd(version string) *cobra.Command {
 	cmd := &cobra.Command{

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -72,20 +72,16 @@
 | `LOG_LEVEL`                | Log level                                                    | `info`                                |
 | `LOG_TYPE`                 | Log type                                                     | `kangal`                              |
 
-## Global config
-| Parameter                  | Description                                                  | Default                               |
-|----------------------------|--------------------------------------------------------------|---------------------------------------|
-| `AWS_ACCESS_KEY_ID`        | AWS access key ID. If not defined report will not be stored  | `my-access-key-id`                    |
-| `AWS_BUCKET_NAME`          | The name of the bucket for saving reports                    | `my-bucket`                           |
-| `AWS_DEFAULT_REGION`       | Storage connection parameter                                 | `us-east-1`                           |
-| `AWS_ENDPOINT_URL`         | Storage connection parameter                                 | `s3.us-east-1.amazonaws.com`          |
-| `AWS_SECRET_ACCESS_KEY`    | AWS secret access key                                        | `my-secret-access-key`                |
-
 ## Report config
-| Parameter                  | Description                        | Default                               |
-|----------------------------|------------------------------------|---------------------------------------|
-| `AWS_PRESIGNED_EXPIRES`    | Expiration time for Presigned URLs | `30m`                                 |
-| `AWS_USE_HTTPS`            | Set to "true" to use HTTPS         | `false`                               |
+| Parameter                  | Description                                                  | Default   |
+|----------------------------|--------------------------------------------------------------|-----------|
+| `AWS_ACCESS_KEY_ID`        | AWS access key ID. If not defined report will not be stored  |           |
+| `AWS_BUCKET_NAME`          | The name of the bucket for saving reports                    |           |
+| `AWS_DEFAULT_REGION`       | Storage connection parameter                                 |           |
+| `AWS_ENDPOINT_URL`         | Storage connection parameter                                 |           |
+| `AWS_PRESIGNED_EXPIRES`    | Expiration time for Presigned URLs                           |           |
+| `AWS_SECRET_ACCESS_KEY`    | AWS secret access key                                        |           |
+| `AWS_USE_HTTPS`            | Set to "true" to use HTTPS                                   | `false`   |
 
 ## Swagger
 | Parameter              | Description                              | Default                                    |

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -66,11 +66,15 @@
 | `GHZ_MASTER_MEMORY_LIMITS`   | Memory limits                       |                         |
 | `GHZ_MASTER_MEMORY_REQUESTS` | Memory requests                     |                         |
 
-## Global config
+## Logger config
 | Parameter                  | Description                                                  | Default                               |
 |----------------------------|--------------------------------------------------------------|---------------------------------------|
 | `LOG_LEVEL`                | Log level                                                    | `info`                                |
 | `LOG_TYPE`                 | Log type                                                     | `kangal`                              |
+
+## Global config
+| Parameter                  | Description                                                  | Default                               |
+|----------------------------|--------------------------------------------------------------|---------------------------------------|
 | `AWS_ACCESS_KEY_ID`        | AWS access key ID. If not defined report will not be stored  | `my-access-key-id`                    |
 | `AWS_BUCKET_NAME`          | The name of the bucket for saving reports                    | `my-bucket`                           |
 | `AWS_DEFAULT_REGION`       | Storage connection parameter                                 | `us-east-1`                           |

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -17,14 +17,14 @@
 | `WEB_HTTP_PORT`                 |                                                      | `8080`                                     |
 
 ## Controller
-| Parameter                       | Description                                       | Default                           |
-|---------------------------------|---------------------------------------------------|-----------------------------------|
-| `CLEANUP_THRESHOLD`             | Life time of a load test                          | `1h`                              |
+| Parameter                       | Description                                       | Default             |
+|---------------------------------|---------------------------------------------------|---------------------|
+| `CLEANUP_THRESHOLD`             | Life time of a load test                          | `1h`                |
 | `DEBUG`                         |        | |
-| `KANGAL_PROXY_URL`              | Endpoints used to store load test reports         | `""` |
-| `KUBE_CLIENT_TIMEOUT`           | Timeout for each operation done by kube client    | `5s` |
-| `SYNC_HANDLER_TIMEOUT`          | Time limit for each sync operation                | `60s`                            |
-| `WEB_HTTP_PORT`                 |                                                   | `8080`               |
+| `KANGAL_PROXY_URL`              | Endpoints used to store load test reports         | `""`                |
+| `KUBE_CLIENT_TIMEOUT`           | Timeout for each operation done by kube client    | `5s`                |
+| `SYNC_HANDLER_TIMEOUT`          | Time limit for each sync operation                | `60s`               |
+| `WEB_HTTP_PORT`                 |                                                   | `8080`              |
 
 ## Backend specific configuration
 ### JMeter
@@ -32,41 +32,41 @@
 |---------------------------------|--------------------------------------|-----------------------------------|
 | `JMETER_MASTER_IMAGE_NAME`      | JMeter master image name/repository  | `hellofresh/kangal-jmeter-master` |
 | `JMETER_MASTER_IMAGE_TAG`       | Tag of the JMeter master image above | `latest`                          |
-| `JMETER_MASTER_CPU_LIMIT`       | Master CPU limit                     | ``                                |
-| `JMETER_MASTER_CPU_REQUESTS`    | Master CPU requests                  | ``                                |
-| `JMETER_MASTER_MEMORY_LIMITS`   | Master memory limits                 | ``                                |
-| `JMETER_MASTER_MEMORY_REQUESTS` | Master memory requests               | ``                                |
+| `JMETER_MASTER_CPU_LIMIT`       | Master CPU limit                     |                                   |
+| `JMETER_MASTER_CPU_REQUESTS`    | Master CPU requests                  |                                   |
+| `JMETER_MASTER_MEMORY_LIMITS`   | Master memory limits                 |                                   |
+| `JMETER_MASTER_MEMORY_REQUESTS` | Master memory requests               |                                   |
 | `JMETER_WORKER_IMAGE_NAME`      | JMeter worker image name/repository  | `hellofresh/kangal-jmeter-worker` |
 | `JMETER_WORKER_IMAGE_TAG`       | Tag of the JMeter worker image above | `latest`                          |
-| `JMETER_WORKER_CPU_LIMITS`      | Worker container CPU limits          | ``                                |
-| `JMETER_WORKER_CPU_REQUESTS`    | Worker CPU requests                  | ``                                |
-| `JMETER_WORKER_MEMORY_LIMITS`   | Worker memory limits                 | ``                                |
-| `JMETER_WORKER_MEMORY_REQUESTS` | Worker memory requests               | ``                                |
+| `JMETER_WORKER_CPU_LIMITS`      | Worker container CPU limits          |                                   |
+| `JMETER_WORKER_CPU_REQUESTS`    | Worker CPU requests                  |                                   |
+| `JMETER_WORKER_MEMORY_LIMITS`   | Worker memory limits                 |                                   |
+| `JMETER_WORKER_MEMORY_REQUESTS` | Worker memory requests               |                                   |
 
 ### Locust
 | Parameter                       | Description                 | Default           |
 |---------------------------------|-----------------------------|-------------------|
-| `LOCUST_IMAGE`                  | Locust image                | ``                |
-| `LOCUST_IMAGE_NAME`             | Locust image name           | ``                |
-| `LOCUST_IMAGE_TAG`              | Locust image tag            | ``                |
-| `LOCUST_MASTER_CPU_LIMITS`      | Master container CPU limits | ``                |
-| `LOCUST_MASTER_CPU_REQUESTS`    | Master CPU requests         | ``                |
-| `LOCUST_MASTER_MEMORY_LIMITS`   | Master memory limits        | ``                |
-| `LOCUST_MASTER_MEMORY_REQUESTS` | Master memory requests      | ``                |
-| `LOCUST_WORKER_CPU_LIMITS`      | Master container CPU limits | ``                |
-| `LOCUST_WORKER_CPU_REQUESTS`    | Master CPU requests         | ``                |
-| `LOCUST_WORKER_MEMORY_LIMITS`   | Master memory limits        | ``                |
-| `LOCUST_WORKER_MEMORY_REQUESTS` | Master memory requests      | ``                |
+| `LOCUST_IMAGE`                  | Locust image                |                   |
+| `LOCUST_IMAGE_NAME`             | Locust image name           |                   |
+| `LOCUST_IMAGE_TAG`              | Locust image tag            |                   |
+| `LOCUST_MASTER_CPU_LIMITS`      | Master container CPU limits |                   |
+| `LOCUST_MASTER_CPU_REQUESTS`    | Master CPU requests         |                   |
+| `LOCUST_MASTER_MEMORY_LIMITS`   | Master memory limits        |                   |
+| `LOCUST_MASTER_MEMORY_REQUESTS` | Master memory requests      |                   |
+| `LOCUST_WORKER_CPU_LIMITS`      | Master container CPU limits |                   |
+| `LOCUST_WORKER_CPU_REQUESTS`    | Master CPU requests         |                   |
+| `LOCUST_WORKER_MEMORY_LIMITS`   | Master memory limits        |                   |
+| `LOCUST_WORKER_MEMORY_REQUESTS` | Master memory requests      |                   |
 
 ### `ghz`
 | Parameter                    | Description                         | Default                 |
 |------------------------------|-------------------------------------|-------------------------|
 | `GHZ_IMAGE_NAME`             | Default ghz image name/repository   | `hellofresh/kangal-ghz` |
 | `GHZ_IMAGE_TAG`              | Tag of the ghz image above          | `latest`                |
-| `GHZ_MASTER_CPU_LIMITS`      | CPU limits                          | ``                      |
-| `GHZ_MASTER_CPU_REQUESTS`    | CPU requests                        | ``                      |
-| `GHZ_MASTER_MEMORY_LIMITS`   | Memory limits                       | ``                      |
-| `GHZ_MASTER_MEMORY_REQUESTS` | Memory requests                     | ``                      |
+| `GHZ_MASTER_CPU_LIMITS`      | CPU limits                          |                         |
+| `GHZ_MASTER_CPU_REQUESTS`    | CPU requests                        |                         |
+| `GHZ_MASTER_MEMORY_LIMITS`   | Memory limits                       |                         |
+| `GHZ_MASTER_MEMORY_REQUESTS` | Memory requests                     |                         |
 
 ## Global config
 | Parameter                  | Description                                                  | Default                               |

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -4,9 +4,8 @@
 | Parameter                       | Description                                          | Default                                    |
 |---------------------------------|------------------------------------------------------|--------------------------------------------|
 | `ALLOWED_CUSTOM_IMAGES`         | Allow custom Images to be defined in the request     | `false`                                    |
-| `DEBUG`                         |        | |
 | `KUBE_CLIENT_TIMEOUT`           | Timeout for each operation done by kube client       | `5s`                                       |
-| `MAX_LIST_LIMIT`                | Output of LIST endpoint                              | 50                                         |
+| `MAX_LIST_LIMIT`                | Output of LIST endpoint                              | `50`                                       |
 | `OPEN_API_SERVER_DESCRIPTION`   | Description to the OpenAPI server URL                | `Kangal proxy default value`               |
 | `OPEN_API_SERVER_URL`           | URL to the OpenAPI specification server              | `https://kangal-proxy.example.com/openapi` |
 | `OPEN_API_SPEC_PATH`            | Path to the openapi spec file                        | `/etc/kangal`                              |
@@ -20,7 +19,6 @@
 | Parameter                       | Description                                       | Default             |
 |---------------------------------|---------------------------------------------------|---------------------|
 | `CLEANUP_THRESHOLD`             | Life time of a load test                          | `1h`                |
-| `DEBUG`                         |        | |
 | `KANGAL_PROXY_URL`              | Endpoints used to store load test reports         | `""`                |
 | `KUBE_CLIENT_TIMEOUT`           | Timeout for each operation done by kube client    | `5s`                |
 | `SYNC_HANDLER_TIMEOUT`          | Time limit for each sync operation                | `60s`               |
@@ -71,7 +69,6 @@
 ## Global config
 | Parameter                  | Description                                                  | Default                               |
 |----------------------------|--------------------------------------------------------------|---------------------------------------|
-| `DEBUG`                    |   |                    |
 | `LOG_LEVEL`                | Log level                                                    | `info`                                |
 | `LOG_TYPE`                 | Log type                                                     | `kangal`                              |
 | `AWS_ACCESS_KEY_ID`        | AWS access key ID. If not defined report will not be stored  | `my-access-key-id`                    |

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -1,0 +1,95 @@
+# Kangal environment variables
+
+## Proxy
+| Parameter                       | Description                                          | Default                                    |
+|---------------------------------|------------------------------------------------------|--------------------------------------------|
+| `ALLOWED_CUSTOM_IMAGES`         | Allow custom Images to be defined in the request     | `false`                                    |
+| `DEBUG`                         |        | |
+| `KUBE_CLIENT_TIMEOUT`           | Timeout for each operation done by kube client       | `5s`                                       |
+| `MAX_LIST_LIMIT`                | Output of LIST endpoint                              | 50                                         |
+| `OPEN_API_SERVER_DESCRIPTION`   | Description to the OpenAPI server URL                | `Kangal proxy default value`               |
+| `OPEN_API_SERVER_URL`           | URL to the OpenAPI specification server              | `https://kangal-proxy.example.com/openapi` |
+| `OPEN_API_SPEC_PATH`            | Path to the openapi spec file                        | `/etc/kangal`                              |
+| `OPEN_API_SPEC_FILE`            | Name of the openapi spec file                        | `openapi.json`                             |
+| `OPEN_API_UI_URL`               | URL to the OpenAPI UI                                | `https://kangal-openapi-ui.example.com`    |
+| `OPEN_API_CORS_ALLOW_ORIGIN`    | List of origins a cross-domain request can be executed from                    | `*`              |
+| `OPEN_API_CORS_ALLOW_HEADERS`   | List of non simple headers client is allowed to use with cross-domain requests | `Content-Type,api_key,Authorization`    |
+| `WEB_HTTP_PORT`                 |                                                      | `8080`                                     |
+
+## Controller
+| Parameter                       | Description                                       | Default                           |
+|---------------------------------|---------------------------------------------------|-----------------------------------|
+| `CLEANUP_THRESHOLD`             | Life time of a load test                          | `1h`                              |
+| `DEBUG`                         |        | |
+| `KANGAL_PROXY_URL`              | Endpoints used to store load test reports         | `""` |
+| `KUBE_CLIENT_TIMEOUT`           | Timeout for each operation done by kube client    | `5s` |
+| `SYNC_HANDLER_TIMEOUT`          | Time limit for each sync operation                | `60s`                            |
+| `WEB_HTTP_PORT`                 |                                                   | `8080`               |
+
+## Backend specific configuration
+### JMeter
+| Parameter                       | Description                          | Default                           |
+|---------------------------------|--------------------------------------|-----------------------------------|
+| `JMETER_MASTER_IMAGE_NAME`      | JMeter master image name/repository  | `hellofresh/kangal-jmeter-master` |
+| `JMETER_MASTER_IMAGE_TAG`       | Tag of the JMeter master image above | `latest`                          |
+| `JMETER_MASTER_CPU_LIMIT`       | Master CPU limit                     | ``                                |
+| `JMETER_MASTER_CPU_REQUESTS`    | Master CPU requests                  | ``                                |
+| `JMETER_MASTER_MEMORY_LIMITS`   | Master memory limits                 | ``                                |
+| `JMETER_MASTER_MEMORY_REQUESTS` | Master memory requests               | ``                                |
+| `JMETER_WORKER_IMAGE_NAME`      | JMeter worker image name/repository  | `hellofresh/kangal-jmeter-worker` |
+| `JMETER_WORKER_IMAGE_TAG`       | Tag of the JMeter worker image above | `latest`                          |
+| `JMETER_WORKER_CPU_LIMITS`      | Worker container CPU limits          | ``                                |
+| `JMETER_WORKER_CPU_REQUESTS`    | Worker CPU requests                  | ``                                |
+| `JMETER_WORKER_MEMORY_LIMITS`   | Worker memory limits                 | ``                                |
+| `JMETER_WORKER_MEMORY_REQUESTS` | Worker memory requests               | ``                                |
+
+### Locust
+| Parameter                       | Description                 | Default           |
+|---------------------------------|-----------------------------|-------------------|
+| `LOCUST_IMAGE`                  | Locust image                | ``                |
+| `LOCUST_IMAGE_NAME`             | Locust image name           | ``                |
+| `LOCUST_IMAGE_TAG`              | Locust image tag            | ``                |
+| `LOCUST_MASTER_CPU_LIMITS`      | Master container CPU limits | ``                |
+| `LOCUST_MASTER_CPU_REQUESTS`    | Master CPU requests         | ``                |
+| `LOCUST_MASTER_MEMORY_LIMITS`   | Master memory limits        | ``                |
+| `LOCUST_MASTER_MEMORY_REQUESTS` | Master memory requests      | ``                |
+| `LOCUST_WORKER_CPU_LIMITS`      | Master container CPU limits | ``                |
+| `LOCUST_WORKER_CPU_REQUESTS`    | Master CPU requests         | ``                |
+| `LOCUST_WORKER_MEMORY_LIMITS`   | Master memory limits        | ``                |
+| `LOCUST_WORKER_MEMORY_REQUESTS` | Master memory requests      | ``                |
+
+### `ghz`
+| Parameter                    | Description                         | Default                 |
+|------------------------------|-------------------------------------|-------------------------|
+| `GHZ_IMAGE_NAME`             | Default ghz image name/repository   | `hellofresh/kangal-ghz` |
+| `GHZ_IMAGE_TAG`              | Tag of the ghz image above          | `latest`                |
+| `GHZ_MASTER_CPU_LIMITS`      | CPU limits                          | ``                      |
+| `GHZ_MASTER_CPU_REQUESTS`    | CPU requests                        | ``                      |
+| `GHZ_MASTER_MEMORY_LIMITS`   | Memory limits                       | ``                      |
+| `GHZ_MASTER_MEMORY_REQUESTS` | Memory requests                     | ``                      |
+
+## Global config
+| Parameter                  | Description                                                  | Default                               |
+|----------------------------|--------------------------------------------------------------|---------------------------------------|
+| `DEBUG`                    |   |                    |
+| `LOG_LEVEL`                | Log level                                                    | `info`                                |
+| `LOG_TYPE`                 | Log type                                                     | `kangal`                              |
+| `AWS_ACCESS_KEY_ID`        | AWS access key ID. If not defined report will not be stored  | `my-access-key-id`                    |
+| `AWS_BUCKET_NAME`          | The name of the bucket for saving reports                    | `my-bucket`                           |
+| `AWS_DEFAULT_REGION`       | Storage connection parameter                                 | `us-east-1`                           |
+| `AWS_ENDPOINT_URL`         | Storage connection parameter                                 | `s3.us-east-1.amazonaws.com`          |
+| `AWS_SECRET_ACCESS_KEY`    | AWS secret access key                                        | `my-secret-access-key`                |
+
+## Report config
+| Parameter                  | Description                        | Default                               |
+|----------------------------|------------------------------------|---------------------------------------|
+| `AWS_PRESIGNED_EXPIRES`    | Expiration time for Presigned URLs | `30m`                                 |
+| `AWS_USE_HTTPS`            | Set to "true" to use HTTPS         | `false`                               |
+
+## Swagger
+| Parameter              | Description                              | Default                                    |
+|------------------------|------------------------------------------|--------------------------------------------|
+| `PORT`                 | The PORT of OpenAPI definition           | `8080`                                     |
+| `URL`                  | The URL pointing to OpenAPI definition   | `https://kangal-proxy.example.com/openapi` |
+| `VALIDATOR_URL`        | The URL to spec validator                | `null`                                     |
+| `KANGAL_PROXY_URL`     | Kangal Proxy URL used to persist reports | `https://kangal-proxy.example.com`         |

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,6 +124,8 @@ export AWS_DEFAULT_REGION=YOUR_AWS_REGION     # storage connection parameter
 export KANGAL_PROXY_URL=http://localhost:8080 # used to persist reports
 ```
 
+For the full list of possible environment variables check [Kangal environment variables](env-vars.md)
+
 ### 6. Run both Kangal proxy and controller
 
 ```bash

--- a/docs/jmeter/README.md
+++ b/docs/jmeter/README.md
@@ -63,6 +63,8 @@ JMETER_WORKER_MEMORY_LIMITS
 JMETER_WORKER_MEMORY_REQUESTS
 ```
 
+For the full list of possible environment variables check [Kangal environment variables](../env-vars.md)
+
 More information regarding resource limits and requests can be found in the following page(s):
 - https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 - https://cloud.google.com/blog/products/gcp/kubernetes-best-practices-resource-requests-and-limits

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -19,3 +19,4 @@ nav:
       - About Locust load generator: 'locust/README.md'
   - Ghz load generator:
       - About ghz load generator: 'ghz/README.md'
+  - Kangal environment variables: 'env-vars.md'

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -8,7 +8,7 @@ import (
 
 // Config is the possible Kangal Controller configurations
 type Config struct {
-	HTTPPort int  `envconfig:"WEB_HTTP_PORT" default:"8080"`
+	HTTPPort int `envconfig:"WEB_HTTP_PORT" default:"8080"`
 	Logger   observability.LoggerConfig
 
 	// CleanUpThresholdEnvVar is used if we want to increase the amount of time a

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -8,7 +8,6 @@ import (
 
 // Config is the possible Kangal Controller configurations
 type Config struct {
-	Debug    bool `envconfig:"DEBUG"`
 	HTTPPort int  `envconfig:"WEB_HTTP_PORT" default:"8080"`
 	Logger   observability.LoggerConfig
 

--- a/pkg/proxy/config.go
+++ b/pkg/proxy/config.go
@@ -9,7 +9,7 @@ import (
 
 // Config is the possible Proxy configurations
 type Config struct {
-	HTTPPort            int  `envconfig:"WEB_HTTP_PORT" default:"8080"`
+	HTTPPort            int `envconfig:"WEB_HTTP_PORT" default:"8080"`
 	Logger              observability.LoggerConfig
 	OpenAPI             OpenAPIConfig
 	Report              report.Config

--- a/pkg/proxy/config.go
+++ b/pkg/proxy/config.go
@@ -9,7 +9,6 @@ import (
 
 // Config is the possible Proxy configurations
 type Config struct {
-	Debug               bool `envconfig:"DEBUG"`
 	HTTPPort            int  `envconfig:"WEB_HTTP_PORT" default:"8080"`
 	Logger              observability.LoggerConfig
 	OpenAPI             OpenAPIConfig


### PR DESCRIPTION
This PR adds a new document which contains all the env vars used to configure Kangal.
Documentation for helm chart was also updated.
Some unused and duplicated variables were removed from configs.
Also superlinter version was updated in the testing workflow.