### PR TITLE
CRS-2490 Limit ClusterRoleBinding to Controller Only

### DIFF
--- a/charts/kangal/Chart.yaml
+++ b/charts/kangal/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - performance tests
   - tests runner
 name: kangal
-version: 2.2.0
+version: 2.2.1
 home: https://github.com/hellofresh/kangal
 icon: https://raw.githubusercontent.com/hellofresh/kangal/master/logo.svg
 maintainers:

--- a/charts/kangal/templates/clusterrolebinding.yaml
+++ b/charts/kangal/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- range $key, $value := .Values }}
-{{- if or (eq $key "proxy") (eq $key "openapi-ui") (eq $key "controller")}}
+{{- if (eq $key "controller")}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Previously ClusterRoleBinding was created for each deployment which is unncessary. Only the controller needs the binding so here we are limiting it to the controller.