### PR TITLE
Ensure Go version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Setup Golang
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.17'
+
       - name: Docker Login
         if: success() && startsWith(github.ref, 'refs/tags/')
         env:


### PR DESCRIPTION
This PR ensure Go version is matching the module in the Release workflow

```
package io/fs is not in GOROOT (/opt/hostedtoolcache/go/1.15.15/x64/src/io/fs)
```