### PR TITLE
Test data compression for all backends

### DIFF
--- a/pkg/backends/backend.go
+++ b/pkg/backends/backend.go
@@ -17,11 +17,15 @@ type Backend interface {
 	// Type must return backend unique type string, called by both Proxy and Controller
 	Type() loadTestV1.LoadTestType
 
+	// UsesCSVTestData must signal whether the testdata files can be assumed to be CSV
+	// This is used to determine if testdata should be split between workers
+	UsesCSVTestData() bool
+
 	// TransformLoadTestSpec should validate and transform LoadTestSpec, called by Proxy
 	TransformLoadTestSpec(spec *loadTestV1.LoadTestSpec) error
 
 	// Sync should create resources if not exists, called by Controller
-	Sync(ctx context.Context, loadTest loadTestV1.LoadTest, reportURL string) error
+	Sync(ctx context.Context, loadTest loadTestV1.LoadTest, testfileConfigMapName string, testdataConfigMapNames []string, reportURL string) error
 	// Sync should update status with current resource state, called by Controller
 	SyncStatus(ctx context.Context, loadTest loadTestV1.LoadTest, loadTestStatus *loadTestV1.LoadTestStatus) error
 }

--- a/pkg/backends/fake/backend.go
+++ b/pkg/backends/fake/backend.go
@@ -36,6 +36,10 @@ func (*Backend) Type() loadTestV1.LoadTestType {
 	return loadTestV1.LoadTestTypeFake
 }
 
