### PR TITLE
extending lt counter metric

### DIFF
--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -232,33 +232,33 @@ func BuildClientConfig(masterURL string, kubeConfigPath string, timeout time.Dur
 }
 
 // CountExistingLoadtests used in metrics to report running loadtests
-func (c *Client) CountExistingLoadtests() (map[string]int64, map[string]int64, error) {
+func (c *Client) CountExistingLoadtests() (map[apisLoadTestV1.LoadTestPhase]int64, map[apisLoadTestV1.LoadTestType]int64, error) {
 	tt, err := c.ltClient.List(context.Background(), metaV1.ListOptions{})
 	if err != nil {
 		c.logger.Error("Couldn't list existing loadtests", zap.Error(err))
 		return nil, nil, err
 	}
 
-	var phaseCount = map[string]int64{
-		apisLoadTestV1.LoadTestRunning.String():  0,
-		apisLoadTestV1.LoadTestFinished.String(): 0,
-		apisLoadTestV1.LoadTestCreating.String(): 0,
-		apisLoadTestV1.LoadTestErrored.String():  0,
-		apisLoadTestV1.LoadTestStarting.String(): 0,
+	var phaseCount = map[apisLoadTestV1.LoadTestPhase]int64{
+		apisLoadTestV1.LoadTestRunning:  0,
+		apisLoadTestV1.LoadTestFinished: 0,
+		apisLoadTestV1.LoadTestCreating: 0,
+		apisLoadTestV1.LoadTestErrored:  0,
+		apisLoadTestV1.LoadTestStarting: 0,
 	}
 
-	var typeCount = map[string]int64{
-		apisLoadTestV1.LoadTestTypeK6.String():     0,
-		apisLoadTestV1.LoadTestTypeJMeter.String(): 0,
-		apisLoadTestV1.LoadTestTypeLocust.String(): 0,
-		apisLoadTestV1.LoadTestTypeGhz.String():    0,
+	var typeCount = map[apisLoadTestV1.LoadTestType]int64{
+		apisLoadTestV1.LoadTestTypeK6:     0,
+		apisLoadTestV1.LoadTestTypeJMeter: 0,
+		apisLoadTestV1.LoadTestTypeLocust: 0,
+		apisLoadTestV1.LoadTestTypeGhz:    0,
 	}
 
 	for _, loadTest := range tt.Items {
-		phaseString := loadTest.Status.Phase.String()
+		phaseString := loadTest.Status.Phase
 		phaseCount[phaseString]++
 
-		typeString := loadTest.Spec.Type.String()
+		typeString := loadTest.Spec.Type
 		typeCount[typeString]++
 	}
 

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -240,18 +240,18 @@ func (c *Client) CountExistingLoadtests() (map[string]int64, map[string]int64, e
 	}
 
 	var phaseCount = map[string]int64{
-		"running":  0,
-		"finished": 0,
-		"creating": 0,
-		"errored":  0,
-		"starting": 0,
+		apisLoadTestV1.LoadTestRunning.String():  0,
+		apisLoadTestV1.LoadTestFinished.String(): 0,
+		apisLoadTestV1.LoadTestCreating.String(): 0,
+		apisLoadTestV1.LoadTestErrored.String():  0,
+		apisLoadTestV1.LoadTestStarting.String(): 0,
 	}
 
 	var typeCount = map[string]int64{
-		"K6":     0,
-		"JMeter": 0,
-		"Locust": 0,
-		"Ghz":    0,
+		apisLoadTestV1.LoadTestTypeK6.String():     0,
+		apisLoadTestV1.LoadTestTypeJMeter.String(): 0,
+		apisLoadTestV1.LoadTestTypeLocust.String(): 0,
+		apisLoadTestV1.LoadTestTypeGhz.String():    0,
 	}
 
 	for _, loadTest := range tt.Items {

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -248,41 +248,18 @@ func (c *Client) CountExistingLoadtests() (map[string]int64, map[string]int64, e
 	}
 
 	var typeCount = map[string]int64{
-		"k6":     0,
-		"jmeter": 0,
-		"locust": 0,
-		"ghz":    0,
+		"K6":     0,
+		"JMeter": 0,
+		"Locust": 0,
+		"Ghz":    0,
 	}
 
 	for _, loadTest := range tt.Items {
-		if loadTest.Status.Phase.String() == "running" {
-			phaseCount["running"]++
-		}
-		if loadTest.Status.Phase.String() == "errored" {
-			phaseCount["errored"]++
-		}
-		if loadTest.Status.Phase.String() == "starting" {
-			phaseCount["starting"]++
-		}
-		if loadTest.Status.Phase.String() == "creating" {
-			phaseCount["creating"]++
-		}
-		if loadTest.Status.Phase.String() == "finished" {
-			phaseCount["finished"]++
-		}
+		phaseString := loadTest.Status.Phase.String()
+		phaseCount[phaseString]++
 
-		if loadTest.Spec.Type == apisLoadTestV1.LoadTestTypeK6 {
-			typeCount["k6"]++
-		}
-		if loadTest.Spec.Type == apisLoadTestV1.LoadTestTypeGhz {
-			typeCount["ghz"]++
-		}
-		if loadTest.Spec.Type == apisLoadTestV1.LoadTestTypeJMeter {
-			typeCount["jmeter"]++
-		}
-		if loadTest.Spec.Type == apisLoadTestV1.LoadTestTypeLocust {
-			typeCount["locust"]++
-		}
+		typeString := loadTest.Spec.Type.String()
+		typeCount[typeString]++
 	}
 
 	return phaseCount, typeCount, nil

--- a/pkg/kubernetes/client_test.go
+++ b/pkg/kubernetes/client_test.go
@@ -483,7 +483,7 @@ func TestCountExistingLoadTests(t *testing.T) {
 			} else {
 				assert.EqualError(t, err, tc.expectedError)
 			}
-			assert.Equal(t, types[apisLoadTestV1.LoadTestTypeK6.String()], tc.expectedTypes)
+			assert.Equal(t, types[apisLoadTestV1.LoadTestTypeK6], tc.expectedTypes)
 
 			total := states["running"] + states["creating"]
 			assert.Equal(t, tc.expectedResult, int(total))

--- a/pkg/kubernetes/client_test.go
+++ b/pkg/kubernetes/client_test.go
@@ -355,8 +355,6 @@ func TestClient_filterLoadTestsByPhase(t *testing.T) {
 }
 
 func TestCountActiveLoadTests(t *testing.T) {
-	ctx := context.Background()
-
 	loadtestClientset := fakeClientset.NewSimpleClientset()
 	kubeClientSet := fake.NewSimpleClientset()
 
@@ -384,9 +382,10 @@ func TestCountActiveLoadTests(t *testing.T) {
 
 	logger := zap.NewNop()
 	c := NewClient(loadtestClientset.KangalV1().LoadTests(), kubeClientSet, logger)
-	counter, err := c.CountActiveLoadTests(ctx)
+	counter, _, err := c.CountExistingLoadtests()
 	assert.NoError(t, err)
-	assert.Equal(t, 2, counter)
+	total := counter["running"] + counter["creating"]
+	assert.Equal(t, 2, int(total))
 }
 
 func TestGetLoadTestNoLoadTest(t *testing.T) {

--- a/pkg/kubernetes/client_test.go
+++ b/pkg/kubernetes/client_test.go
@@ -354,38 +354,141 @@ func TestClient_filterLoadTestsByPhase(t *testing.T) {
 	}
 }
 
-func TestCountActiveLoadTests(t *testing.T) {
-	loadtestClientset := fakeClientset.NewSimpleClientset()
-	kubeClientSet := fake.NewSimpleClientset()
-
-	loadtestClientset.Fake.PrependReactor("list", "loadtests", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
-		return true, &apisLoadTestV1.LoadTestList{
-			Items: []apisLoadTestV1.LoadTest{
-				{
-					Status: apisLoadTestV1.LoadTestStatus{
-						Phase: apisLoadTestV1.LoadTestRunning,
+func TestCountExistingLoadTests(t *testing.T) {
+	testCases := []struct {
+		scenario       string
+		opt            ListOptions
+		result         *apisLoadTestV1.LoadTestList
+		error          error
+		expectedResult int
+		expectedError  string
+		expectedTypes  int64
+	}{
+		{
+			scenario:       "error in client",
+			result:         &apisLoadTestV1.LoadTestList{},
+			error:          errors.New("client error"),
+			expectedError:  "client error",
+			expectedResult: 0,
+			expectedTypes:  0,
+		},
+		{
+			scenario: "unknown phase",
+			result: &apisLoadTestV1.LoadTestList{
+				Items: []apisLoadTestV1.LoadTest{
+					{
+						Status: apisLoadTestV1.LoadTestStatus{
+							Phase: "",
+						},
+						Spec: apisLoadTestV1.LoadTestSpec{
+							Type: apisLoadTestV1.LoadTestTypeK6,
+						},
 					},
-				},
-				{
-					Status: apisLoadTestV1.LoadTestStatus{
-						Phase: apisLoadTestV1.LoadTestCreating,
-					},
-				},
-				{
-					Status: apisLoadTestV1.LoadTestStatus{
-						Phase: apisLoadTestV1.LoadTestErrored,
+					{
+						Status: apisLoadTestV1.LoadTestStatus{
+							Phase: apisLoadTestV1.LoadTestFinished,
+						},
+						Spec: apisLoadTestV1.LoadTestSpec{
+							Type: apisLoadTestV1.LoadTestTypeK6,
+						},
 					},
 				},
 			},
-		}, nil
-	})
+			error:          nil,
+			expectedError:  "",
+			expectedResult: 0,
+			expectedTypes:  2,
+		},
+		{
+			scenario: "unknown type",
+			result: &apisLoadTestV1.LoadTestList{
+				Items: []apisLoadTestV1.LoadTest{
+					{
+						Status: apisLoadTestV1.LoadTestStatus{
+							Phase: apisLoadTestV1.LoadTestCreating,
+						},
+						Spec: apisLoadTestV1.LoadTestSpec{
+							Type: "foo",
+						},
+					},
+					{
+						Status: apisLoadTestV1.LoadTestStatus{
+							Phase: apisLoadTestV1.LoadTestFinished,
+						},
+						Spec: apisLoadTestV1.LoadTestSpec{
+							Type: "bar",
+						},
+					},
+				},
+			},
+			error:          nil,
+			expectedError:  "",
+			expectedResult: 1,
+			expectedTypes:  0,
+		},
+		{
+			scenario: "success",
+			result: &apisLoadTestV1.LoadTestList{
+				Items: []apisLoadTestV1.LoadTest{
+					{
+						Status: apisLoadTestV1.LoadTestStatus{
+							Phase: apisLoadTestV1.LoadTestRunning,
+						},
+						Spec: apisLoadTestV1.LoadTestSpec{
+							Type: apisLoadTestV1.LoadTestTypeK6,
+						},
+					},
+					{
+						Status: apisLoadTestV1.LoadTestStatus{
+							Phase: apisLoadTestV1.LoadTestCreating,
+						},
+						Spec: apisLoadTestV1.LoadTestSpec{
+							Type: apisLoadTestV1.LoadTestTypeGhz,
+						},
+					},
+					{
+						Status: apisLoadTestV1.LoadTestStatus{
+							Phase: apisLoadTestV1.LoadTestErrored,
+						},
+						Spec: apisLoadTestV1.LoadTestSpec{
+							Type: apisLoadTestV1.LoadTestTypeJMeter,
+						},
+					},
+				},
+			},
+			error:          nil,
+			expectedError:  "",
+			expectedResult: 2,
+			expectedTypes:  1,
+		},
+	}
 
-	logger := zap.NewNop()
-	c := NewClient(loadtestClientset.KangalV1().LoadTests(), kubeClientSet, logger)
-	counter, _, err := c.CountExistingLoadtests()
-	assert.NoError(t, err)
-	total := counter["running"] + counter["creating"]
-	assert.Equal(t, 2, int(total))
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.scenario, func(t *testing.T) {
+			t.Parallel()
+
+			loadtestClientset := fakeClientset.NewSimpleClientset()
+			kubeClientSet := fake.NewSimpleClientset()
+
+			loadtestClientset.Fake.PrependReactor("list", "loadtests", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+				return true, tc.result, tc.error
+			})
+
+			logger := zap.NewNop()
+			c := NewClient(loadtestClientset.KangalV1().LoadTests(), kubeClientSet, logger)
+			states, types, err := c.CountExistingLoadtests()
+			if tc.expectedError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.expectedError)
+			}
+			assert.Equal(t, types[apisLoadTestV1.LoadTestTypeK6.String()], tc.expectedTypes)
+
+			total := states["running"] + states["creating"]
+			assert.Equal(t, tc.expectedResult, int(total))
+		})
+	}
 }
 
 func TestGetLoadTestNoLoadTest(t *testing.T) {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -47,7 +47,7 @@ type MetricsReporter struct {
 // NewMetricsReporter contains loadtest metrics definition
 func NewMetricsReporter(meter metric.Meter, kubeClient *kube.Client) (*MetricsReporter, error) {
 	countRunningLoadtests, err := meter.AsyncInt64().UpDownCounter(
-		"kangal_running_loadtests_count",
+		"kangal_loadtests_count",
 		instrument.WithDescription("The number of currently running loadtests"),
 		instrument.WithUnit(unit.Dimensionless),
 	)
@@ -56,8 +56,17 @@ func NewMetricsReporter(meter metric.Meter, kubeClient *kube.Client) (*MetricsRe
 	}
 
 	if err := meter.RegisterCallback([]instrument.Asynchronous{countRunningLoadtests}, func(ctx context.Context) {
-		lt := kubeClient.CountRunningLoadtests()
-		countRunningLoadtests.Observe(ctx, lt, attribute.String("loadtest", "running"))
+		states, types, err := kubeClient.CountExistingLoadtests()
+		if err != nil {
+			fmt.Errorf("could not get metric data for CountExistingLoadtests: %w", err)
+		}
+		for k, v := range states {
+			countRunningLoadtests.Observe(ctx, v, attribute.String("phase", k))
+		}
+
+		for k, v := range types {
+			countRunningLoadtests.Observe(ctx, v, attribute.String("type", k))
+		}
 	},
 	); err != nil {
 		return nil, err
@@ -202,15 +211,16 @@ func (p *Proxy) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// check the number of active loadtests currently running on the cluster
-	activeLoadTests, err := p.kubeClient.CountActiveLoadTests(ctx)
+	testsByPhase, _, err := p.kubeClient.CountExistingLoadtests()
 	if err != nil {
 		logger.Error("Could not count active load tests", zap.Error(err))
 		render.Render(w, r, cHttp.ErrResponse(http.StatusInternalServerError, "Could not count active load tests"))
 		return
 	}
+	activeLoadTests := testsByPhase["running"] + testsByPhase["creating"]
 
-	if activeLoadTests >= p.maxLoadTestsRun {
-		logger.Warn("number of active load tests reached limit", zap.Int("current", activeLoadTests), zap.Int("limit", p.maxLoadTestsRun))
+	if int(activeLoadTests) >= p.maxLoadTestsRun {
+		logger.Warn("number of active load tests reached limit", zap.Int("current", int(activeLoadTests)), zap.Int("limit", p.maxLoadTestsRun))
 		render.Render(w, r, cHttp.ErrResponse(http.StatusTooManyRequests, "Number of active load tests reached limit"))
 		return
 	}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -48,7 +48,7 @@ type MetricsReporter struct {
 func NewMetricsReporter(meter metric.Meter, kubeClient *kube.Client) (*MetricsReporter, error) {
 	countRunningLoadtests, err := meter.AsyncInt64().UpDownCounter(
 		"kangal_loadtests_count",
-		instrument.WithDescription("The number of currently running loadtests"),
+		instrument.WithDescription("Current number of loadtests in cluster, grouped by type and phase"),
 		instrument.WithUnit(unit.Dimensionless),
 	)
 	if err != nil {
@@ -61,11 +61,11 @@ func NewMetricsReporter(meter metric.Meter, kubeClient *kube.Client) (*MetricsRe
 			fmt.Errorf("could not get metric data for CountExistingLoadtests: %w", err)
 		}
 		for k, v := range states {
-			countRunningLoadtests.Observe(ctx, v, attribute.String("phase", k))
+			countRunningLoadtests.Observe(ctx, v, attribute.String("phase", k.String()))
 		}
 
 		for k, v := range types {
-			countRunningLoadtests.Observe(ctx, v, attribute.String("type", k))
+			countRunningLoadtests.Observe(ctx, v, attribute.String("type", k.String()))
 		}
 	},
 	); err != nil {


### PR DESCRIPTION
This PR extends the logic of existing CountRunningLoadtests to count all the tests currently existing in the cluster:
- rename metric to CountExistingLoadtests
- metric returns count of loadtests by type and by phase
- the same method CountExistingLoadtests now can be used instead of CountActiveLoadTests with duplicated logic
