### PR TITLE
Allow integration test to be run selectively

### DIFF
--- a/ci/integration-tests.sh
+++ b/ci/integration-tests.sh
@@ -6,72 +6,105 @@ export AWS_SECRET_ACCESS_KEY=""
 
 # Create a simple service to be called from the created loadTest
 # This service will log all the requests
-kubectl create ns test-busybox
-kubectl run busybox --namespace=test-busybox --port=8280 --image=busybox -- sh -c "echo 'Hello' > /var/www/index.html && httpd -f -p 8280 -h /var/www/ -vv"
-kubectl expose pod busybox --type=NodePort --namespace=test-busybox
-kubectl wait --for=condition=ready pod busybox -n test-busybox
+function prepare_jmeter_integration_test {
+  kubectl create ns test-busybox
+  kubectl run busybox --namespace=test-busybox --port=8280 --image=busybox -- sh -c "echo 'Hello' > /var/www/index.html && httpd -f -p 8280 -h /var/www/ -vv"
+  kubectl expose pod busybox --type=NodePort --namespace=test-busybox
+  kubectl wait --for=condition=ready pod busybox -n test-busybox
 
-NODE_IP=$(kubectl describe pod busybox -n test-busybox | grep "Node:" | cut -d '/' -f 2)
-NODE_PORT=$(kubectl get service busybox -n test-busybox | grep busybox | cut -d ':' -f 2 | cut -d '/' -f 1)
+  NODE_IP=$(kubectl describe pod busybox -n test-busybox | grep "Node:" | cut -d '/' -f 2)
+  NODE_PORT=$(kubectl get service busybox -n test-busybox | grep busybox | cut -d ':' -f 2 | cut -d '/' -f 1)
 
-# Update JMX test to use node_ip:port to send requests
-sed -i "s/TEST_IP/$NODE_IP/g" ./pkg/controller/testdata/valid/integration_test.jmx
-sed -i "s/TEST_PORT/${NODE_PORT}/g" ./pkg/controller/testdata/valid/integration_test.jmx
+  # Update JMX test to use node_ip:port to send requests
+  sed -i "s/TEST_IP/$NODE_IP/g" ./pkg/controller/testdata/valid/integration_test.jmx
+  sed -i "s/TEST_PORT/${NODE_PORT}/g" ./pkg/controller/testdata/valid/integration_test.jmx
+}
 
 # Run dummy grpc server to test ghz
-kubectl create ns test-ghz
-kubectl run greeter-server --namespace=test-ghz --port=50051 --image=greeter_server:local
-kubectl expose pod greeter-server --type=NodePort --namespace=test-ghz
-kubectl wait --for=condition=ready pod greeter-server -n test-ghz
+function prepare_ghz_integration_test {
+  kubectl create ns test-ghz
+  kubectl run greeter-server --namespace=test-ghz --port=50051 --image=greeter_server:local
+  kubectl expose pod greeter-server --type=NodePort --namespace=test-ghz
+  kubectl wait --for=condition=ready pod greeter-server -n test-ghz
 
-NODE_IP=$(kubectl describe pod greeter-server -n test-ghz | grep "Node:" | cut -d '/' -f 2)
-NODE_PORT=$(kubectl get service greeter-server -n test-ghz | grep greeter-server | cut -d ':' -f 2 | cut -d '/' -f 1)
+  NODE_IP=$(kubectl describe pod greeter-server -n test-ghz | grep "Node:" | cut -d '/' -f 2)
+  NODE_PORT=$(kubectl get service greeter-server -n test-ghz | grep greeter-server | cut -d ':' -f 2 | cut -d '/' -f 1)
 
-sed -i "s/0.0.0.0/$NODE_IP/g" ./pkg/controller/testdata/ghz/config.json
-sed -i "s/50051/${NODE_PORT}/g" ./pkg/controller/testdata/ghz/config.json
+  sed -i "s/0.0.0.0/$NODE_IP/g" ./pkg/controller/testdata/ghz/config.json
+  sed -i "s/50051/${NODE_PORT}/g" ./pkg/controller/testdata/ghz/config.json
+}
 
