### PR TITLE
Remove usage of the deprecated GitHub Actions commands

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -97,7 +97,7 @@ jobs:
           make build
 
       - name: Build dummy gRPC server Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           tags: greeter_server:local
           context: pkg/controller/testdata/ghz

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -39,7 +39,7 @@ jobs:
         id: get_tag
         run: |
           VERSION="$(git tag | grep -v kangal | sort -rV | head -n 1)"
-          echo "::set-output name=tag::$VERSION"
+          echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Lint GoReleaser
         uses: goreleaser/goreleaser-action@v3


### PR DESCRIPTION
And write to the `GITHUB_OUTPUT` environment file instead.