### PR TITLE
add a note to JMeter docs regarding PVC creation

### DIFF
--- a/docs/jmeter/writing-tests.md
+++ b/docs/jmeter/writing-tests.md
@@ -393,7 +393,14 @@ You don't need any special configuration elements to use environment variables i
 In the example above the environment variable AUTH_CLIENT_ID used in HTTP Authorization Manager.
 
 ## Test with custom data
-Some tests require files as images, JAR files, etc. You can provide this from a S3 Bucket. If the environment variable JMETER_WORKER_REMOTE_CUSTOM_DATA_ENABLED is set to true, before pod creation, a PVC will be created asking the cluster for a volume of size defined in the environment variable JMETER_WORKER_REMOTE_CUSTOM_DATA_VOLUME_SIZE and access mode ReadWriteMany.
+Some tests require files as images, JAR files, etc. You can provide this from a S3 Bucket. 
+If the environment variable JMETER_WORKER_REMOTE_CUSTOM_DATA_ENABLED is set to true, before pod creation, 
+a PVC will be created asking the cluster for a volume of size defined in the environment variable 
+JMETER_WORKER_REMOTE_CUSTOM_DATA_VOLUME_SIZE and access mode ReadWriteMany.
+
+!!! Warning
+    This feature won't be available if your cluster does not support ReadWriteMany access mode.
+    Please check with your local admins.
 
 The data will be cloned from the bucket to the volume using [Rclone](https://rclone.org/) and will be available to all the pods.
 

--- a/docs/jmeter/writing-tests.md
+++ b/docs/jmeter/writing-tests.md
@@ -393,9 +393,9 @@ You don't need any special configuration elements to use environment variables i
 In the example above the environment variable AUTH_CLIENT_ID used in HTTP Authorization Manager.
 
 ## Test with custom data
-Some tests require files as images, JAR files, etc. You can provide this from a S3 Bucket. 
-If the environment variable JMETER_WORKER_REMOTE_CUSTOM_DATA_ENABLED is set to true, before pod creation, 
-a PVC will be created asking the cluster for a volume of size defined in the environment variable 
+Some tests require files as images, JAR files, etc. You can provide this from a S3 Bucket.
+If the environment variable JMETER_WORKER_REMOTE_CUSTOM_DATA_ENABLED is set to true, before pod creation,
+a PVC will be created asking the cluster for a volume of size defined in the environment variable
 JMETER_WORKER_REMOTE_CUSTOM_DATA_VOLUME_SIZE and access mode ReadWriteMany.
 
 !!! Warning


### PR DESCRIPTION
This PR adds a warning to documentation, that PVC creating for JMeter backend is limited by cluster settings.