### PR TITLE
Add customdata to Jmeter tests (#179)

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -40,6 +40,14 @@
 | `JMETER_WORKER_CPU_REQUESTS`    | Worker CPU requests                  |                                   |
 | `JMETER_WORKER_MEMORY_LIMITS`   | Worker memory limits                 |                                   |
 | `JMETER_WORKER_MEMORY_REQUESTS` | Worker memory requests               |                                   |
+| `JMETER_WORKER_REMOTE_CUSTOM_DATA_ENABLED` | Enable remote custom data | `false`                           |
+| `JMETER_WORKER_REMOTE_CUSTOM_DATA_BUCKET` | The name of the bucket where remote data is |                                   |
+| `JMETER_WORKER_REMOTE_CUSTOM_DATA_VOLUME_SIZE` | Volume size used by download remote data | `1Gi`                          |
+| `RCLONE_CONFIG_REMOTECUSTOMDATA_TYPE` | [Rclone](https://rclone.org/) environment variable for type |                           |
+| `RCLONE_CONFIG_REMOTECUSTOMDATA_ACCESS_KEY_ID` | [Rclone](https://rclone.org/) environment variable for access key ID |                          |
+| `RCLONE_CONFIG_REMOTECUSTOMDATA_SECRET_ACCESS_KEY` | [Rclone](https://rclone.org/) environment variable for secret access key |                          |
+| `RCLONE_CONFIG_REMOTECUSTOMDATA_REGION` | [Rclone](https://rclone.org/) environment variable for region |                          |
+| `RCLONE_CONFIG_REMOTECUSTOMDATA_ENDPOINT` | [Rclone](https://rclone.org/) environment variable for endpoint |                           |
 
 ### Locust
 | Parameter                       | Description                 | Default           |

--- a/docs/jmeter/writing-tests.md
+++ b/docs/jmeter/writing-tests.md
@@ -15,6 +15,7 @@
   - [Thread group](#thread-group)
 - [Test with CSV data](#test-with-csv-data)
 - [Test with environment variables](#test-with-environment-variables)
+- [Test with custom data](#test-with-custom-data)
 
 ## Introduction
 
@@ -389,3 +390,12 @@ You don't need any special configuration elements to use environment variables i
 ![http_auth_manager dmg](images/http_auth_manager.png){ height=500 }
 
 In the example above the environment variable AUTH_CLIENT_ID used in HTTP Authorization Manager.
+
+## Test with custom data
+Some tests require files as images, JAR files, etc. You can provide this from a S3 Bucket. If the environment variable JMETER_WORKER_REMOTE_CUSTOM_DATA_ENABLED is set to true, before pod creation, a PVC will be created asking the cluster for a volume of size defined in the environment variable JMETER_WORKER_REMOTE_CUSTOM_DATA_VOLUME_SIZE and access mode ReadWriteMany.
+
+The data will be cloned from the bucket to the volume using [Rclone](https://rclone.org/) and will be available to all the pods.
+
+For the full list of possible environment variables check [Kangal environment variables](env-vars.md)
+
+**Attention** The [Dynamic volume provisioning](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/) must be set on the cluster

--- a/pkg/core/waitfor/waitfor.go
+++ b/pkg/core/waitfor/waitfor.go
@@ -33,6 +33,11 @@ func (Condition) PodRunning(event watch.Event) (bool, error) {
 	return false, nil
 }
 
+// PvcReady waits until is bound
+func (Condition) PvcReady(event watch.Event) (bool, error) {
+	return coreV1.ClaimBound == event.Object.(*coreV1.PersistentVolumeClaim).Status.Phase, nil
+}
+
 // LoadTestRunning waits until Loadtest are with status phase running
 func (Condition) LoadTestRunning(event watch.Event) (bool, error) {
 	if apisLoadTestV1.LoadTestRunning == event.Object.(*apisLoadTestV1.LoadTest).Status.Phase {


### PR DESCRIPTION
Implementation of #179 
- Requirement: The [Dynamic volume provisioning](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/) must be set on the cluster

- If JMETER_WORKER_REMOTE_CUSTOM_DATA_ENABLED is set, before pod creation, a PVC will be created asking the cluster for a volume of size defined in the environment variable JMETER_WORKER_REMOTE_CUSTOM_DATA_VOLUME_SIZE and access mode ReadWriteMany.
- The volume will be the same for all pods and data from S3 bucket will be cloned using [Rclone](https://rclone.org/) 

Get variables from envvar file:
```
JMETER_WORKER_REMOTE_CUSTOM_DATA_ENABLED,true
JMETER_WORKER_REMOTE_CUSTOM_DATA_BUCKET,mybucket
JMETER_WORKER_REMOTE_CUSTOM_DATA_VOLUME_SIZE,1Gi
RCLONE_CONFIG_REMOTECUSTOMDATA_TYPE,s3
RCLONE_CONFIG_REMOTECUSTOMDATA_ACCESS_KEY_ID,value1
RCLONE_CONFIG_REMOTECUSTOMDATA_SECRET_ACCESS_KEY,value2
RCLONE_CONFIG_REMOTECUSTOMDATA_REGION,undefined
RCLONE_CONFIG_REMOTECUSTOMDATA_ENDPOINT,endpoint.com
```