### PR TITLE
CRS-2490 Add ClusterRole Binding For Proxy

### DIFF
--- a/charts/kangal/Chart.yaml
+++ b/charts/kangal/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - performance tests
   - tests runner
 name: kangal
-version: 2.2.1
+version: 2.2.2
 home: https://github.com/hellofresh/kangal
 icon: https://raw.githubusercontent.com/hellofresh/kangal/master/logo.svg
 maintainers:

--- a/charts/kangal/templates/clusterrolebinding.yaml
+++ b/charts/kangal/templates/clusterrolebinding.yaml
@@ -1,10 +1,10 @@
 {{- range $key, $value := .Values }}
-{{- if (eq $key "controller")}}
+{{- if or (eq $key "proxy") (eq $key "controller")}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system-controller-kangal-controller-{{ $.Release.Namespace }}
+  name: system-controller-kangal-{{ $key }}-{{ $.Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
It turns out that the proxy also needs to talk to kubernetes and requires a cluster role binding which I was not aware of. Adding a binding for proxy as well. Otherise the error is:

>{"level":"error","ts":"2022-02-24T10:30:24.851Z","caller":"kubernetes/client.go:134","msg":"failed to list load tests","type":"kangal","error":"loadtests.kangal.hellofresh.com is forbidden: User \"system:serviceaccount:default:kangal-proxy\" cannot list resource \"loadtests\" in API group \"kangal.hellofresh.com\


if service accounts not enabled, its creates 2 cluster role bindings one for the controller and one for the proxy each bound to the default service account. 

```
kind: ClusterRoleBinding
metadata:
  name: system-controller-kangal-controller-ns
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: system-controller-kangal-controller-ns
subjects:
- apiGroup: rbac.authorization.k8s.io
  kind: User
  name: system:serviceaccount:ns:default
---
# Source: kangal/templates/clusterrolebinding.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: system-controller-kangal-proxy-ns
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: system-controller-kangal-controller-ns
subjects:
- apiGroup: rbac.authorization.k8s.io
  kind: User
  name: system:serviceaccount:ns:default
```


if service accounts is enabled, its creates 2 cluster role bindings one for the controller and one for the proxy each bound with different service account. 


```
kind: ClusterRoleBinding
metadata:
  name: system-controller-kangal-controller-ns
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: system-controller-kangal-controller-ns
subjects:
- apiGroup: rbac.authorization.k8s.io
  kind: User
  name: system:serviceaccount:ns:kangal-controller
---
# Source: kangal/templates/clusterrolebinding.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: system-controller-kangal-proxy-ns
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: system-controller-kangal-controller-ns
subjects:
- apiGroup: rbac.authorization.k8s.io
  kind: User
  name: system:serviceaccount:ns:kangal-proxy
```

Service Accounts

```
kind: ServiceAccount
metadata:
  name: kangal-controller
  labels:
    app: kangal-controller
    chart: kangal-2.2.1
    release: kangal
    heritage: Helm
---
# Source: kangal/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: kangal-proxy
  labels:
    app: kangal-proxy
    chart: kangal-2.2.1
    release: kangal
    heritage: Helm
```