### PR TITLE
Updating docs to explain the usage of custom docker images

### DIFF
--- a/charts/kangal/Chart.yaml
+++ b/charts/kangal/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - performance tests
   - tests runner
 name: kangal
-version: 2.2.3
+version: 2.2.4
 home: https://github.com/hellofresh/kangal
 icon: https://raw.githubusercontent.com/hellofresh/kangal/master/logo.svg
 maintainers:

--- a/charts/kangal/README.md
+++ b/charts/kangal/README.md
@@ -65,28 +65,28 @@ To install Kangal to your infrastructure you need 3 deployments: Kangal-Proxy, K
 
 The following table lists the common configurable parameters for `Kangal` chart:
 
-| Parameter                            | Description                                                                                         | Default                               |
-|--------------------------------------|-----------------------------------------------------------------------------------------------------|---------------------------------------|
-| `environment`                        | The name that identifies the environment installation                                               | `dev`                                 |
-| `fullnameOverride`                   | String to fully override kangal.fullname template with a string                                     |                                       |
-| `nameOverride`                       | String to partially override kangal.fullname template with a string (will prepend the release name) |                                       |
-| `secrets.AWS_ACCESS_KEY_ID`          | AWS access key ID. If not defined report will not be stored                                         | `my-access-key-id`                    |
-| `secrets.AWS_SECRET_ACCESS_KEY`      | AWS secret access key                                                                               | `my-secret-access-key`                |
-| `configMap.AWS_BUCKET_NAME`          | The name of the bucket for saving reports                                                           | `my-bucket`                           |
-| `configMap.AWS_ENDPOINT_URL`         | Storage connection parameter                                                                        | `s3.us-east-1.amazonaws.com`          |
-| `configMap.AWS_DEFAULT_REGION`       | Storage connection parameter                                                                        | `us-east-1`                           |
-| `configMap.AWS_USE_HTTPS`            | Set to "true" to use HTTPS                                                                          | `false`                               |
-| `configMap.AWS_PRESIGNED_EXPIRES`    | Expiration time for Presigned URLs                                                                  | `30m`                                 |
-| `configMap.GHZ_IMAGE_NAME`           | Default ghz image name/repository if none is provided when creating a new loadtest                  | `hellofresh/kangal-ghz`               |
-| `configMap.GHZ_IMAGE_TAG`            | Tag of the ghz image above                                                                          | `latest`                               |
-| `configMap.JMETER_MASTER_IMAGE_NAME` | Default JMeter master image name/repository if none is provided when creating a new loadtest        | `hellofresh/kangal-jmeter-master`     |
-| `configMap.JMETER_MASTER_IMAGE_TAG`  | Tag of the JMeter master image above                                                                | `latest`                              |
-| `configMap.JMETER_WORKER_IMAGE_NAME` | Default JMeter worker image name/repository if none is provided when creating a new loadtest        | `hellofresh/kangal-jmeter-worker`     |
-| `configMap.JMETER_WORKER_IMAGE_TAG`  | Tag of the JMeter worker image above                                                                | `latest`                              |
-| `configMap.LOCUST_IMAGE_NAME`        | Default Locust image name/repository if none is provided when creating a new loadtest               | `locustio/locust`                     |
-| `configMap.LOCUST_IMAGE_TAG`         | Tag of the Locust image above                                                                       | `1.3.0`                               |
-| `configMap.K6_IMAGE_NAME`        | Default k6 image name/repository if none is provided when creating a new loadtest               | `loadimpact/k6`                     |
-| `configMap.K6_IMAGE_TAG`         | Tag of the k6 image above                                                                       | `latest`                               |
+| Parameter                            | Description                                                                                         | Default                           |
+|--------------------------------------|-----------------------------------------------------------------------------------------------------|-----------------------------------|
+| `environment`                        | The name that identifies the environment installation                                               | `dev`                             |
+| `fullnameOverride`                   | String to fully override kangal.fullname template with a string                                     |                                   |
+| `nameOverride`                       | String to partially override kangal.fullname template with a string (will prepend the release name) |                                   |
+| `secrets.AWS_ACCESS_KEY_ID`          | AWS access key ID. If not defined report will not be stored                                         | `my-access-key-id`                |
+| `secrets.AWS_SECRET_ACCESS_KEY`      | AWS secret access key                                                                               | `my-secret-access-key`            |
+| `configMap.AWS_BUCKET_NAME`          | The name of the bucket for saving reports                                                           | `my-bucket`                       |
+| `configMap.AWS_ENDPOINT_URL`         | Storage connection parameter                                                                        | `s3.us-east-1.amazonaws.com`      |
+| `configMap.AWS_DEFAULT_REGION`       | Storage connection parameter                                                                        | `us-east-1`                       |
+| `configMap.AWS_USE_HTTPS`            | Set to "true" to use HTTPS                                                                          | `false`                           |
+| `configMap.AWS_PRESIGNED_EXPIRES`    | Expiration time for Presigned URLs                                                                  | `30m`                             |
+| `configMap.GHZ_IMAGE_NAME`           | Default ghz docker image name/repository if none is provided when creating a new loadtest           | `hellofresh/kangal-ghz`           |
+| `configMap.GHZ_IMAGE_TAG`            | Tag of the ghz docker image                                                                         | `latest`                          |
+| `configMap.JMETER_MASTER_IMAGE_NAME` | Default JMeter master docker image name/repository if none is provided when creating a new loadtest | `hellofresh/kangal-jmeter-master` |
+| `configMap.JMETER_MASTER_IMAGE_TAG`  | Tag of the JMeter master docker image                                                               | `latest`                          |
+| `configMap.JMETER_WORKER_IMAGE_NAME` | Default JMeter worker docker image name/repository if none is provided when creating a new loadtest | `hellofresh/kangal-jmeter-worker` |
+| `configMap.JMETER_WORKER_IMAGE_TAG`  | Tag of the JMeter worker docker image                                                               | `latest`                          |
+| `configMap.LOCUST_IMAGE_NAME`        | Default Locust docker image name/repository if none is provided when creating a new loadtest        | `locustio/locust`                 |
+| `configMap.LOCUST_IMAGE_TAG`         | Tag of the Locust docker image                                                                      | `1.3.0`                           |
+| `configMap.K6_IMAGE_NAME`            | Default k6 docker image name/repository if none is provided when creating a new loadtest            | `loadimpact/k6`                   |
+| `configMap.K6_IMAGE_TAG`             | Tag of the k6 docker image above                                                                    | `latest`                          |
 
 Deployment specific configurations:
 
