### PR TITLE
CRS-2490 Allow ClusterRoleBinding to Bind to Non Default Service Account

### DIFF
--- a/charts/kangal/Chart.yaml
+++ b/charts/kangal/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - performance tests
   - tests runner
 name: kangal
-version: 2.1.0
+version: 2.2.0
 home: https://github.com/hellofresh/kangal
 icon: https://raw.githubusercontent.com/hellofresh/kangal/master/logo.svg
 maintainers:

--- a/charts/kangal/templates/clusterrolebinding.yaml
+++ b/charts/kangal/templates/clusterrolebinding.yaml
@@ -1,3 +1,5 @@
+{{- range $key, $value := .Values }}
+{{- if or (eq $key "proxy") (eq $key "openapi-ui") (eq $key "controller")}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -10,4 +12,14 @@ roleRef:
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
+  {{- if $value.serviceAccount }}
+  {{- if $value.serviceAccount.create }}
+  name: system:serviceaccount:{{ $.Release.Namespace }}:{{ template "<CHARTNAME>.fullname" $ }}-{{ $key }}
+  {{- else }}
   name: system:serviceaccount:{{ $.Release.Namespace }}:default
+  {{- end }}
+  {{- else }}
+  name: system:serviceaccount:{{ $.Release.Namespace }}:default
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/kangal/templates/deployment.yaml
+++ b/charts/kangal/templates/deployment.yaml
@@ -48,7 +48,11 @@ spec:
 {{- end }}
 {{- end }}
     spec:
-      serviceAccountName: {{ if $value.serviceAccountName }}{{ $value.serviceAccountName }}{{ else }}{{ template "<CHARTNAME>.fullname" $ }}-{{ $key }}{{ end }}
+      {{- if $value.serviceAccount }}
+      {{- if $value.serviceAccount.create }}
+      serviceAccountName: {{ template "<CHARTNAME>.fullname" $ }}-{{ $key }}
+      {{- end }}
+      {{- end }}
       dnsConfig:
         options:
           - name: ndots

--- a/charts/kangal/templates/serviceaccount.yaml
+++ b/charts/kangal/templates/serviceaccount.yaml
@@ -1,5 +1,7 @@
 {{- range $key, $value := .Values }}
 {{- if or (eq $key "proxy") (eq $key "openapi-ui") (eq $key "controller")}}
+{{- if $value.serviceAccount }}
+{{- if $value.serviceAccount.create }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -10,11 +12,13 @@ metadata:
     chart: {{ template "<CHARTNAME>.chart" $ }}
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
-  {{- if ($value.serviceAccountAnnotations) }}
+  {{- if ($value.serviceAccount.annotations) }}
   annotations:
-    {{- with $value.serviceAccountAnnotations }}
+    {{- with $value.serviceAccount.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- end }}
+{{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kangal/values.yaml
+++ b/charts/kangal/values.yaml
@@ -57,8 +57,10 @@ proxy:
   # Annotations to be added to pod
   podAnnotations: {}
 
-  # Annotations to be added to service account
-  serviceAccountAnnotations: {}
+  # Create a new service account
+  serviceAccount:
+    create: false
+    annotations: {}
 
   # The ports that the container listens to
   containerPorts:
@@ -130,8 +132,10 @@ controller:
   env:
     KANGAL_PROXY_URL: https://kangal-proxy.example.com
 
-  # Annotations to be added to service account
-  serviceAccountAnnotations: {}
+  # Create a new service account
+  serviceAccount:
+    create: false
+    annotations: {}
 
 openapi-ui:
   enabled: true
@@ -160,8 +164,10 @@ openapi-ui:
   # Annotations to be added to pod
   podAnnotations: {}
 
-  # Annotations to be added to service account
-  serviceAccountAnnotations: {}
+  # Create a new service account
+  serviceAccount:
+    create: false
+    annotations: {}
 
   # The ports that the container listens to
   containerPorts:


### PR DESCRIPTION
Previously the `ClusterRoleBinding` was bound to the default service account ie:
`name: system:serviceaccount:{{ $.Release.Namespace }}:default`

In this PR, if `serviceAccount.create`  is defined then a new service account will be created for that deployment and a associated  `ClusterRoleBinding` will bind to that service account. 

Otherwise, without this PR when a service account was defined, the deployment could not access the kube cluster since the service account had no role binding
