### PR TITLE
Removing unused metrics for loadtests counting

### DIFF
--- a/pkg/controller/loadtest.go
+++ b/pkg/controller/loadtest.go
@@ -437,12 +437,6 @@ func (c *Controller) updateLoadTestStatus(ctx context.Context, key string, loadT
 
 		logger.Debug("Status updated", zap.Any("status", loadTest.Status))
 	}
-
-	// Compare phase change and update metrics
-	if loadTestFromCache.Status.Phase != loadTestV1.LoadTestFinished &&
-		loadTest.Status.Phase == loadTestV1.LoadTestFinished {
-		stats.Record(ctx, observability.MFinishedLoadtestCountStat.M(1))
-	}
 }
 
 // checkOrCreateNamespace checks if a namespace has been created and if not deletes it
@@ -468,7 +462,6 @@ func (c *Controller) checkOrCreateNamespace(ctx context.Context, loadtest *loadT
 		}
 		namespaceName = namespaceObj.GetName()
 		c.logger.Info("Created new namespace", zap.String("namespace", namespaceName), zap.String("loadtest", loadtest.GetName()))
-		stats.Record(ctx, observability.MCreatedLoadtestCountStat.M(1))
 	} else {
 		namespaceName = namespaces.Items[0].Name
 	}

--- a/pkg/core/observability/controller.go
+++ b/pkg/core/observability/controller.go
@@ -15,12 +15,6 @@ var (
 	reconcileCountStat   = stats.Int64("reconcile_count", "Number of reconcile operations", stats.UnitDimensionless)
 	reconcileLatencyStat = stats.Int64("reconcile_latency", "Latency of reconcile operations", stats.UnitMilliseconds)
 
-	// MCreatedLoadtestCountStat counts the number of loadtests created
-	MCreatedLoadtestCountStat = stats.Int64("created_loadtests_count", "Number of loadtests created", stats.UnitDimensionless)
-
-	// MFinishedLoadtestCountStat counts the number of finished loadtests
-	MFinishedLoadtestCountStat = stats.Int64("finished_loadtests_count", "Number of finished loadtests", stats.UnitDimensionless)
-
 	// MRunningLoadtestCountStat counts the number of running loadtests
 	MRunningLoadtestCountStat = stats.Int64("running_loadtests_count", "Number of running loadtests", stats.UnitDimensionless)
 
@@ -54,16 +48,6 @@ var ControllerViews = []*view.View{
 		Measure:     reconcileLatencyStat,
 		Aggregation: reconcileDistribution,
 		TagKeys:     []tag.Key{reconcilerTagKey, keyTagKey, successTagKey},
-	},
-	{
-		Description: MCreatedLoadtestCountStat.Description(),
-		Measure:     MCreatedLoadtestCountStat,
-		Aggregation: view.Count(),
-	},
-	{
-		Description: MFinishedLoadtestCountStat.Description(),
-		Measure:     MFinishedLoadtestCountStat,
-		Aggregation: view.Count(),
 	},
 	{
 		Description: MRunningLoadtestCountStat.Description(),


### PR DESCRIPTION
This PR removes unused metric to count started and finished load tests. These metrics were replaced in #233 by MRunningLoadtestCountStat used to count currently running load tests.