### PR TITLE
Allow user-specified storageClass for JMeter Remote Data PVC - fixes #256

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -43,6 +43,7 @@
 | `JMETER_WORKER_REMOTE_CUSTOM_DATA_ENABLED`         | Enable remote custom data                                                | `false`                           |
 | `JMETER_WORKER_REMOTE_CUSTOM_DATA_BUCKET`          | The name of the bucket where remote data is                              |                                   |
 | `JMETER_WORKER_REMOTE_CUSTOM_DATA_VOLUME_SIZE`     | Volume size used by download remote data                                 | `1Gi`                             |
+| `JMETER_WORKER_REMOTE_CUSTOM_DATA_STORAGECLASS`    | StorageClass used for remote data PVC (ReadWriteMany required)       | kubernetes environment default |
 | `RCLONE_CONFIG_REMOTECUSTOMDATA_TYPE`              | [Rclone](https://rclone.org/) environment variable for type              |                                   |
 | `RCLONE_CONFIG_REMOTECUSTOMDATA_ACCESS_KEY_ID`     | [Rclone](https://rclone.org/) environment variable for access key ID     |                                   |
 | `RCLONE_CONFIG_REMOTECUSTOMDATA_SECRET_ACCESS_KEY` | [Rclone](https://rclone.org/) environment variable for secret access key |                                   |

--- a/docs/jmeter/writing-tests.md
+++ b/docs/jmeter/writing-tests.md
@@ -411,6 +411,8 @@ JMETER_WORKER_REMOTE_CUSTOM_DATA_VOLUME_SIZE (defaults to 1GB) and access mode R
     This feature won't be available if your cluster does not support ReadWriteMany access mode.
     Please check with your local admins.
 
+You can set the StorageClass to be used for the PVC by setting the JMETER_WORKER_REMOTE_CUSTOM_DATA_STORAGECLASS environment variable to the name of the StorageClass you want to use.  If this environment variable is unset, Kangal will use the default StorageClass in your environment.
+
 The data will be cloned from the bucket to the volume using [Rclone](https://rclone.org/) and will be available to all the pods.
 
 For the full list of possible environment variables check [Kangal environment variables](../env-vars.md)

--- a/pkg/backends/jmeter/resources.go
+++ b/pkg/backends/jmeter/resources.go
@@ -163,10 +163,17 @@ func (b *Backend) NewTestdataConfigMap(loadTest loadTestV1.LoadTest) ([]*coreV1.
 
 // NewPVC creates a new pvc for customdata
 func (b *Backend) NewPVC(loadTest loadTestV1.LoadTest, i int) *coreV1.PersistentVolumeClaim {
+
 	volumeSize := loadTestWorkerRemoteCustomDataVolumeSize
+	var storageClass *string
 	if val, ok := loadTest.Spec.EnvVars["JMETER_WORKER_REMOTE_CUSTOM_DATA_VOLUME_SIZE"]; ok {
 		volumeSize = val
 	}
+
+	if val, ok := loadTest.Spec.EnvVars["JMETER_WORKER_REMOTE_CUSTOM_DATA_STORAGECLASS"]; ok {
+		storageClass = &val
+	}
+
 	return &coreV1.PersistentVolumeClaim{
 		ObjectMeta: metaV1.ObjectMeta{
 			Name:   fmt.Sprintf("pvc-%s", loadTestWorkerName),
@@ -182,6 +189,7 @@ func (b *Backend) NewPVC(loadTest loadTestV1.LoadTest, i int) *coreV1.Persistent
 					coreV1.ResourceName(coreV1.ResourceStorage): resource.MustParse(volumeSize),
 				},
 			},
+			StorageClassName: storageClass,
 		},
 	}
 }


### PR DESCRIPTION
Allow user-specified storageClass for JMeter Remote Data PVC - fixes #256