+func (*Backend) UsesCSVTestData() bool {
+	return false
+}
+
 // SetDefaults must set default values
 func (b *Backend) SetDefaults() {
 	b.config = loadTestV1.ImageDetails{
@@ -66,7 +70,7 @@ func (b *Backend) SetKubeClientSet(kubeClientSet kubernetes.Interface) {
 }
 
 // Sync check if Fake kubernetes resources have been create, if they have not been create them
-func (b *Backend) Sync(ctx context.Context, loadTest loadTestV1.LoadTest, _ string) error {
+func (b *Backend) Sync(ctx context.Context, loadTest loadTestV1.LoadTest, _ string, _ []string, _ string) error {
 	// Get the Namespace resource
 	namespace, err := b.kubeClient.CoreV1().Namespaces().Get(ctx, loadTest.Status.Namespace, metaV1.GetOptions{})
 	// The LoadTest resource may no longer exist, in which case we stop

--- a/pkg/backends/fake/backend.go
+++ b/pkg/backends/fake/backend.go
@@ -36,6 +36,7 @@ func (*Backend) Type() loadTestV1.LoadTestType {
 	return loadTestV1.LoadTestTypeFake
 }
 
+// UsesCSVTestData must signal whether the testdata files can be assumed to be CSV
 func (*Backend) UsesCSVTestData() bool {
 	return false
 }

--- a/pkg/backends/fake/backend_test.go
+++ b/pkg/backends/fake/backend_test.go
@@ -42,7 +42,7 @@ func TestSync(t *testing.T) {
 			kubeClient: client,
 			logger:     zaptest.NewLogger(t),
 		}
-		assert.NoError(t, backend.Sync(context.TODO(), lt, ""))
+		assert.NoError(t, backend.Sync(context.TODO(), lt, "", []string{}, ""))
 	})
 
 	t.Run("job exists", func(t *testing.T) {
@@ -64,7 +64,7 @@ func TestSync(t *testing.T) {
 			kubeClient: client,
 			logger:     zaptest.NewLogger(t),
 		}
-		assert.NoError(t, backend.Sync(context.TODO(), lt, ""))
+		assert.NoError(t, backend.Sync(context.TODO(), lt, "", []string{}, ""))
 	})
 
 	t.Run("job doesn't exist, creating", func(t *testing.T) {
@@ -87,7 +87,7 @@ func TestSync(t *testing.T) {
 			kubeClient: client,
 			logger:     zaptest.NewLogger(t),
 		}
-		assert.NoError(t, backend.Sync(context.TODO(), lt, ""))
+		assert.NoError(t, backend.Sync(context.TODO(), lt, "", []string{}, ""))
 	})
 }
 

--- a/pkg/backends/ghz/backend.go
+++ b/pkg/backends/ghz/backend.go
@@ -50,6 +50,10 @@ func (*Backend) Type() loadTestV1.LoadTestType {
 	return loadTestV1.LoadTestTypeGhz
 }
 
+func (*Backend) UsesCSVTestData() bool {
+	return false
+}
+
 // GetEnvConfig must return config struct pointer
 func (b *Backend) GetEnvConfig() interface{} {
 	b.config = &Config{}
@@ -123,7 +127,7 @@ func (b *Backend) TransformLoadTestSpec(spec *loadTestV1.LoadTestSpec) error {
 }
 
 // Sync checks if ghz kubernetes resources have been created, create them if they haven't
-func (b *Backend) Sync(ctx context.Context, loadTest loadTestV1.LoadTest, reportURL string) error {
+func (b *Backend) Sync(ctx context.Context, loadTest loadTestV1.LoadTest, testfileConfigMapName string, testdataConfigMapNames []string, reportURL string) error {
 	jobs, err := b.kubeClientSet.
 		BatchV1().
 		Jobs(loadTest.Status.Namespace).
@@ -140,54 +144,19 @@ func (b *Backend) Sync(ctx context.Context, loadTest loadTestV1.LoadTest, report
 		return nil
 	}
 
-	var (
-		tdCfgMap   *coreV1.ConfigMap
-		configMaps = make([]*coreV1.ConfigMap, 1)
-	)
-
-	// Create testfile ConfigMap
-	tfCfgMap, err := NewFileConfigMap(loadTestFileConfigMapName, configFileName, loadTest.Spec.TestFile)
-	if err != nil {
-		b.logger.Error("Error creating testfile configmap resource", zap.Error(err))
-		return err
-	}
-	configMaps[0] = tfCfgMap
-
-	// Prepare testdata ConfigMap
-	if len(loadTest.Spec.TestData) != 0 {
-		tdCfgMap, err = NewFileConfigMap(loadTestDataConfigMapName, testdataFileName, loadTest.Spec.TestData)
-		if err != nil {
-			b.logger.Error("Error creating testdata configmap resource", zap.Error(err))
-			return err
-		}
-		configMaps = append(configMaps, tdCfgMap)
-	}
-
-	// Create testfile and testdata configmaps
-	for _, cfg := range configMaps {
-		_, err = b.kubeClientSet.
-			CoreV1().
-			ConfigMaps(loadTest.Status.Namespace).
-			Create(ctx, cfg, metaV1.CreateOptions{})
-		if err != nil && !k8sAPIErrors.IsAlreadyExists(err) {
-			b.logger.Error("Error creating configmap", zap.String("configmap", cfg.GetName()), zap.Error(err))
-			return err
-		}
-	}
-
 	// Prepare Volume and VolumeMount for job creation
 	var (
 		volumes = make([]coreV1.Volume, 1)
 		mounts  = make([]coreV1.VolumeMount, 1)
 	)
 
-	volumes[0], mounts[0] = NewFileVolumeAndMount(loadTestFileVolumeName, tfCfgMap.Name, configFileName)
+	volumes[0], mounts[0] = NewFileVolumeAndMount(loadTestFileVolumeName, testfileConfigMapName, configFileName, backends.LoadTestScript)
 
-	if tdCfgMap != nil {
-		v, m := NewFileVolumeAndMount(loadTestDataVolumeName, tdCfgMap.Name, testdataFileName)
+	if len(testdataConfigMapNames) == 1 {
+		v, m := NewFileVolumeAndMount(loadTestDataVolumeName, testdataConfigMapNames[0], testdataFileName, backends.LoadTestData)
 		volumes = append(volumes, v)
 		mounts = append(mounts, m)
-	}
+	} // FIXME: else if len(testdataConfigMapNames) > 1
 
 	// Create Job
 	job := b.NewJob(loadTest, volumes, mounts, reportURL)

--- a/pkg/backends/ghz/backend.go
+++ b/pkg/backends/ghz/backend.go
@@ -153,10 +153,18 @@ func (b *Backend) Sync(ctx context.Context, loadTest loadTestV1.LoadTest, testfi
 	volumes[0], mounts[0] = NewFileVolumeAndMount(loadTestFileVolumeName, testfileConfigMapName, configFileName, backends.LoadTestScript)
 
 	if len(testdataConfigMapNames) == 1 {
-		v, m := NewFileVolumeAndMount(loadTestDataVolumeName, testdataConfigMapNames[0], testdataFileName, backends.LoadTestData)
-		volumes = append(volumes, v)
-		mounts = append(mounts, m)
-	} // FIXME: else if len(testdataConfigMapNames) > 1
+		v, m := NewFileVolumeAndMount(loadTestDataVolumeName, testdataConfigMapNames[0], compressedTestdataFileName, backends.LoadTestData)
+		volumes = append(volumes, v, coreV1.Volume{
+			Name: "testdata",
+			VolumeSource: coreV1.VolumeSource{
+				EmptyDir: &coreV1.EmptyDirVolumeSource{},
+			},
+		})
+		mounts = append(mounts, m, coreV1.VolumeMount{
+			Name:      "testdata",
+			MountPath: testdataDir,
+		})
+	}
 
 	// Create Job
 	job := b.NewJob(loadTest, volumes, mounts, reportURL)

--- a/pkg/backends/ghz/backend.go
+++ b/pkg/backends/ghz/backend.go
@@ -50,6 +50,7 @@ func (*Backend) Type() loadTestV1.LoadTestType {
 	return loadTestV1.LoadTestTypeGhz
 }
 
+// UsesCSVTestData must signal whether the testdata files can be assumed to be CSV
 func (*Backend) UsesCSVTestData() bool {
 	return false
 }

--- a/pkg/backends/ghz/backend_test.go
+++ b/pkg/backends/ghz/backend_test.go
@@ -45,16 +45,12 @@ func TestSync(t *testing.T) {
 		kubeClientSet: kubeClient,
 	}
 
-	err := b.Sync(ctx, loadTest, reportURL)
+	err := b.Sync(ctx, loadTest, reportURL, []string{}, "")
 	require.NoError(t, err, "Error when CheckOrCreateResources")
 
 	jobs, err := kubeClient.BatchV1().Jobs(namespace).List(ctx, metaV1.ListOptions{})
 	require.NoError(t, err, "Error when listing jobs")
 	assert.NotEmpty(t, jobs.Items, "Expected job to be created but there's none")
-
-	configMaps, err := kubeClient.CoreV1().ConfigMaps(namespace).List(ctx, metaV1.ListOptions{})
-	require.NoError(t, err, "Error when listing configmaps")
-	assert.NotEmpty(t, configMaps.Items, "Expected configmap to be created but there's none")
 }
 
 func TestSyncStatus(t *testing.T) {
@@ -89,7 +85,7 @@ func TestSyncStatus(t *testing.T) {
 	}
 
 	// First sync should update status to creating
-	err := b.Sync(ctx, loadTest, reportURL)
+	err := b.Sync(ctx, loadTest, reportURL, []string{}, "")
 	require.NoError(t, err, "Sync error")
 
 	err = b.SyncStatus(ctx, loadTest, &loadTest.Status)

--- a/pkg/backends/ghz/resources.go
+++ b/pkg/backends/ghz/resources.go
@@ -1,9 +1,7 @@
 package ghz
 
 import (
-	"errors"
 	"fmt"
-	"strings"
 
 	"go.uber.org/zap"
 	batchV1 "k8s.io/api/batch/v1"
@@ -103,7 +101,7 @@ func (b *Backend) NewJob(
 }
 
 // NewFileVolumeAndMount creates a new volume and volume mount for a configmap file
-func NewFileVolumeAndMount(name, cfg, filename string) (coreV1.Volume, coreV1.VolumeMount) {
+func NewFileVolumeAndMount(name, cfg, filename, subpath string) (coreV1.Volume, coreV1.VolumeMount) {
 	v := coreV1.Volume{
 		Name: name,
 		VolumeSource: coreV1.VolumeSource{
@@ -118,34 +116,10 @@ func NewFileVolumeAndMount(name, cfg, filename string) (coreV1.Volume, coreV1.Vo
 	m := coreV1.VolumeMount{
 		Name:      name,
 		MountPath: fmt.Sprintf("/data/%s", filename),
-		SubPath:   filename,
+		SubPath:   subpath,
 	}
 
 	return v, m
-}
-
-// NewFileConfigMap creates a configmap for the provided file information
-func NewFileConfigMap(cfgName, filename string, content []byte) (*coreV1.ConfigMap, error) {
-	if strings.TrimSpace(cfgName) == "" {
-		return nil, errors.New("empty config name")
-	}
-
-	if strings.TrimSpace(filename) == "" {
-		return nil, fmt.Errorf("invalid name for configmap %s", cfgName)
-	}
-
-	if len(content) == 0 {
-		return nil, fmt.Errorf("invalid file %s for configmap %s, empty content", filename, cfgName)
-	}
-
-	return &coreV1.ConfigMap{
-		ObjectMeta: metaV1.ObjectMeta{
-			Name: cfgName,
-		},
-		BinaryData: map[string][]byte{
-			filename: content,
-		},
-	}, nil
 }
 
 // determineLoadTestStatusFromJobs reads existing job statuses and determines what the loadtest status should be

--- a/pkg/backends/ghz/resources_test.go
+++ b/pkg/backends/ghz/resources_test.go
@@ -56,7 +56,7 @@ func TestNewFileVolumeAndMount(t *testing.T) {
 			tag:      "volume and mount are created with specified name, file and /data mount path",
 			name:     "load-test-volume",
 			cfg:      "test-configmap",
-			filename: "testfile.json",
+			filename: "/data/testfile.json",
 			subpath:  "load-test-file",
 			expectedVol: coreV1.Volume{
 				Name: "load-test-volume",

--- a/pkg/backends/jmeter/backend.go
+++ b/pkg/backends/jmeter/backend.go
@@ -62,6 +62,7 @@ func (*Backend) Type() loadTestV1.LoadTestType {
 	return loadTestV1.LoadTestTypeJMeter
 }
 
+// UsesCSVTestData must signal whether the testdata files can be assumed to be CSV
 func (*Backend) UsesCSVTestData() bool {
 	return true
 }

--- a/pkg/backends/jmeter/backend.go
+++ b/pkg/backends/jmeter/backend.go
@@ -1,10 +1,7 @@
 package jmeter
 
 import (
-	"bytes"
-	"compress/gzip"
 	"context"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"time"
@@ -173,15 +170,6 @@ func (b *Backend) TransformLoadTestSpec(spec *loadTestV1.LoadTestSpec) error {
 		spec.WorkerConfig.Tag = b.workerConfig.Tag
 	}
 
-	if len(spec.TestData) > 0 {
-		testDataBase64, err := generateBase64(string(spec.TestData))
-		if err != nil {
-			return err
-		}
-
-		spec.TestData = []byte(testDataBase64)
-	}
-
 	return nil
 }
 
@@ -303,28 +291,6 @@ func (b *Backend) SyncStatus(ctx context.Context, loadTest loadTestV1.LoadTest, 
 	loadTestStatus.JobStatus = job.Status
 
 	return nil
-}
-
-func generateBase64(testData string) (string, error) {
-	var result string
-
-	var by bytes.Buffer
-	gz := gzip.NewWriter(&by)
-	if _, err := gz.Write([]byte(testData)); err != nil {
-		return result, err
-	}
-
-	if err := gz.Flush(); err != nil {
-		return result, err
-	}
-
-	if err := gz.Close(); err != nil {
-		return result, err
-	}
-
-	result = base64.RawStdEncoding.EncodeToString(by.Bytes())
-
-	return result, nil
 }
 
 func getLoadTestStatusPhaseByPod(pod coreV1.Pod) loadTestV1.LoadTestPhase {

--- a/pkg/backends/jmeter/backend_test.go
+++ b/pkg/backends/jmeter/backend_test.go
@@ -164,7 +164,7 @@ func TestSync(t *testing.T) {
 		},
 	}
 
-	err := b.Sync(ctx, loadTest, reportURL)
+	err := b.Sync(ctx, loadTest, reportURL, []string{}, "")
 	require.NoError(t, err, "Error when syncing")
 
 	services, err := kubeClient.CoreV1().Services(namespace).List(ctx, metaV1.ListOptions{})

--- a/pkg/backends/jmeter/resources.go
+++ b/pkg/backends/jmeter/resources.go
@@ -125,15 +125,19 @@ func (b *Backend) NewPod(loadTest loadTestV1.LoadTest, i int, configMapName stri
 	if configMapName != "" {
 		volumeMounts = []coreV1.VolumeMount{
 			{
-				Name:      "testdata",
-				MountPath: "/testdata/testdata.csv",
+				Name:      "testdatatmp",
+				MountPath: "/testdatatmp/testdata.csv.gz",
 				SubPath:   backends.LoadTestData,
+			},
+			{
+				Name:      "testdata",
+				MountPath: "/testdata",
 			},
 		}
 
 		volumes = []coreV1.Volume{
 			{
-				Name: "testdata",
+				Name: "testdatatmp",
 				VolumeSource: coreV1.VolumeSource{
 					ConfigMap: &coreV1.ConfigMapVolumeSource{
 						LocalObjectReference: coreV1.LocalObjectReference{
@@ -141,6 +145,12 @@ func (b *Backend) NewPod(loadTest loadTestV1.LoadTest, i int, configMapName stri
 						},
 						Optional: &optionalVolume,
 					},
+				},
+			},
+			{
+				Name: "testdata",
+				VolumeSource: coreV1.VolumeSource{
+					EmptyDir: &coreV1.EmptyDirVolumeSource{},
 				},
 			},
 		}
@@ -172,6 +182,15 @@ func (b *Backend) NewPod(loadTest loadTestV1.LoadTest, i int, configMapName stri
 							},
 						},
 					},
+				},
+			},
+			InitContainers: []coreV1.Container{
+				{
+					Name:         "inflate-testdata",
+					Image:        "alpine:latest",
+					Command:      []string{"/bin/sh"},
+					Args:         []string{"-c", "(ls /testdatatmp/testdata.csv.gz >/dev/null 2>&1 && cat /testdatatmp/testdata.csv.gz |zcat > /testdata/testdata.csv) || echo \"no testdata.csv.gz file\""},
+					VolumeMounts: volumeMounts,
 				},
 			},
 			Containers: []coreV1.Container{

--- a/pkg/backends/jmeter/resources.go
+++ b/pkg/backends/jmeter/resources.go
@@ -1,10 +1,7 @@
 package jmeter
 
 import (
-	"bytes"
-	"compress/gzip"
 	"context"
-	"encoding/base64"
 	"encoding/csv"
 	"fmt"
 	"io"
@@ -62,25 +59,6 @@ var (
 	}
 )
 
-// NewConfigMap creates a new configMap containing loadtest script
-func (b *Backend) NewConfigMap(loadTest loadTestV1.LoadTest) *coreV1.ConfigMap {
-	testfile := loadTest.Spec.TestFile
-
-	data := map[string]string{
-		"testfile.jmx": string(testfile),
-	}
-
-	return &coreV1.ConfigMap{
-		ObjectMeta: metaV1.ObjectMeta{
-			Name: loadTestFile,
-			Labels: map[string]string{
-				"app": "hf-jmeter",
-			},
-		},
-		Data: data,
-	}
-}
-
 // NewSecret creates a secret from file envVars
 func (b *Backend) NewSecret(loadTest loadTestV1.LoadTest) (*coreV1.Secret, error) {
 	secretMap := loadTest.Spec.EnvVars
@@ -92,73 +70,6 @@ func (b *Backend) NewSecret(loadTest loadTestV1.LoadTest) (*coreV1.Secret, error
 		},
 		StringData: secretMap,
 	}, nil
-}
-
-// NewTestdataConfigMap creates a new configMap containing testdata
-func (b *Backend) NewTestdataConfigMap(loadTest loadTestV1.LoadTest) ([]*coreV1.ConfigMap, error) {
-	logger := b.logger.With(
-		zap.String("loadtest", loadTest.GetName()),
-		zap.String("namespace", loadTest.Status.Namespace),
-	)
-
-	testdata := loadTest.Spec.TestData
-	if len(testdata) > 0 {
-		testdataDecoded, _ := base64.RawStdEncoding.DecodeString(string(loadTest.Spec.TestData))
-		gz, err := gzip.NewReader(bytes.NewReader(testdataDecoded))
-		if err != nil && err != io.EOF {
-			logger.Error("Error on gzip reader", zap.Error(err))
-			return nil, err
-		}
-		defer gz.Close()
-
-		result, err := io.ReadAll(gz)
-		if err != nil && err != io.EOF {
-			logger.Error("Error on ioutil reader", zap.Error(err))
-			return nil, err
-		}
-		testdata = result
-	}
-
-	n := int(*loadTest.Spec.DistributedPods)
-
-	cMaps := make([]*coreV1.ConfigMap, n)
-
-	chunks, err := splitTestData(string(testdata), n, logger)
-	if err != nil {
-		logger.Error("Error on splitting csv test data", zap.Error(err))
-		return nil, err
-	}
-
-	var buf bytes.Buffer
-	gzipWriter := gzip.NewWriter(&buf)
-
-	for i := 0; i < n; i++ {
-		csvWriter := csv.NewWriter(gzipWriter)
-		if err := csvWriter.WriteAll(chunks[i]); err != nil {
-			logger.Error("Error on writing csv test data to chunks", zap.Error(err))
-			return nil, err
-		}
-		gzipWriter.Close()
-
-		data := map[string]string{
-			"testdata.csv.gz": base64.RawStdEncoding.EncodeToString(buf.Bytes()),
-		}
-
-		buf.Reset()
-		buf = *new(bytes.Buffer)
-		gzipWriter.Reset(&buf)
-
-		cmName := fmt.Sprintf("%s-%03d", loadTestFile, i)
-
-		cMaps[i] = &coreV1.ConfigMap{
-			ObjectMeta: metaV1.ObjectMeta{
-				Name: cmName,
-			},
-			Data: data,
-		}
-	}
-
-	return cMaps, nil
 }
 
 // NewPVC creates a new pvc for customdata
@@ -195,7 +106,7 @@ func (b *Backend) NewPVC(loadTest loadTestV1.LoadTest, i int) *coreV1.Persistent
 }
 
 // NewPod creates a new pod which mounts a configmap that contains jmeter testdata
-func (b *Backend) NewPod(loadTest loadTestV1.LoadTest, i int, configMap *coreV1.ConfigMap, podAnnotations map[string]string) *coreV1.Pod {
+func (b *Backend) NewPod(loadTest loadTestV1.LoadTest, i int, configMapName string, podAnnotations map[string]string) *coreV1.Pod {
 	logger := b.logger.With(
 		zap.String("loadtest", loadTest.GetName()),
 		zap.String("namespace", loadTest.Status.Namespace),
@@ -207,6 +118,33 @@ func (b *Backend) NewPod(loadTest loadTestV1.LoadTest, i int, configMap *coreV1.
 	if loadTest.Spec.WorkerConfig.Image == "" || loadTest.Spec.WorkerConfig.Tag == "" {
 		imageRef = fmt.Sprintf("%s:%s", b.workerConfig.Image, b.workerConfig.Tag)
 		logger.Debug("Loadtest.Spec.WorkerConfig is empty; using worker image from config", zap.String("imageRef", imageRef))
+	}
+
+	volumeMounts := []coreV1.VolumeMount{}
+	volumes := []coreV1.Volume{}
+	if configMapName != "" {
+		volumeMounts = []coreV1.VolumeMount{
+			{
+				Name:      "testdata",
+				MountPath: "/testdata/testdata.csv",
+				SubPath:   backends.LoadTestData,
+			},
+		}
+
+		volumes = []coreV1.Volume{
+			{
+				Name: "testdata",
+				VolumeSource: coreV1.VolumeSource{
+					ConfigMap: &coreV1.ConfigMapVolumeSource{
+						LocalObjectReference: coreV1.LocalObjectReference{
+							Name: configMapName,
+						},
+						Optional: &optionalVolume,
+					},
+				},
+			},
+		}
+
 	}
 
 	pod := &coreV1.Pod{
@@ -236,24 +174,6 @@ func (b *Backend) NewPod(loadTest loadTestV1.LoadTest, i int, configMap *coreV1.
 					},
 				},
 			},
-			InitContainers: []coreV1.Container{
-				{
-					Name:    "convert-data-back-to-csv",
-					Image:   "alpine:latest",
-					Command: []string{"/bin/sh"},
-					Args:    []string{"-c", "(ls /testdatatmp/testdata.csv.gz >/dev/null 2>&1 && cat /testdatatmp/testdata.csv.gz |base64 -d|zcat > /testdata/testdata.csv) || echo \"no testdata.csv.gz file\""},
-					VolumeMounts: []coreV1.VolumeMount{
-						{
-							Name:      "testdatatmp",
-							MountPath: "/testdatatmp",
-						},
-						{
-							Name:      "testdata",
-							MountPath: "/testdata",
-						},
-					},
-				},
-			},
 			Containers: []coreV1.Container{
 				{
 					Name:            loadTestWorkerName,
@@ -263,13 +183,8 @@ func (b *Backend) NewPod(loadTest loadTestV1.LoadTest, i int, configMap *coreV1.
 						{ContainerPort: 1099},
 						{ContainerPort: 50000},
 					},
-					VolumeMounts: []coreV1.VolumeMount{
-						{
-							Name:      "testdata",
-							MountPath: "/testdata",
-						},
-					},
-					Resources: backends.BuildResourceRequirements(b.workerResources),
+					VolumeMounts: volumeMounts,
+					Resources:    backends.BuildResourceRequirements(b.workerResources),
 					EnvFrom: []coreV1.EnvFromSource{
 						{
 							SecretRef: &coreV1.SecretEnvSource{
@@ -281,25 +196,7 @@ func (b *Backend) NewPod(loadTest loadTestV1.LoadTest, i int, configMap *coreV1.
 					},
 				},
 			},
-			Volumes: []coreV1.Volume{
-				{
-					Name: "testdatatmp",
-					VolumeSource: coreV1.VolumeSource{
-						ConfigMap: &coreV1.ConfigMapVolumeSource{
-							LocalObjectReference: coreV1.LocalObjectReference{
-								Name: configMap.Name,
-							},
-							Optional: &optionalVolume,
-						},
-					},
-				},
-				{
-					Name: "testdata",
-					VolumeSource: coreV1.VolumeSource{
-						EmptyDir: &coreV1.EmptyDirVolumeSource{},
-					},
-				},
-			},
+			Volumes: volumes,
 		},
 	}
 
@@ -356,7 +253,7 @@ func (b *Backend) NewPod(loadTest loadTestV1.LoadTest, i int, configMap *coreV1.
 }
 
 // NewJMeterMasterJob creates a new job which runs the jmeter master pod
-func (b *Backend) NewJMeterMasterJob(loadTest loadTestV1.LoadTest, reportURL string, podAnnotations map[string]string) *batchV1.Job {
+func (b *Backend) NewJMeterMasterJob(loadTest loadTestV1.LoadTest, testfileConfigMapName string, reportURL string, podAnnotations map[string]string) *batchV1.Job {
 	logger := b.logger.With(
 		zap.String("loadtest", loadTest.GetName()),
 		zap.String("namespace", loadTest.Status.Namespace),
@@ -422,7 +319,8 @@ func (b *Backend) NewJMeterMasterJob(loadTest loadTestV1.LoadTest, reportURL str
 							VolumeMounts: []coreV1.VolumeMount{
 								{
 									Name:      "tests",
-									MountPath: "/tests",
+									MountPath: "/tests/testfile.jmx",
+									SubPath:   backends.LoadTestScript,
 								},
 							},
 							Resources: backends.BuildResourceRequirements(b.masterResources),
@@ -434,7 +332,7 @@ func (b *Backend) NewJMeterMasterJob(loadTest loadTestV1.LoadTest, reportURL str
 							VolumeSource: coreV1.VolumeSource{
 								ConfigMap: &coreV1.ConfigMapVolumeSource{
 									LocalObjectReference: coreV1.LocalObjectReference{
-										Name: loadTestFile,
+										Name: testfileConfigMapName,
 									},
 								},
 							},
@@ -479,31 +377,17 @@ func (b *Backend) NewJMeterService() *coreV1.Service {
 }
 
 // CreatePodsWithTestdata creates workers Pods
-func (b *Backend) CreatePodsWithTestdata(ctx context.Context, configMaps []*coreV1.ConfigMap, loadTest *loadTestV1.LoadTest, namespace string) error {
+func (b *Backend) CreatePodsWithTestdata(ctx context.Context, configMapNames []string, loadTest *loadTestV1.LoadTest, namespace string) error {
 	logger := b.logger.With(
 		zap.String("loadtest", loadTest.GetName()),
 		zap.String("namespace", loadTest.Status.Namespace),
 	)
-	for i, cm := range configMaps {
-		configMap, err := b.kubeClientSet.CoreV1().ConfigMaps(namespace).Create(ctx, cm, metaV1.CreateOptions{})
-		if err != nil && !kerrors.IsAlreadyExists(err) {
-			logger.Error("Error on creating testdata configMaps", zap.Error(err))
-			return err
-		}
-
-		if kerrors.IsAlreadyExists(err) {
-			configMap, err = b.kubeClientSet.CoreV1().ConfigMaps(namespace).Get(ctx, cm.Name, metaV1.GetOptions{})
-			if nil != err {
-				logger.Error("unable to reload ConfigMap", zap.Error(err))
-				return err
-			}
-		}
-
+	for i := 0; i < int(*loadTest.Spec.DistributedPods); i = i + 1 {
 		if _, ok := loadTest.Spec.EnvVars["JMETER_WORKER_REMOTE_CUSTOM_DATA_ENABLED"]; ok {
 			logger.Info("Remote custom data enabled, creating PVC")
 
 			pvc := b.NewPVC(*loadTest, i)
-			_, err = b.kubeClientSet.CoreV1().PersistentVolumeClaims(namespace).Create(ctx, pvc, metaV1.CreateOptions{})
+			_, err := b.kubeClientSet.CoreV1().PersistentVolumeClaims(namespace).Create(ctx, pvc, metaV1.CreateOptions{})
 			if err != nil && !kerrors.IsAlreadyExists(err) {
 				logger.Error("Error on creating pvc", zap.Error(err))
 				return err
@@ -519,8 +403,12 @@ func (b *Backend) CreatePodsWithTestdata(ctx context.Context, configMaps []*core
 			waitfor.Resource(watchObjPvc, (waitfor.Condition{}).PvcReady, b.config.WaitForResourceTimeout)
 		}
 
-		pod := b.NewPod(*loadTest, i, configMap, b.podAnnotations)
-		_, err = b.kubeClientSet.CoreV1().Pods(namespace).Create(ctx, pod, metaV1.CreateOptions{})
+		cmName := ""
+		if i < len(configMapNames) {
+			cmName = configMapNames[i]
+		}
+		pod := b.NewPod(*loadTest, i, cmName, b.podAnnotations)
+		_, err := b.kubeClientSet.CoreV1().Pods(namespace).Create(ctx, pod, metaV1.CreateOptions{})
 		if err != nil && !kerrors.IsAlreadyExists(err) {
 			logger.Error("Error on creating distributed pods", zap.Error(err))
 			return err

--- a/pkg/backends/jmeter/resources_test.go
+++ b/pkg/backends/jmeter/resources_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap/zaptest"
-	coreV1 "k8s.io/api/core/v1"
 
 	"github.com/hellofresh/kangal/pkg/backends"
 	loadTestV1 "github.com/hellofresh/kangal/pkg/kubernetes/apis/loadtest/v1"
@@ -135,13 +134,13 @@ func TestPodResourceConfiguration(t *testing.T) {
 		},
 	}
 
-	masterJob := c.NewJMeterMasterJob(lt, "http://kangal-proxy.local/load-test/loadtest-name/report", map[string]string{"": ""})
+	masterJob := c.NewJMeterMasterJob(lt, "load-test-script", "http://kangal-proxy.local/load-test/loadtest-name/report", map[string]string{"": ""})
 	assert.Equal(t, c.masterResources.CPULimits, masterJob.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String())
 	assert.Equal(t, c.masterResources.CPURequests, masterJob.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String())
 	assert.Equal(t, c.masterResources.MemoryLimits, masterJob.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String())
 	assert.Equal(t, c.masterResources.MemoryRequests, masterJob.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String())
 
-	workerPod := c.NewPod(lt, 0, &coreV1.ConfigMap{}, map[string]string{"": ""})
+	workerPod := c.NewPod(lt, 0, "load-test-cm", map[string]string{"": ""})
 	assert.Equal(t, c.workerResources.CPULimits, workerPod.Spec.Containers[0].Resources.Limits.Cpu().String())
 	assert.Equal(t, c.workerResources.CPURequests, workerPod.Spec.Containers[0].Resources.Requests.Cpu().String())
 	assert.Equal(t, c.workerResources.MemoryLimits, workerPod.Spec.Containers[0].Resources.Limits.Memory().String())

--- a/pkg/backends/k6/backend.go
+++ b/pkg/backends/k6/backend.go
@@ -167,9 +167,17 @@ func (b *Backend) Sync(ctx context.Context, loadTest loadTestV1.LoadTest, testfi
 		volumes[0], mounts[0] = NewFileVolumeAndMount(loadTestFileVolumeName, testfileConfigMapName, backends.LoadTestScript, scriptTestFileName)
 
 		if len(testdataConfigMapNames) > 0 {
-			v, m := NewFileVolumeAndMount(loadTestDataVolumeName, testdataConfigMapNames[i%int32(len(testdataConfigMapNames))], backends.LoadTestData, testdataFileName)
-			volumes = append(volumes, v)
-			mounts = append(mounts, m)
+			v, m := NewFileVolumeAndMount(loadTestDataVolumeName, testdataConfigMapNames[i%int32(len(testdataConfigMapNames))], backends.LoadTestData, compressedTestdataFileName)
+			volumes = append(volumes, v, coreV1.Volume{
+				Name: "testdata",
+				VolumeSource: coreV1.VolumeSource{
+					EmptyDir: &coreV1.EmptyDirVolumeSource{},
+				},
+			})
+			mounts = append(mounts, m, coreV1.VolumeMount{
+				Name:      "testdata",
+				MountPath: testdataDir,
+			})
 		}
 		// Create Job
 		job := b.NewJob(loadTest, volumes, mounts, secret, reportURL, i)

--- a/pkg/backends/k6/backend.go
+++ b/pkg/backends/k6/backend.go
@@ -50,6 +50,7 @@ func (*Backend) Type() loadTestV1.LoadTestType {
 	return loadTestV1.LoadTestTypeK6
 }
 
+// UsesCSVTestData must signal whether the testdata files can be assumed to be CSV
 func (*Backend) UsesCSVTestData() bool {
 	return false
 }

--- a/pkg/backends/k6/backend_test.go
+++ b/pkg/backends/k6/backend_test.go
@@ -45,16 +45,12 @@ func TestSync(t *testing.T) {
 		kubeClientSet: kubeClient,
 	}
 
-	err := b.Sync(ctx, loadTest, reportURL)
+	err := b.Sync(ctx, loadTest, reportURL, []string{}, "")
 	require.NoError(t, err, "Error when CheckOrCreateResources")
 
 	jobs, err := kubeClient.BatchV1().Jobs(namespace).List(ctx, metaV1.ListOptions{})
 	require.NoError(t, err, "Error when listing jobs")
 	assert.NotEmpty(t, jobs.Items, "Expected job to be created but there's none")
-
-	configMaps, err := kubeClient.CoreV1().ConfigMaps(namespace).List(ctx, metaV1.ListOptions{})
-	require.NoError(t, err, "Error when listing configmaps")
-	assert.NotEmpty(t, configMaps.Items, "Expected configmap to be created but there's none")
 }
 
 func TestSyncStatus(t *testing.T) {
@@ -90,7 +86,7 @@ func TestSyncStatus(t *testing.T) {
 	}
 
 	// First sync should update status to creating
-	err := b.Sync(ctx, loadTest, reportURL)
+	err := b.Sync(ctx, loadTest, reportURL, []string{}, "")
 	require.NoError(t, err, "Sync error")
 
 	err = b.SyncStatus(ctx, loadTest, &loadTest.Status)

--- a/pkg/backends/k6/resources.go
+++ b/pkg/backends/k6/resources.go
@@ -150,7 +150,7 @@ func (b *Backend) NewJob(
 }
 
 // NewFileVolumeAndMount creates a new volume and volume mount for a configmap file
-func NewFileVolumeAndMount(name, cfg, filename string) (coreV1.Volume, coreV1.VolumeMount) {
+func NewFileVolumeAndMount(name, cfg, subpath, filename string) (coreV1.Volume, coreV1.VolumeMount) {
 	v := coreV1.Volume{
 		Name: name,
 		VolumeSource: coreV1.VolumeSource{
@@ -165,7 +165,7 @@ func NewFileVolumeAndMount(name, cfg, filename string) (coreV1.Volume, coreV1.Vo
 	m := coreV1.VolumeMount{
 		Name:      name,
 		MountPath: fmt.Sprintf("/data/%s", filename),
-		SubPath:   filename,
+		SubPath:   subpath,
 	}
 
 	return v, m

--- a/pkg/backends/k6/resources.go
+++ b/pkg/backends/k6/resources.go
@@ -1,10 +1,8 @@
 package k6
 
 import (
-	"encoding/csv"
 	"errors"
 	"fmt"
-	"io"
 	"strings"
 
 	"go.uber.org/zap"
@@ -23,15 +21,17 @@ const (
 	loadTestFileVolumeName    = "loadtest-testfile-volume"
 	loadTestDataVolumeName    = "loadtest-testdata-volume"
 
-	scriptTestFileName = "test.js"
-	testdataFileName   = "testdata"
+	scriptTestFileName         = "/script/test.js"
+	compressedTestdataFileName = "/datatmp/testdata.gz"
+	testdataDir                = "/data"
+	testdataFileBaseName       = "testdata"
 )
 
 var (
 	loadTestLabelKey         = "app"
 	loadTestWorkerLabelValue = "loadtest-worker-pod"
 
-	defaultArgs = []string{"run", "/data/test.js"}
+	defaultArgs = []string{"run", scriptTestFileName}
 )
 
 // NewJob creates a new job that runs k6
@@ -132,6 +132,15 @@ func (b *Backend) NewJob(
 					},
 					RestartPolicy: "Never",
 					Volumes:       volumes,
+					InitContainers: []coreV1.Container{
+						{
+							Name:         "inflate-testdata",
+							Image:        "alpine:latest",
+							Command:      []string{"/bin/sh"},
+							Args:         []string{"-c", fmt.Sprintf("(ls %s >/dev/null 2>&1 && cat %s |zcat > %s) || echo \"no testdata.gz file\"", compressedTestdataFileName, compressedTestdataFileName, testdataDir+"/"+testdataFileBaseName)},
+							VolumeMounts: mounts,
+						},
+					},
 					Containers: []coreV1.Container{
 						{
 							Name:         "k6",
@@ -164,7 +173,7 @@ func NewFileVolumeAndMount(name, cfg, subpath, filename string) (coreV1.Volume, 
 
 	m := coreV1.VolumeMount{
 		Name:      name,
-		MountPath: fmt.Sprintf("/data/%s", filename),
+		MountPath: fmt.Sprintf(filename),
 		SubPath:   subpath,
 	}
 
@@ -193,99 +202,6 @@ func NewFileConfigMap(cfgName, filename string, content []byte) (*coreV1.ConfigM
 			filename: content,
 		},
 	}, nil
-}
-
-// NewTestdataConfigMaps
-func NewTestdataConfigMaps(cfgName, filename string, n int, content string) ([]*coreV1.ConfigMap, error) {
-	// TODO: split test data
-	if strings.TrimSpace(cfgName) == "" {
-		return nil, errors.New("empty config name")
-	}
-
-	if strings.TrimSpace(filename) == "" {
-		return nil, fmt.Errorf("invalid name for configmap %s", cfgName)
-	}
-
-	if strings.TrimSpace(content) == "" {
-		return nil, fmt.Errorf("invalid file %s for configmap %s, empty content", filename, cfgName)
-	}
-
-	cMaps := make([]*coreV1.ConfigMap, n)
-
-	chunks, err := splitTestData(content, n)
-	if err != nil {
-		return nil, err
-	}
-
-	stringWriter := new(strings.Builder)
-
-	for i := 0; i < n; i++ {
-		csvWriter := csv.NewWriter(stringWriter)
-		if err := csvWriter.WriteAll(chunks[i]); err != nil {
-			return nil, err
-		}
-
-		data := map[string]string{
-			"testdata.csv": stringWriter.String(),
-		}
-
-		stringWriter.Reset()
-
-		cmName := fmt.Sprintf("%s-%03d", filename, i)
-
-		cMaps[i] = &coreV1.ConfigMap{
-			ObjectMeta: metaV1.ObjectMeta{
-				Name: cmName,
-			},
-			Data: data,
-		}
-	}
-
-	return cMaps, nil
-}
-
-// splitTestData splits provided csv test data and returns the array of file chunks
-func splitTestData(testdata string, n int) ([][][]string, error) {
-	reader := csv.NewReader(strings.NewReader(testdata))
-
-	count := 0
-	for {
-		_, err := reader.Read()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return nil, err
-		}
-		count++
-	}
-
-	linesInChunk := count / n
-
-	chunk := 0
-	chunks := make([][][]string, n)
-	reader = csv.NewReader(strings.NewReader(testdata))
-	for line := 0; chunk < n; line++ {
-		rec, err := reader.Read()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return nil, err
-		}
-
-		if line >= linesInChunk {
-			chunk++
-			line = 0
-		}
-
-		if chunk >= n {
-			break
-		}
-
-		chunks[chunk] = append(chunks[chunk], rec)
-	}
-	return chunks, nil
 }
 
 func segmentArgs(index, total int32) []string {

--- a/pkg/backends/k6/resources_test.go
+++ b/pkg/backends/k6/resources_test.go
@@ -111,6 +111,7 @@ func TestNewFileVolumeAndMount(t *testing.T) {
 		name          string
 		cfg           string
 		filename      string
+		subpath       string
 		expectedVol   coreV1.Volume
 		expectedMount coreV1.VolumeMount
 	}{
@@ -119,6 +120,7 @@ func TestNewFileVolumeAndMount(t *testing.T) {
 			name:     "load-test-volume",
 			cfg:      "test-configmap",
 			filename: "testfile.json",
+			subpath:  "load-test-script",
 			expectedVol: coreV1.Volume{
 				Name: "load-test-volume",
 				VolumeSource: coreV1.VolumeSource{
@@ -132,12 +134,12 @@ func TestNewFileVolumeAndMount(t *testing.T) {
 			expectedMount: coreV1.VolumeMount{
 				Name:      "load-test-volume",
 				MountPath: "/data/testfile.json",
-				SubPath:   "testfile.json",
+				SubPath:   "load-test-script",
 			},
 		},
 	} {
 		t.Run(tt.tag, func(t *testing.T) {
-			v, m := NewFileVolumeAndMount(tt.name, tt.cfg, tt.filename)
+			v, m := NewFileVolumeAndMount(tt.name, tt.cfg, tt.subpath, tt.filename)
 			assert.Equal(t, tt.expectedVol, v)
 			assert.Equal(t, tt.expectedMount, m)
 		})

--- a/pkg/backends/k6/resources_test.go
+++ b/pkg/backends/k6/resources_test.go
@@ -119,7 +119,7 @@ func TestNewFileVolumeAndMount(t *testing.T) {
 			tag:      "volume and mount are created with specified name, file and /data mount path",
 			name:     "load-test-volume",
 			cfg:      "test-configmap",
-			filename: "testfile.json",
+			filename: "/data/testfile.json",
 			subpath:  "load-test-script",
 			expectedVol: coreV1.Volume{
 				Name: "load-test-volume",

--- a/pkg/backends/locust/backend.go
+++ b/pkg/backends/locust/backend.go
@@ -51,6 +51,7 @@ func (*Backend) Type() loadTestV1.LoadTestType {
 	return loadTestV1.LoadTestTypeLocust
 }
 
+// UsesCSVTestData must signal whether the testdata files can be assumed to be CSV
 func (*Backend) UsesCSVTestData() bool {
 	return false
 }

--- a/pkg/backends/locust/backend_test.go
+++ b/pkg/backends/locust/backend_test.go
@@ -61,16 +61,12 @@ func TestSync(t *testing.T) {
 		kubeClientSet: kubeClient,
 	}
 
-	err := b.Sync(ctx, loadTest, reportURL)
+	err := b.Sync(ctx, loadTest, reportURL, []string{}, "")
 	require.NoError(t, err, "Error when CheckOrCreateResources")
 
 	services, err := kubeClient.CoreV1().Services(namespace).List(ctx, metaV1.ListOptions{})
 	require.NoError(t, err, "Error when listing services")
 	assert.NotEmpty(t, services.Items, "Expected non-zero services amount after CheckOrCreateResources but found zero")
-
-	configMaps, err := kubeClient.CoreV1().ConfigMaps(namespace).List(ctx, metaV1.ListOptions{})
-	require.NoError(t, err, "Error when listing services")
-	assert.NotEmpty(t, configMaps.Items, "Expected non-zero configMaps amount after CheckOrCreateResources but found zero")
 }
 
 func TestSyncStatus(t *testing.T) {

--- a/pkg/backends/locust/resources.go
+++ b/pkg/backends/locust/resources.go
@@ -67,7 +67,7 @@ func newMasterJobName(loadTest loadTestV1.LoadTest) string {
 
 func newMasterJob(
 	loadTest loadTestV1.LoadTest,
-	testfileConfigMap *coreV1.ConfigMap,
+	testfileConfigMapName string,
 	envvarSecret *coreV1.Secret,
 	reportURL string,
 	masterResources backends.Resources,
@@ -152,7 +152,7 @@ func newMasterJob(
 								{
 									Name:      "testfile",
 									MountPath: "/data/locustfile.py",
-									SubPath:   "locustfile.py",
+									SubPath:   backends.LoadTestScript,
 								},
 							},
 							Resources: backends.BuildResourceRequirements(masterResources),
@@ -165,7 +165,7 @@ func newMasterJob(
 							VolumeSource: coreV1.VolumeSource{
 								ConfigMap: &coreV1.ConfigMapVolumeSource{
 									LocalObjectReference: coreV1.LocalObjectReference{
-										Name: testfileConfigMap.GetName(),
+										Name: testfileConfigMapName,
 									},
 								},
 							},
@@ -213,7 +213,7 @@ func newWorkerJobName(loadTest loadTestV1.LoadTest) string {
 
 func newWorkerJob(
 	loadTest loadTestV1.LoadTest,
-	testfileConfigMap *coreV1.ConfigMap,
+	testfileConfigMapName string,
 	envvarSecret *coreV1.Secret,
 	masterService *coreV1.Service,
 	workerResources backends.Resources,
@@ -288,7 +288,7 @@ func newWorkerJob(
 								{
 									Name:      "testfile",
 									MountPath: "/data/locustfile.py",
-									SubPath:   "locustfile.py",
+									SubPath:   backends.LoadTestScript,
 								},
 							},
 							Resources: backends.BuildResourceRequirements(workerResources),
@@ -301,7 +301,7 @@ func newWorkerJob(
 							VolumeSource: coreV1.VolumeSource{
 								ConfigMap: &coreV1.ConfigMapVolumeSource{
 									LocalObjectReference: coreV1.LocalObjectReference{
-										Name: testfileConfigMap.GetName(),
+										Name: testfileConfigMapName,
 									},
 								},
 							},

--- a/pkg/backends/mock.go
+++ b/pkg/backends/mock.go
@@ -41,7 +41,7 @@ func (m *MockBackend) EXPECT() *MockBackendMockRecorder {
 }
 
 // Sync mocks base method.
-func (m *MockBackend) Sync(ctx context.Context, loadTest v1.LoadTest, reportURL string) error {
+func (m *MockBackend) Sync(ctx context.Context, loadTest v1.LoadTest, reportURL string, _ []string, _ string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Sync", ctx, loadTest, reportURL)
 	ret0, _ := ret[0].(error)
@@ -52,6 +52,20 @@ func (m *MockBackend) Sync(ctx context.Context, loadTest v1.LoadTest, reportURL 
 func (mr *MockBackendMockRecorder) Sync(ctx, loadTest, reportURL interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockBackend)(nil).Sync), ctx, loadTest, reportURL)
+}
+
+// UsesCSVTestData mocks base method.
+func (m *MockBackend) UsesCSVTestData() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UsesCSVTestData")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// UsesCSVTestData indicates an expected call of UsesCSVTestData.
+func (mr *MockBackendMockRecorder) UsesCSVTestData() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UsesCSVTestData", reflect.TypeOf((*MockBackend)(nil).UsesCSVTestData))
 }
 
 // SyncStatus mocks base method.

--- a/pkg/backends/resources.go
+++ b/pkg/backends/resources.go
@@ -8,9 +8,9 @@ import (
 const (
 	// LoadTestLabel label used for test resources
 	LoadTestLabel = "loadtest"
-	// loadTestData is the prefix for the names of the testdata files inside the configmap/filesystem
+	// LoadTestData is the prefix for the names of the testdata files inside the configmap/filesystem
 	LoadTestData = LoadTestLabel + "-testdata"
-	// loadTestScript is the name of the testfile script inside the configmap/filesystem
+	// LoadTestScript is the name of the testfile script inside the configmap/filesystem
 	LoadTestScript = LoadTestLabel + "-script"
 )
 

--- a/pkg/backends/resources.go
+++ b/pkg/backends/resources.go
@@ -5,6 +5,15 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
+const (
+	// LoadTestLabel label used for test resources
+	LoadTestLabel = "loadtest"
+	// loadTestData is the prefix for the names of the testdata files inside the configmap/filesystem
+	LoadTestData = LoadTestLabel + "-testdata"
+	// loadTestScript is the name of the testfile script inside the configmap/filesystem
+	LoadTestScript = LoadTestLabel + "-script"
+)
+
 // Resources contains resources limits/requests
 type Resources struct {
 	CPULimits      string

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -95,10 +95,10 @@ func TestShouldSplitCSVTestData(t *testing.T) {
 	assert.Equal(t, 5, len(cms.Items))
 
 	assert.Equal(t, tdNames[0], cms.Items[0].Name)
-	assert.Equal(t, []byte("first line\n"), cms.Items[0].BinaryData[backends.LoadTestData])
+	assert.Equal(t, gzipped([]byte("first line\n")), cms.Items[0].BinaryData[backends.LoadTestData])
 
 	assert.Equal(t, tdNames[2], cms.Items[2].Name)
-	assert.Equal(t, []byte("third line\n"), cms.Items[2].BinaryData[backends.LoadTestData])
+	assert.Equal(t, gzipped([]byte("third line\n")), cms.Items[2].BinaryData[backends.LoadTestData])
 
 	assert.Equal(t, tfName, cms.Items[4].Name)
 }

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1,0 +1,102 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hellofresh/kangal/pkg/backends"
+	"github.com/hellofresh/kangal/pkg/backends/fake"
+	"github.com/hellofresh/kangal/pkg/backends/jmeter"
+	loadTestV1 "github.com/hellofresh/kangal/pkg/kubernetes/apis/loadtest/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestShouldCreateConfigMaps(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	kubeClient := k8sfake.NewSimpleClientset()
+	logger := zaptest.NewLogger(t)
+	c := &Controller{
+		kubeClientSet: kubeClient,
+		logger:        logger,
+	}
+
+	namespace := "test"
+	distributedPods := int32(4)
+
+	loadTest := &loadTestV1.LoadTest{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name: "loadtest-name",
+		},
+		Spec: loadTestV1.LoadTestSpec{
+			DistributedPods: &distributedPods,
+			TestFile:        []byte("test"),
+			TestData:        []byte("data"),
+		},
+		Status: loadTestV1.LoadTestStatus{
+			Namespace: namespace,
+		},
+	}
+
+	tfName, tdNames, _ := c.checkOrCreateConfigMaps(ctx, &fake.Backend{}, loadTest)
+
+	assert.Equal(t, 1, len(tdNames))
+
+	cms, err := kubeClient.CoreV1().ConfigMaps(namespace).List(ctx, metaV1.ListOptions{})
+	require.NoError(t, err, "Error when listing config maps")
+	assert.Equal(t, 2, len(cms.Items))
+	assert.Equal(t, tdNames[0], cms.Items[0].Name)
+	assert.Equal(t, []byte("data"), cms.Items[0].BinaryData[backends.LoadTestData])
+	assert.Equal(t, tfName, cms.Items[1].Name)
+	assert.Equal(t, []byte("test"), cms.Items[1].BinaryData[backends.LoadTestScript])
+}
+
+func TestShouldSplitCSVTestData(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	kubeClient := k8sfake.NewSimpleClientset()
+	logger := zaptest.NewLogger(t)
+	c := &Controller{
+		kubeClientSet: kubeClient,
+		logger:        logger,
+	}
+
+	namespace := "test"
+	distributedPods := int32(4)
+
+	loadTest := &loadTestV1.LoadTest{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name: "loadtest-name",
+		},
+		Spec: loadTestV1.LoadTestSpec{
+			DistributedPods: &distributedPods,
+			TestFile:        []byte("test"),
+			TestData:        []byte("first line\nsecond line\nthird line\nfourth line"),
+		},
+		Status: loadTestV1.LoadTestStatus{
+			Namespace: namespace,
+		},
+	}
+
+	tfName, tdNames, _ := c.checkOrCreateConfigMaps(ctx, &jmeter.Backend{}, loadTest)
+
+	assert.Equal(t, 4, len(tdNames))
+
+	cms, err := kubeClient.CoreV1().ConfigMaps(namespace).List(ctx, metaV1.ListOptions{})
+	require.NoError(t, err, "Error when listing config maps")
+	assert.Equal(t, 5, len(cms.Items))
+
+	assert.Equal(t, tdNames[0], cms.Items[0].Name)
+	assert.Equal(t, []byte("first line\n"), cms.Items[0].BinaryData[backends.LoadTestData])
+
+	assert.Equal(t, tdNames[2], cms.Items[2].Name)
+	assert.Equal(t, []byte("third line\n"), cms.Items[2].BinaryData[backends.LoadTestData])
+
+	assert.Equal(t, tfName, cms.Items[4].Name)
+}

--- a/pkg/controller/loadtest.go
+++ b/pkg/controller/loadtest.go
@@ -489,7 +489,7 @@ func (c *Controller) updateLoadTestStatus(ctx context.Context, key string, loadT
 	}
 }
 
-// checkOrCreateNamespace checks if a namespace has been created and if not deletes it
+// checkOrCreateNamespace checks if a namespace has been created and if not creates it
 func (c *Controller) checkOrCreateNamespace(ctx context.Context, loadtest *loadTestV1.LoadTest) error {
 	if loadtest.Status.Namespace != "" {
 		return nil

--- a/pkg/controller/loadtest.go
+++ b/pkg/controller/loadtest.go
@@ -700,8 +700,16 @@ func NewTestdataConfigMaps(cfgName, filename string, n int, content []byte, logg
 
 	for i := 0; i < n; i++ {
 		byteWriter := new(bytes.Buffer)
-		csvWriter := csv.NewWriter(byteWriter)
+		gzipWriter := gzip.NewWriter(byteWriter)
+		csvWriter := csv.NewWriter(gzipWriter)
 		if err := csvWriter.WriteAll(chunks[i]); err != nil {
+			return nil, err
+		}
+
+		if err := gzipWriter.Flush(); err != nil {
+			return nil, err
+		}
+		if err := gzipWriter.Close(); err != nil {
 			return nil, err
 		}
 

--- a/pkg/controller/loadtest_test.go
+++ b/pkg/controller/loadtest_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	batchV1 "k8s.io/api/batch/v1"
+	coreV1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	loadTestV1 "github.com/hellofresh/kangal/pkg/kubernetes/apis/loadtest/v1"
@@ -97,6 +98,68 @@ func TestShouldDeleteLoadtest(t *testing.T) {
 			timedout := checkLoadTestLifeTimeExceeded(&test.LoadTest, test.Threshold)
 			assert.Equal(t, test.ExpectedResponse, timedout)
 
+		})
+	}
+}
+
+func TestNewFileConfigMap(t *testing.T) {
+	for _, ti := range []struct {
+		tag         string
+		cfgName     string
+		filename    string
+		content     []byte
+		expected    *coreV1.ConfigMap
+		expectError bool
+	}{
+		{
+			tag:         "no configmap name",
+			cfgName:     "",
+			filename:    "file",
+			content:     []byte("file content"),
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			tag:         "no filename",
+			cfgName:     "test",
+			filename:    "",
+			content:     []byte("file content"),
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			tag:         "no content",
+			cfgName:     "test",
+			filename:    "file",
+			content:     []byte{},
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			tag:      "valid args",
+			cfgName:  "test",
+			filename: "file",
+			content:  []byte("file content"),
+			expected: &coreV1.ConfigMap{
+				ObjectMeta: metaV1.ObjectMeta{
+					Name: "test",
+				},
+				BinaryData: map[string][]byte{
+					"file": []byte("file content"),
+				},
+			},
+			expectError: false,
+		},
+	} {
+		t.Run(ti.tag, func(t *testing.T) {
+			cfgmap, err := NewFileConfigMap(ti.cfgName, ti.filename, ti.content)
+
+			assert.Equal(t, ti.expected, cfgmap)
+			if ti.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }

--- a/pkg/proxy/request.go
+++ b/pkg/proxy/request.go
@@ -145,10 +145,12 @@ func fromHTTPRequestToLoadTestSpec(r *http.Request, logger *zap.Logger, allowedC
 		return apisLoadTestV1.LoadTestSpec{}, fmt.Errorf("error getting %s from request: %w", testData, err)
 	}
 
-	td, err = gzipped(td)
-	if err != nil {
-		logger.Debug("Could not gzip testdata", zap.String("file", testData), zap.Error(err))
-		return apisLoadTestV1.LoadTestSpec{}, fmt.Errorf("error gzipping request testdata: %w", err)
+	if len(td) > 0 {
+		td, err = gzipped(td)
+		if err != nil {
+			logger.Debug("Could not gzip testdata", zap.String("file", testData), zap.Error(err))
+			return apisLoadTestV1.LoadTestSpec{}, fmt.Errorf("error gzipping request testdata: %w", err)
+		}
 	}
 
 	ev, err := getEnvVars(r)


### PR DESCRIPTION
This PR enables the test data compression available in JMeter for all other backends. This is achieved by compressing testdata prior to storing LoadTest objects _outside of_ the backend (i.e. should work for all future backends). It also externalizes the CSV splitting behaviour found in JMeter. To achieve that a new ` UsesCSVTestData`  property has been added to the backend interface.

_Rebased copy of #253 just because I couldn't figure out how to reopen it_

Since the data is now gzipped, all testdata-using backends now need init containers to inflate back the data and make it available for the main container.

### Caveat 1: Generated mock

I couldn't figure out the right `mockgen`  incantation that would generate a conforming `mock.go`  and ended up changing it manually. Just point me in the right direction and I'll fix that.

### Caveat 2: CSV splitting

One may notice that I started assuming that k6 also used CSV test data and progressed to port CSV splitting for it. I later realised that JMeter is currently the only backend that supports CSV test data exclusively. K6 and locust also support it, but just because they support any file type opaquely.

Maybe CSV splitting is just making the common code more complex. Just let me know if you think it really belongs inside the JMeter backend and I'll patch the PR accordingly.

Fixes #229 

_As always, shoutout to @amandahla, author of the [original gzip PR](https://github.com/hellofresh/kangal/pull/177) for the JMeter backend._