### PR TITLE
update kangal clusterrole to work with pvc

### DIFF
--- a/charts/kangal/Chart.yaml
+++ b/charts/kangal/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - performance tests
   - tests runner
 name: kangal
-version: 2.2.2
+version: 2.2.3
 home: https://github.com/hellofresh/kangal
 icon: https://raw.githubusercontent.com/hellofresh/kangal/master/logo.svg
 maintainers:

--- a/charts/kangal/templates/clusterrole.yaml
+++ b/charts/kangal/templates/clusterrole.yaml
@@ -99,3 +99,13 @@ rules:
       - list
       - create
       - delete
+
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - create
+      - list
+      - watch


### PR DESCRIPTION
To enable the feature implemented in #177 we need to allow Kangal to create PersistentVolumeClaims.
This PR updates helm template for clusterrole adding a new resource.