### PR TITLE
Replace deprecated default k6 image

### DIFF
--- a/charts/kangal/Chart.yaml
+++ b/charts/kangal/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - performance tests
   - tests runner
 name: kangal
-version: 2.2.5
+version: 2.2.6
 home: https://github.com/hellofresh/kangal
 icon: https://raw.githubusercontent.com/hellofresh/kangal/master/logo.svg
 maintainers:

--- a/charts/kangal/README.md
+++ b/charts/kangal/README.md
@@ -85,7 +85,7 @@ The following table lists the common configurable parameters for `Kangal` chart:
 | `configMap.JMETER_WORKER_IMAGE_TAG`  | Tag of the JMeter worker docker image                                                               | `latest`                          |
 | `configMap.LOCUST_IMAGE_NAME`        | Default Locust docker image name/repository if none is provided when creating a new loadtest        | `locustio/locust`                 |
 | `configMap.LOCUST_IMAGE_TAG`         | Tag of the Locust docker image                                                                      | `1.3.0`                           |
-| `configMap.K6_IMAGE_NAME`            | Default k6 docker image name/repository if none is provided when creating a new loadtest            | `loadimpact/k6`                   |
+| `configMap.K6_IMAGE_NAME`            | Default k6 docker image name/repository if none is provided when creating a new loadtest            | `grafana/k6`                   |
 | `configMap.K6_IMAGE_TAG`             | Tag of the k6 docker image above                                                                    | `latest`                          |
 
 Deployment specific configurations:

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -78,7 +78,7 @@
 ### k6
 | Parameter            | Description     | Default         |
 |----------------------|-----------------|-----------------|
-| `K6_IMAGE_NAME`      | K6 image name   | `loadimpact/k6` |
+| `K6_IMAGE_NAME`      | K6 image name   | `grafana/k6` |
 | `K6_IMAGE_TAG`       | K6 image tag    | `latest`        |
 | `K6_CPU_LIMITS`      | CPU limits      |                 |
 | `K6_CPU_REQUESTS`    | CPU requests    |                 |

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ Currently, there are the following load generator types implemented for Kangal:
 - **JMeter** - Kangal creates JMeter load test environments based on [hellofresh/kangal-jmeter](https://github.com/hellofresh/kangal-jmeter) docker image.
 - **Locust** - Kangal creates Locust load test environments based on official docker image [locustio/locust](https://hub.docker.com/r/locustio/locust).
 - **`ghz`** - Kangal creates `ghz` load test environments using [hellofresh/kangal-ghz](https://github.com/hellofresh/kangal-ghz) docker image.
-- **k6** - Kangal creates k6 load test environments based on official docker image [loadimpact/k6](https://hub.docker.com/r/loadimpact/k6).
+- **k6** - Kangal creates k6 load test environments based on official docker image [grafana/k6](https://hub.docker.com/r/grafana/k6).
 
 ### JMeter
 JMeter is a powerful tool which can be used for different performance testing tasks.

--- a/docs/k6/README.md
+++ b/docs/k6/README.md
@@ -8,7 +8,7 @@
 - [Logs](#logs)
 - [Using k6 extensions](#using-k6-extensions)
 
-K6 is one of the load generators implemented in Kangal. It uses the official docker image [loadimpact/k6](https://hub.docker.com/r/loadimpact/k6).
+K6 is one of the load generators implemented in Kangal. It uses the official docker image [grafana/k6](https://hub.docker.com/r/grafana/k6).
 
 Kangal requires a JavaScript testfile describing the test.
 
@@ -152,7 +152,7 @@ curl -X GET http://${KANGAL_PROXY_ADDRESS}/load-test/loadtest-name/logs/0
 
 ## Using k6 extensions
 
-By default, kangal will use loadimpact/k6:latest as the container image for the test jobs. If you want to use extensions built with **xk6** you'll need to create your own image. Example:
+By default, kangal will use grafana/k6:latest as the container image for the test jobs. If you want to use extensions built with **xk6** you'll need to create your own image. Example:
 
 ```Dockerfile
 # Build the k6 binary with the extension
@@ -162,6 +162,6 @@ RUN go install go.k6.io/xk6/cmd/xk6@latest
 RUN xk6 build --output /k6 --with github.com/walterwanderley/xk6-stomp@latest
 
 # Use the official base image and override the k6 binary
-FROM loadimpact/k6:latest
+FROM grafana/k6:latest
 COPY --from=builder /k6 /usr/bin/k6
 ```

--- a/pkg/backends/k6/backend.go
+++ b/pkg/backends/k6/backend.go
@@ -23,7 +23,7 @@ var (
 )
 
 const (
-	defaultImageName = "loadimpact/k6"
+	defaultImageName = "grafana/k6"
 	defaultImageTag  = "latest"
 )
 


### PR DESCRIPTION
This PR replace the deprecated k6 image default image used.

```
loadtest-job-0-lf2l6 k6 +------------------------------------------------------------------------------+
loadtest-job-0-lf2l6 k6 | WARNING: The loadimpact/k6 Docker image has been replaced by grafana/k6.     |
loadtest-job-0-lf2l6 k6 |          THIS IMAGE IS DEPRECATED and its support will be discontinued after |
loadtest-job-0-lf2l6 k6 |          Dec 31, 2023. Please update your scripts to use grafana/k6 to       |
loadtest-job-0-lf2l6 k6 |          continue using the latest version of k6.                            |
loadtest-job-0-lf2l6 k6 +------------------------------------------------------------------------------+
```