### PR TITLE
Disable cleanup of completed and error-ed  tests

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -16,13 +16,13 @@
 | `WEB_HTTP_PORT`               |                                                                                | `8080`                                     |
 
 ## Controller
-| Parameter                       | Description                                       | Default             |
-|---------------------------------|---------------------------------------------------|---------------------|
-| `CLEANUP_THRESHOLD`             | Life time of a load test                          | `1h`                |
-| `KANGAL_PROXY_URL`              | Endpoints used to store load test reports         | `""`                |
-| `KUBE_CLIENT_TIMEOUT`           | Timeout for each operation done by kube client    | `5s`                |
-| `SYNC_HANDLER_TIMEOUT`          | Time limit for each sync operation                | `60s`               |
-| `WEB_HTTP_PORT`                 |                                                   | `8080`              |
+| Parameter                       | Description                                             | Default             |
+|---------------------------------|---------------------------------------------------------|---------------------|
+| `CLEANUP_THRESHOLD`             | Life time of a load test (disable by setting value to 0)| `1h`                |
+| `KANGAL_PROXY_URL`              | Endpoints used to store load test reports               | `""`                |
+| `KUBE_CLIENT_TIMEOUT`           | Timeout for each operation done by kube client          | `5s`                |
+| `SYNC_HANDLER_TIMEOUT`          | Time limit for each sync operation                      | `60s`               |
+| `WEB_HTTP_PORT`                 |                                                         | `8080`              |
 
 ## Backend specific configuration
 ### JMeter

--- a/pkg/controller/loadtest.go
+++ b/pkg/controller/loadtest.go
@@ -342,7 +342,7 @@ func (c *Controller) syncHandler(key string) error {
 	}
 
 	// check and delete stale finished/errored loadtests
-	if checkLoadTestLifeTimeExceeded(loadTest, c.cfg.CleanUpThreshold) {
+	if c.cfg.CleanUpThreshold != 0 && checkLoadTestLifeTimeExceeded(loadTest, c.cfg.CleanUpThreshold) {
 		logger.Info("Deleting loadtest due to exceeded lifetime",
 			zap.String("phase", loadTest.Status.Phase.String()),
 		)


### PR DESCRIPTION
This PR allows the cleanup behavior to be skipped when the `CLEANUP_THRESHOLD` is set to 0.

related to #227 