### PR TITLE
Add Affinity Spec for K6 and JMeter #210

### DIFF
--- a/pkg/backends/jmeter/backend.go
+++ b/pkg/backends/jmeter/backend.go
@@ -310,6 +310,10 @@ func generateBase64(testData string) (string, error) {
 		return result, err
 	}
 
+	if err := gz.Flush(); err != nil {
+		return result, err
+	}
+
 	if err := gz.Close(); err != nil {
 		return result, err
 	}

--- a/pkg/backends/jmeter/resources.go
+++ b/pkg/backends/jmeter/resources.go
@@ -106,11 +106,15 @@ func (b *Backend) NewTestdataConfigMap(loadTest loadTestV1.LoadTest) ([]*coreV1.
 	if len(testdata) > 0 {
 		testdataDecoded, _ := base64.RawStdEncoding.DecodeString(loadTest.Spec.TestData)
 		gz, err := gzip.NewReader(bytes.NewReader(testdataDecoded))
-		if err != nil {
+		if err != nil && err != io.EOF {
+			logger.Error("Error on gzip reader", zap.Error(err))
 			return nil, err
 		}
+		defer gz.Close()
+
 		result, err := ioutil.ReadAll(gz)
-		if err != nil {
+		if err != nil && err != io.EOF {
+			logger.Error("Error on ioutil reader", zap.Error(err))
 			return nil, err
 		}
 		testdata = string(result)

--- a/pkg/backends/jmeter/resources.go
+++ b/pkg/backends/jmeter/resources.go
@@ -208,6 +208,21 @@ func (b *Backend) NewPod(loadTest loadTestV1.LoadTest, i int, configMap *coreV1.
 			},
 		},
 		Spec: coreV1.PodSpec{
+			Affinity: &coreV1.Affinity{
+				PodAntiAffinity: &coreV1.PodAntiAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []coreV1.WeightedPodAffinityTerm{
+						{
+							Weight: 1,
+							PodAffinityTerm: coreV1.PodAffinityTerm{
+								LabelSelector: &metaV1.LabelSelector{
+									MatchLabels: loadTestWorkerPodLabels,
+								},
+								TopologyKey: "kubernetes.io/hostname",
+							},
+						},
+					},
+				},
+			},
 			InitContainers: []coreV1.Container{
 				{
 					Name:    "convert-data-back-to-csv",

--- a/pkg/backends/k6/resources.go
+++ b/pkg/backends/k6/resources.go
@@ -108,6 +108,23 @@ func (b *Backend) NewJob(
 					Annotations: b.podAnnotations,
 				},
 				Spec: coreV1.PodSpec{
+					Affinity: &coreV1.Affinity{
+						PodAntiAffinity: &coreV1.PodAntiAffinity{
+							PreferredDuringSchedulingIgnoredDuringExecution: []coreV1.WeightedPodAffinityTerm{
+								{
+									Weight: 1,
+									PodAffinityTerm: coreV1.PodAffinityTerm{
+										LabelSelector: &metaV1.LabelSelector{
+											MatchLabels: map[string]string{
+												loadTestLabelKey: loadTestWorkerLabelValue,
+											},
+										},
+										TopologyKey: "kubernetes.io/hostname",
+									},
+								},
+							},
+						},
+					},
 					RestartPolicy: "Never",
 					Volumes:       volumes,
 					Containers: []coreV1.Container{


### PR DESCRIPTION
Problem:
Pods are being created at the same node, overloading it

Proposal:
Define Affinity Spec at Pod

- Where would be better to define that? Like proxy and openapi affinity configuration
- We have found that all pods are created with same label "app=loadtest-worker-pod". It's not possible to use label-selector to create a pod in a node with no pods from the same test.