@@ -115,7 +115,7 @@ Deployment specific configurations:
 | `proxy.env.OPEN_API_SERVER_DESCRIPTION` | *Required.* A Description to the OpenAPI server URL         | `Kangal proxy default value`               |
 | `proxy.env.OPEN_API_SERVER_URL`         | *Required.* A URL to the OpenAPI specification server       | `https://kangal-proxy.example.com/openapi` |
 | `proxy.env.OPEN_API_UI_URL`             | A URL to the OpenAPI UI                                     | `https://kangal-openapi-ui.example.com`    |
-| `proxy.env.ALLOWED_CUSTOM_IMAGES`       | Allow or not custom Images to be defined in the request     | `false`                                    |
+| `proxy.env.ALLOWED_CUSTOM_IMAGES`       | Allow to use custom backend images specified in the request | `false`                                    |
 
 ### OpenAPI UI
 | Parameter                             | Description                                     | Default                                    |
@@ -190,9 +190,9 @@ Deployment specific configurations:
 | `controller.env.GHZ_MASTER_MEMORY_REQUESTS` | Memory requests |                   |
 
 ### Kangal Controller (`k6` specific)
-| Parameter                                   | Description     | Default           |
-|---------------------------------------------|-----------------|-------------------|
-| `controller.env.K6_CPU_LIMITS`      | CPU limits      |                   |
-| `controller.env.K6_CPU_REQUESTS`    | CPU requests    |                   |
-| `controller.env.K6_MEMORY_LIMITS`   | Memory limits   |                   |
-| `controller.env.K6_MEMORY_REQUESTS` | Memory requests |                   |
+| Parameter                           | Description     | Default |
+|-------------------------------------|-----------------|---------|
+| `controller.env.K6_CPU_LIMITS`      | CPU limits      |         |
+| `controller.env.K6_CPU_REQUESTS`    | CPU requests    |         |
+| `controller.env.K6_MEMORY_LIMITS`   | Memory limits   |         |
+| `controller.env.K6_MEMORY_REQUESTS` | Memory requests |         |

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -3,7 +3,7 @@
 ## Proxy
 | Parameter                     | Description                                                                    | Default                                    |
 |-------------------------------|--------------------------------------------------------------------------------|--------------------------------------------|
-| `ALLOWED_CUSTOM_IMAGES`       | Allow custom Images to be defined in the request                               | `false`                                    |
+| `ALLOWED_CUSTOM_IMAGES`       | Allow to use custom backend images specified in the request                    | `false`                                    |
 | `KUBE_CLIENT_TIMEOUT`         | Timeout for each operation done by kube client                                 | `5s`                                       |
 | `MAX_LIST_LIMIT`              | Output of LIST endpoint                                                        | `50`                                       |
 | `OPEN_API_SERVER_DESCRIPTION` | Description to the OpenAPI server URL                                          | `Kangal proxy default value`               |
@@ -16,13 +16,13 @@
 | `WEB_HTTP_PORT`               |                                                                                | `8080`                                     |
 
 ## Controller
