### PR TITLE
adding metric to count running loadtests

### DIFF
--- a/pkg/controller/loadtest.go
+++ b/pkg/controller/loadtest.go
@@ -524,7 +524,7 @@ func (c *Controller) countRunningLoadtests() int64 {
 	var rt = 0
 	for _, loadTest := range tt.Items {
 		if loadTest.Status.Phase == loadTestV1.LoadTestRunning {
-			rt += 1
+			rt++
 		}
 	}
 

--- a/pkg/controller/loadtest.go
+++ b/pkg/controller/loadtest.go
@@ -277,6 +277,7 @@ func (c *Controller) syncHandler(key string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), c.cfg.SyncHandlerTimeout)
 	defer cancel()
 
+	stats.Record(ctx, observability.MRunningLoadtestCountStat.M(c.countRunningLoadtests()))
 	logger := c.logger.With(
 		zap.String("loadtest", key),
 	)
@@ -383,6 +384,8 @@ func (c *Controller) handleObject(obj interface{}) {
 		}
 
 		c.logger.Debug("Processing object", zap.String("object-name", object.GetName()))
+		stats.Record(context.Background(), observability.MRunningLoadtestCountStat.M(c.countRunningLoadtests()))
+
 		foo, err := c.loadtestsLister.Get(ownerRef.Name)
 		if err != nil {
 			c.logger.Debug("ignoring orphaned object", zap.String("loadtest", object.GetSelfLink()),
@@ -509,6 +512,24 @@ func checkLoadTestLifeTimeExceeded(loadTest *loadTestV1.LoadTest, deleteThreshol
 	}
 
 	return false
+}
+
+func (c *Controller) countRunningLoadtests() int64 {
+	tt, err := c.kangalClientSet.KangalV1().LoadTests().List(context.Background(), metaV1.ListOptions{})
+	if err != nil {
+		c.logger.Error("Couldn't list existing loadtests", zap.Error(err))
+		return 0
+	}
+
+	var rt = 0
+	for _, loadTest := range tt.Items {
+		if loadTest.Status.Phase == loadTestV1.LoadTestRunning {
+			rt += 1
+		}
+	}
+
+	return int64(rt)
+
 }
 
 func (c *Controller) deleteLoadTest(ctx context.Context, key string, loadTest *loadTestV1.LoadTest) {

--- a/pkg/core/observability/controller.go
+++ b/pkg/core/observability/controller.go
@@ -21,6 +21,9 @@ var (
 	// MFinishedLoadtestCountStat counts the number of finished loadtests
 	MFinishedLoadtestCountStat = stats.Int64("finished_loadtests_count", "Number of finished loadtests", stats.UnitDimensionless)
 
+	// MRunningLoadtestCountStat counts the number of running loadtests
+	MRunningLoadtestCountStat = stats.Int64("running_loadtests_count", "Number of running loadtests", stats.UnitDimensionless)
+
 	// reconcileDistribution defines the bucket boundaries for the histogram of reconcile latency metric.
 	// Bucket boundaries are 10ms, 100ms, 1s, 10s, 30s and 60s.
 	reconcileDistribution = view.Distribution(10, 100, 1000, 10000, 30000, 60000)
@@ -61,6 +64,11 @@ var ControllerViews = []*view.View{
 		Description: MFinishedLoadtestCountStat.Description(),
 		Measure:     MFinishedLoadtestCountStat,
 		Aggregation: view.Count(),
+	},
+	{
+		Description: MRunningLoadtestCountStat.Description(),
+		Measure:     MRunningLoadtestCountStat,
+		Aggregation: view.LastValue(),
 	},
 }
 


### PR DESCRIPTION
**Current problem:** 
existing metrics used to calculate the number of running loadtests don't give a reliable picture, when objects got deleted, when controller restarts or when there is a conflict in object state. 

**Solution:**
This PR adds a new metric `MRunningLoadtestCountStat` to count the number of loadtests currently in `running` phase by direct request to k8s API. This metric is sent from `SyncHandler` on every sync and from `handleObject` to catch the change when loadtest was deleted and only orphaned objects stayed.