### PR TITLE
update dockerfile to use ubuntu:20.04 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM ubuntu:20.10
+FROM ubuntu:20.04
 
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y ca-certificates && \
+    apt-get install --no-install-recommends -y ca-certificates=20210119 && \
     mkdir -p /etc/kangal
 
-ADD kangal /bin/kangal
-ADD openapi.json /etc/kangal/
+COPY kangal /bin/kangal
+COPY openapi.json /etc/kangal/
 
 RUN chmod a+x /bin/kangal && \
     chmod -R a+r /etc/kangal

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM ubuntu:20.04
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y ca-certificates=20210119 && \
-    mkdir -p /etc/kangal
+    mkdir -p /etc/kangal && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY kangal /bin/kangal
 COPY openapi.json /etc/kangal/


### PR DESCRIPTION
Currently kangal dockerfile is using ubuntu:20.10 which reached the end of life already. 
We need to use ubuntu:20.04 LTS.