-echo "Starting kangal proxy"
-./bin/kangal proxy --kubeconfig="$HOME/.kube/config" --max-load-tests 1 >/tmp/kangal_proxy.log 2>&1 &
-PID_PROXY=$!
-sleep 1
-echo "Check if proxy is running"
-if ! kill -s 0 "${PID_PROXY}"; then
-  echo "Failed to run kangal proxy"
-  cat /tmp/kangal_proxy.log
-  exit 1
-fi
+# Start Kangal
+function prepare_kangal {
+  echo "Starting kangal proxy"
+  ./bin/kangal proxy --kubeconfig="$HOME/.kube/config" --max-load-tests 1 >/tmp/kangal_proxy.log 2>&1 &
+  PID_PROXY=$!
+  sleep 1
+  echo "Check if proxy is running"
+  if ! kill -s 0 "${PID_PROXY}"; then
+    echo "Failed to run kangal proxy"
+    cat /tmp/kangal_proxy.log
+    exit 1
+  fi
 
-echo "Proxy is running"
-echo "Starting kangal controller"
-WEB_HTTP_PORT=8888 CLEANUP_THRESHOLD=10s SYNC_HANDLER_TIMEOUT=10s ./bin/kangal controller --kubeconfig="$HOME/.kube/config" >/tmp/kangal_controller.log 2>&1 &
-PID_CONTROLLER=$!
-sleep 1
-echo "Check if controller is running"
-if ! kill -s 0 "${PID_CONTROLLER}"; then
-  echo "Failed to run kangal controller"
-  cat /tmp/kangal_controller.log
-  exit 1
-fi
+  echo "Proxy is running"
+  echo "Starting kangal controller"
+  WEB_HTTP_PORT=8888 CLEANUP_THRESHOLD=10s SYNC_HANDLER_TIMEOUT=10s ./bin/kangal controller --kubeconfig="$HOME/.kube/config" >/tmp/kangal_controller.log 2>&1 &
+  PID_CONTROLLER=$!
+  sleep 1
+  echo "Check if controller is running"
+  if ! kill -s 0 "${PID_CONTROLLER}"; then
+    echo "Failed to run kangal controller"
+    cat /tmp/kangal_controller.log
+    exit 1
+  fi
 
-echo "Controller is running"
-echo "Starting integration tests"
-
-# Run the integration tests
-KUBECONFIG="$HOME/.kube/config" make test-integration
+  echo "Controller is running"
+}
 
 # Check the logs of busybox server and count the number of requests sent by JMeter.
 # integration_test.jmx is designed to send 30 requests during 30 seconds.
 # jmeter_integration_test.go creates a loadTest with 2 distributed pods, which leads us to 60 desired requests to the server
-DESIRED_REQUESTS_COUNT=60
-REQUEST_COUNT=$(kubectl logs busybox -n test-busybox | grep -c "response:200")
-if [ "${REQUEST_COUNT}" -ne "${DESIRED_REQUESTS_COUNT}" ]; then
-  echo "JMeter Integration Test sent $REQUEST_COUNT requests, but $DESIRED_REQUESTS_COUNT requests were expected. Test failed."
-  exit 1
-fi
+function verify_jmeter_integration_test {
+  DESIRED_REQUESTS_COUNT=60
+  REQUEST_COUNT=$(kubectl logs busybox -n test-busybox | grep -c "response:200")
+  if [ "${REQUEST_COUNT}" -ne "${DESIRED_REQUESTS_COUNT}" ]; then
+    echo "JMeter Integration Test sent $REQUEST_COUNT requests, but $DESIRED_REQUESTS_COUNT requests were expected. Test failed."
+    exit 1
+  fi
+}
 
 # Verify that greeter-server received something
