### PR TITLE
Take into account worker and master images for Locust

### DIFF
--- a/docs/user-flow.md
+++ b/docs/user-flow.md
@@ -66,7 +66,6 @@ curl -X POST http://${KANGAL_PROXY_ADDRESS}/load-test \
   -F masterImage=hellofresh/kangal-jmeter-master:5.4.1 \
   -F workerImage=hellofresh/kangal-jmeter-worker:5.4.1
 ```
-**Note:** For locust only master image will be taken into account!!
 
 ## Check
 Check the status of the load test.

--- a/pkg/backends/locust/backend.go
+++ b/pkg/backends/locust/backend.go
@@ -182,7 +182,7 @@ func (b *Backend) Sync(ctx context.Context, loadTest loadTestV1.LoadTest, report
 		}
 	}
 
-	masterJob := newMasterJob(loadTest, configMap, secret, reportURL, b.masterResources, b.podAnnotations, b.nodeSelector, b.podTolerations, b.image, b.logger)
+	masterJob := newMasterJob(loadTest, configMap, secret, reportURL, b.masterResources, b.podAnnotations, b.nodeSelector, b.podTolerations, loadTest.Spec.MasterConfig, b.logger)
 	_, err = b.kubeClientSet.
 		BatchV1().
 		Jobs(loadTest.Status.Namespace).
@@ -199,7 +199,7 @@ func (b *Backend) Sync(ctx context.Context, loadTest loadTestV1.LoadTest, report
 		return err
 	}
 
-	workerJob := newWorkerJob(loadTest, configMap, secret, masterService, b.workerResources, b.podAnnotations, b.nodeSelector, b.podTolerations, b.image, b.logger)
+	workerJob := newWorkerJob(loadTest, configMap, secret, masterService, b.workerResources, b.podAnnotations, b.nodeSelector, b.podTolerations, loadTest.Spec.WorkerConfig, b.logger)
 	_, err = b.kubeClientSet.
 		BatchV1().
 		Jobs(loadTest.Status.Namespace).

--- a/pkg/backends/locust/resources.go
+++ b/pkg/backends/locust/resources.go
@@ -81,9 +81,9 @@ func newMasterJob(
 
 	ownerRef := metaV1.NewControllerRef(&loadTest, loadTestV1.SchemeGroupVersion.WithKind("LoadTest"))
 
-	imageRef := fmt.Sprintf("%s:%s", loadTest.Spec.MasterConfig.Image, loadTest.Spec.MasterConfig.Tag)
+	imageRef := fmt.Sprintf("%s:%s", image.Image, image.Tag)
 	if imageRef == ":" {
-		imageRef = fmt.Sprintf("%s:%s", image.Image, image.Tag)
+		imageRef = fmt.Sprintf("%s:%s", loadTest.Spec.MasterConfig.Image, loadTest.Spec.MasterConfig.Tag)
 		logger.Warn("Loadtest.Spec.MasterConfig is empty; using default image", zap.String("imageRef", imageRef))
 	}
 
@@ -227,9 +227,9 @@ func newWorkerJob(
 
 	ownerRef := metaV1.NewControllerRef(&loadTest, loadTestV1.SchemeGroupVersion.WithKind("LoadTest"))
 
-	imageRef := fmt.Sprintf("%s:%s", loadTest.Spec.MasterConfig.Image, loadTest.Spec.MasterConfig.Tag)
+	imageRef := fmt.Sprintf("%s:%s", image.Image, image.Tag)
 	if imageRef == ":" {
-		imageRef = fmt.Sprintf("%s:%s", image.Image, image.Tag)
+		imageRef = fmt.Sprintf("%s:%s", loadTest.Spec.MasterConfig.Image, loadTest.Spec.MasterConfig.Tag)
 		logger.Warn("Loadtest.Spec.MasterConfig is empty; using default image", zap.String("imageRef", imageRef))
 	}
 


### PR DESCRIPTION
Use master and worker images for Locust runner if specified.

This is very useful if using Locust Master and Locust Boomer workers.
