### PR TITLE
Update docs warning about csv data split between distributed pods

### DIFF
--- a/docs/jmeter/writing-tests.md
+++ b/docs/jmeter/writing-tests.md
@@ -379,6 +379,8 @@ This config element should be nested under HTTP request sampler. Read more about
 
 > **Important note!** In Kangal the path to the test data file is always the same **/testdata/testdata.csv**. Please specify this path in Filename field of your CSV Data Set Config. Otherwise the test run by Kangal will not see the the provided data.
 
+**The test data will be equally divided between the number of pods set on distributedPods parameter**
+
 ## Test with environment variables
 Some tests may contain sensitive information like DB connection parameters, authorization tokens, etc. You can provide this information as environment variables which will be applied in load test environment before running test.
 

--- a/docs/user-flow.md
+++ b/docs/user-flow.md
@@ -10,6 +10,8 @@ Create a new load test by making a POST request to Kangal Proxy.
 
 > **Note**: The sample CURL commands below use example test files, those files can be found in [Kangal repository](https://github.com/hellofresh/kangal/).
 
+**The test data will be equally divided between the number of pods set on distributedPods parameter**
+
 ### Using JMeter
 ```shell
 curl -X POST http://${KANGAL_PROXY_ADDRESS}/load-test \


### PR DESCRIPTION
Avoid confusion about test data usage and clarify that won't be duplicated data.