-| Parameter                       | Description                                             | Default             |
-|---------------------------------|---------------------------------------------------------|---------------------|
-| `CLEANUP_THRESHOLD`             | Life time of a load test (disable by setting value to 0)| `1h`                |
-| `KANGAL_PROXY_URL`              | Endpoints used to store load test reports               | `""`                |
-| `KUBE_CLIENT_TIMEOUT`           | Timeout for each operation done by kube client          | `5s`                |
-| `SYNC_HANDLER_TIMEOUT`          | Time limit for each sync operation                      | `60s`               |
-| `WEB_HTTP_PORT`                 |                                                         | `8080`              |
+| Parameter              | Description                                              | Default |
+|------------------------|----------------------------------------------------------|---------|
+| `CLEANUP_THRESHOLD`    | Life time of a load test (disable by setting value to 0) | `1h`    |
+| `KANGAL_PROXY_URL`     | Endpoints used to store load test reports                | `""`    |
+| `KUBE_CLIENT_TIMEOUT`  | Timeout for each operation done by kube client           | `5s`    |
+| `SYNC_HANDLER_TIMEOUT` | Time limit for each sync operation                       | `60s`   |
+| `WEB_HTTP_PORT`        |                                                          | `8080`  |
 
 ## Backend specific configuration
 ### JMeter
@@ -85,10 +85,10 @@
 | `K6_MEMORY_REQUESTS` | Memory requests |                 |
 
 ## Logger config
-| Parameter                  | Description                                                  | Default                               |
-|----------------------------|--------------------------------------------------------------|---------------------------------------|
-| `LOG_LEVEL`                | Log level                                                    | `info`                                |
-| `LOG_TYPE`                 | Log type                                                     | `kangal`                              |
+| Parameter                  | Description            | Default     |
+|----------------------------|------------------------|-------------|
+| `LOG_LEVEL`                | Log level              | `info`      |
+| `LOG_TYPE`                 | Log type               | `kangal`    |
 
 ## Report config
 | Parameter                  | Description                                                  | Default   |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -10,7 +10,7 @@ To troubleshoot Kangal you will need access to your Kubernetes cluster.
 ## Problems with a specific load test
 You can make basic troubleshooting using Kangal API endpoints or either exploring load test Pods if is the case of your backend.
 
-- Get status of the load test 
+- Get status of the load test
 ```bash
 curl -X GET 'http://${KANGAL_PROXY_ADDRESS}/load-test/loadtest-random-name/' 
 ```
@@ -22,3 +22,18 @@ curl -X GET 'http://${KANGAL_PROXY_ADDRESS}/load-test/loadtest-random-name/logs'
 ```bash
 curl -X GET 'http://${KANGAL_PROXY_ADDRESS}/load-test/loadtest-random-name/logs/0' 
 ```
+
+## I want to use a specific version of docker image for my backend but another version is used automatically
+If you want to use a custom docker image for your load tests, as describe here, check the following:
+
+- you have `ALLOWED_CUSTOM_IMAGES=true` environment variable set for your Kangal Proxy deployment. If not - no custom images are allowed
+
+The default images and tags are specified as constants in `/pkg/backends/your_backend_name/backend.go` files. You can find
+an example of K6 [here](https://github.com/hellofresh/kangal/blob/master/pkg/backends/k6/backend.go#L26).
+
+If you want to redefine the default images and tags - use deployment [environment variables](https://github.com/hellofresh/kangal/blob/master/docs/env-vars.md#backend-specific-configuration) for Proxy and Controller.
+
+- `JMETER_MASTER_IMAGE_NAME` and `JMETER_MASTER_IMAGE_TAG` for JMeter master pods and `JMETER_WORKER_IMAGE_NAME` and `JMETER_WORKER_IMAGE_TAG` for JMeter worker pods
+- `LOCUST_IMAGE_NAME` and `LOCUST_IMAGE_TAG` for Locust
+- `GHZ_IMAGE_NAME` and `GHZ_IMAGE_TAG` for Ghz
+- `K6_IMAGE_NAME` and `K6_IMAGE_TAG` for K6

--- a/docs/user-flow.md
+++ b/docs/user-flow.md
@@ -37,6 +37,7 @@ curl -X POST http://${KANGAL_PROXY_ADDRESS}/load-test \
   -F overwrite=true
 ```
 
+### Use tags
 You can also tag the load test so that you can find them later, the format is `tag1:value1,tag2:value2`
 
 ```bash
@@ -51,7 +52,8 @@ curl -X POST http://${KANGAL_PROXY_ADDRESS}/load-test \
   -F overwrite=true
 ```
 
-Or even select the container images to use for Master and Worker roles:
+### Use custom image
+Specify the container images to use for Master and Worker roles:
 
 ```bash
 curl -X POST http://${KANGAL_PROXY_ADDRESS}/load-test \


### PR DESCRIPTION
This PR updates the docs to cover the following info: 
- how to use the custom images for Loadtests backend
- how to allow images
- what is the default image and how to change it