-REQUEST_COUNT=$(kubectl logs greeter-server -n test-ghz --tail=100 | grep -c "Received")
-if [ "$REQUEST_COUNT" -eq "0" ]; then
-  echo "Expected dummy grpc server to receive >0 request, but found 0. Test failed."
-  exit 1
+function verify_ghz_integration_test {
+  REQUEST_COUNT=$(kubectl logs greeter-server -n test-ghz --tail=100 | grep -c "Received")
+  if [ "$REQUEST_COUNT" -eq "0" ]; then
+    echo "Expected dummy grpc server to receive >0 request, but found 0. Test failed."
+    exit 1
+  fi
+}
+
+# Main
+# --------
+# Prepare environment for integration test
+prepare_kangal
+
+if [[ "$SKIP_JMETER_INTEGRATION_TEST" != "" ]]; then
+  prepare_jmeter_integration_test
+fi
+
+if [[ "$SKIP_GHZ_INTEGRATION_TEST" != "" ]]; then
+  prepare_ghz_integration_test
+fi
+
+# Run the integration tests
+echo "Starting integration tests"
+KUBECONFIG="$HOME/.kube/config" make test-integration
+
+# Verify results
+if [[ "$SKIP_JMETER_INTEGRATION_TEST" != "" ]]; then
+  verify_jmeter_integration_test
+fi
+
+if [[ "$SKIP_GHZ_INTEGRATION_TEST" != "" ]]; then
+  verify_ghz_integration_test
 fi

--- a/ci/integration-tests.sh
+++ b/ci/integration-tests.sh
@@ -86,8 +86,6 @@ function verify_ghz_integration_test {
 # Main
 # --------
 # Prepare environment for integration test
-prepare_kangal
-
 if [[ "$SKIP_JMETER_INTEGRATION_TEST" != "" ]]; then
   prepare_jmeter_integration_test
 fi
@@ -95,6 +93,9 @@ fi
 if [[ "$SKIP_GHZ_INTEGRATION_TEST" != "" ]]; then
   prepare_ghz_integration_test
 fi
+
+prepare_kangal
+
 
 # Run the integration tests
 echo "Starting integration tests"

--- a/ci/integration-tests.sh
+++ b/ci/integration-tests.sh
@@ -86,11 +86,11 @@ function verify_ghz_integration_test {
 # Main
 # --------
 # Prepare environment for integration test
-if [[ "$SKIP_JMETER_INTEGRATION_TEST" != "" ]]; then
+if [[ "$SKIP_JMETER_INTEGRATION_TEST" != "1" ]]; then
   prepare_jmeter_integration_test
 fi
 
-if [[ "$SKIP_GHZ_INTEGRATION_TEST" != "" ]]; then
+if [[ "$SKIP_GHZ_INTEGRATION_TEST" != "1" ]]; then
   prepare_ghz_integration_test
 fi
 

--- a/pkg/controller/ghz_integration_test.go
+++ b/pkg/controller/ghz_integration_test.go
@@ -26,7 +26,7 @@ func TestIntegrationGhz(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	if os.Getenv("SKIP_GHZ_INTEGRATION_TEST") != "" {
+	if _, ok := os.LookupEnv("SKIP_GHZ_INTEGRATION_TEST"); ok {
 		t.Skip("Skipping ghz integration test!")
 	}
 

--- a/pkg/controller/ghz_integration_test.go
+++ b/pkg/controller/ghz_integration_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -24,6 +25,11 @@ func TestIntegrationGhz(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
+
+	if os.Getenv("SKIP_GHZ_INTEGRATION_TEST") != "" {
+		t.Skip("Skipping ghz integration test!")
+	}
+
 	t.Log()
 
 	t.Cleanup(func() {

--- a/pkg/controller/jmeter_integration_test.go
+++ b/pkg/controller/jmeter_integration_test.go
@@ -37,7 +37,7 @@ func TestIntegrationJMeter(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	if os.Getenv("SKIP_JMETER_INTEGRATION_TEST") != "" {
+	if _, ok := os.LookupEnv("SKIP_JMETER_INTEGRATION_TEST"); ok {
 		t.Skip("Skipping jmeter integration test!")
 	}
 

--- a/pkg/controller/jmeter_integration_test.go
+++ b/pkg/controller/jmeter_integration_test.go
@@ -36,6 +36,11 @@ func TestIntegrationJMeter(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
+
+	if os.Getenv("SKIP_JMETER_INTEGRATION_TEST") != "" {
+		t.Skip("Skipping jmeter integration test!")
+	}
+
 	t.Log()
 
 	distributedPods := int32(2)


### PR DESCRIPTION
This PR adds `SKIP_GHZ_INTEGRATION_TEST` and `SKIP_JMETER_INTEGRATION_TEST` environment variable flag, that skips the respective test when set to any non-empty value.