### PR TITLE
save ghz test results as html

### DIFF
--- a/pkg/backends/ghz/resources.go
+++ b/pkg/backends/ghz/resources.go
@@ -27,7 +27,7 @@ const (
 
 var defaultArgs = []string{
 	"--config=/data/config",
-	"--output=/results",
+	"--output=/results.html",
 	"--format=html",
 }
 


### PR DESCRIPTION
Currently Ghz backend saves results to `/results`. This PR chanes it it `/results.html` which will help serving a report in a better way.