### PR TITLE
update ca-certificates version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y ca-certificates=20211016~20.04.1 && \
+    apt-get install --no-install-recommends -y ca-certificates=20211016ubuntu0.20.04.1 && \
     mkdir -p /etc/kangal && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Update ca-certificates to [new patched version](https://launchpad.net/ubuntu/+source/ca-certificates/20211016~20.04.1) fixing the [issue in build the Dockerfile](https://github.com/hellofresh/kangal/actions/runs/3656300245/jobs/6178584390#step:7:106)