### PR TITLE
Ensure all images can be modified with environment variables

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -49,13 +49,15 @@
 | `RCLONE_CONFIG_REMOTECUSTOMDATA_SECRET_ACCESS_KEY` | [Rclone](https://rclone.org/) environment variable for secret access key |                                   |
 | `RCLONE_CONFIG_REMOTECUSTOMDATA_REGION`            | [Rclone](https://rclone.org/) environment variable for region            |                                   |
 | `RCLONE_CONFIG_REMOTECUSTOMDATA_ENDPOINT`          | [Rclone](https://rclone.org/) environment variable for endpoint          |                                   |
+| `JMETER_TESTDATA_DECOMPRESS_IMAGE`                 | Image used to decompress the testdata.                                   | `alpine:latest`                   |
+| `JMETER_WORKER_REMOTE_CUSTOM_DATA_IMAGE`           | Image used to sync remote custom data.                                   | `rclone/rclone:latest`            |
 
 ### Locust
 | Parameter                       | Description                 | Default           |
 |---------------------------------|-----------------------------|-------------------|
 | `LOCUST_IMAGE`                  | Locust image                |                   |
-| `LOCUST_IMAGE_NAME`             | Locust image name           |                   |
-| `LOCUST_IMAGE_TAG`              | Locust image tag            |                   |
+| `LOCUST_IMAGE_NAME`             | Locust image name           | `locustio/locust` |
+| `LOCUST_IMAGE_TAG`              | Locust image tag            | `latest`          |
 | `LOCUST_MASTER_CPU_LIMITS`      | Master container CPU limits |                   |
 | `LOCUST_MASTER_CPU_REQUESTS`    | Master CPU requests         |                   |
 | `LOCUST_MASTER_MEMORY_LIMITS`   | Master memory limits        |                   |

--- a/pkg/backends/ghz/backend.go
+++ b/pkg/backends/ghz/backend.go
@@ -22,11 +22,6 @@ var (
 	ErrRequireTestFile = errors.New("LoadTest TestFile is required")
 )
 
-const (
-	defaultImageName = "hellofresh/kangal-ghz"
-	defaultImageTag  = "latest"
-)
-
 func init() {
 	backends.Register(&Backend{})
 }
@@ -58,10 +53,6 @@ func (b *Backend) GetEnvConfig() interface{} {
 
 // SetDefaults must set default values
 func (b *Backend) SetDefaults() {
-	if b.config.ImageName == "" || b.config.ImageTag == "" {
-		b.config.ImageName = defaultImageName
-		b.config.ImageTag = defaultImageTag
-	}
 	b.image = loadTestV1.ImageDetails{
 		Image: b.config.ImageName,
 		Tag:   b.config.ImageTag,

--- a/pkg/backends/ghz/config.go
+++ b/pkg/backends/ghz/config.go
@@ -2,9 +2,8 @@ package ghz
 
 // Config specific to ghz backend
 type Config struct {
-	Image          string `envconfig:"GHZ_IMAGE"`
-	ImageName      string `envconfig:"GHZ_IMAGE_NAME"`
-	ImageTag       string `envconfig:"GHZ_IMAGE_TAG"`
+	ImageName      string `envconfig:"GHZ_IMAGE_NAME" default:"hellofresh/kangal-ghz"`
+	ImageTag       string `envconfig:"GHZ_IMAGE_TAG" default:"latest"`
 	CPULimits      string `envconfig:"GHZ_CPU_LIMITS"`
 	CPURequests    string `envconfig:"GHZ_CPU_REQUESTS"`
 	MemoryLimits   string `envconfig:"GHZ_MEMORY_LIMITS"`

--- a/pkg/backends/jmeter/backend.go
+++ b/pkg/backends/jmeter/backend.go
@@ -73,20 +73,6 @@ func (b *Backend) GetEnvConfig() interface{} {
 
 // SetDefaults must set default values
 func (b *Backend) SetDefaults() {
-	if b.config.MasterImageName == "" {
-		b.config.MasterImageName = defaultMasterImageName
-	}
-	if b.config.MasterImageTag == "" {
-		b.config.MasterImageTag = defaultMasterImageTag
-	}
-
-	if b.config.WorkerImageName == "" {
-		b.config.WorkerImageName = defaultWorkerImageName
-	}
-	if b.config.WorkerImageTag == "" {
-		b.config.WorkerImageTag = defaultWorkerImageTag
-	}
-
 	b.masterConfig = loadTestV1.ImageDetails{
 		Image: b.config.MasterImageName,
 		Tag:   b.config.MasterImageTag,

--- a/pkg/backends/jmeter/backend_test.go
+++ b/pkg/backends/jmeter/backend_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kelseyhightower/envconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
@@ -237,8 +238,10 @@ func TestSetDefaults(t *testing.T) {
 	})
 
 	t.Run("No default", func(t *testing.T) {
+		cfg := Config{}
+		envconfig.MustProcess("", &cfg)
 		jmeter := &Backend{
-			config: &Config{},
+			config: &cfg,
 		}
 		jmeter.SetDefaults()
 

--- a/pkg/backends/jmeter/config.go
+++ b/pkg/backends/jmeter/config.go
@@ -6,17 +6,19 @@ import (
 
 // Config specific to JMeter backend
 type Config struct {
-	MasterImageName        string        `envconfig:"JMETER_MASTER_IMAGE_NAME"`
-	MasterImageTag         string        `envconfig:"JMETER_MASTER_IMAGE_TAG"`
-	MasterCPULimits        string        `envconfig:"JMETER_MASTER_CPU_LIMITS"`
-	MasterCPURequests      string        `envconfig:"JMETER_MASTER_CPU_REQUESTS"`
-	MasterMemoryLimits     string        `envconfig:"JMETER_MASTER_MEMORY_LIMITS"`
-	MasterMemoryRequests   string        `envconfig:"JMETER_MASTER_MEMORY_REQUESTS"`
-	WorkerImageName        string        `envconfig:"JMETER_WORKER_IMAGE_NAME"`
-	WorkerImageTag         string        `envconfig:"JMETER_WORKER_IMAGE_TAG"`
-	WorkerCPULimits        string        `envconfig:"JMETER_WORKER_CPU_LIMITS"`
-	WorkerCPURequests      string        `envconfig:"JMETER_WORKER_CPU_REQUESTS"`
-	WorkerMemoryLimits     string        `envconfig:"JMETER_WORKER_MEMORY_LIMITS"`
-	WorkerMemoryRequests   string        `envconfig:"JMETER_WORKER_MEMORY_REQUESTS"`
-	WaitForResourceTimeout time.Duration `envconfig:"WAIT_FOR_RESOURCE_TIMEOUT" default:"30s"`
+	MasterImageName         string        `envconfig:"JMETER_MASTER_IMAGE_NAME" default:"hellofresh/kangal-jmeter-master"`
+	MasterImageTag          string        `envconfig:"JMETER_MASTER_IMAGE_TAG" default:"latest"`
+	MasterCPULimits         string        `envconfig:"JMETER_MASTER_CPU_LIMITS"`
+	MasterCPURequests       string        `envconfig:"JMETER_MASTER_CPU_REQUESTS"`
+	MasterMemoryLimits      string        `envconfig:"JMETER_MASTER_MEMORY_LIMITS"`
+	MasterMemoryRequests    string        `envconfig:"JMETER_MASTER_MEMORY_REQUESTS"`
+	WorkerImageName         string        `envconfig:"JMETER_WORKER_IMAGE_NAME" default:"hellofresh/kangal-jmeter-worker"`
+	WorkerImageTag          string        `envconfig:"JMETER_WORKER_IMAGE_TAG" default:"latest"`
+	WorkerCPULimits         string        `envconfig:"JMETER_WORKER_CPU_LIMITS"`
+	WorkerCPURequests       string        `envconfig:"JMETER_WORKER_CPU_REQUESTS"`
+	WorkerMemoryLimits      string        `envconfig:"JMETER_WORKER_MEMORY_LIMITS"`
+	WorkerMemoryRequests    string        `envconfig:"JMETER_WORKER_MEMORY_REQUESTS"`
+	TestDataDecompressImage string        `envconfig:"JMETER_TESTDATA_DECOMPRESS_IMAGE" default:"alpine:latest"`
+	RemoteCustomDataImage   string        `envconfig:"JMETER_WORKER_REMOTE_CUSTOM_DATA_IMAGE" default:"rclone/rclone:latest"`
+	WaitForResourceTimeout  time.Duration `envconfig:"WAIT_FOR_RESOURCE_TIMEOUT" default:"30s"`
 }

--- a/pkg/backends/jmeter/resources.go
+++ b/pkg/backends/jmeter/resources.go
@@ -239,7 +239,7 @@ func (b *Backend) NewPod(loadTest loadTestV1.LoadTest, i int, configMap *coreV1.
 			InitContainers: []coreV1.Container{
 				{
 					Name:    "convert-data-back-to-csv",
-					Image:   "alpine:latest",
+					Image:   b.config.TestDataDecompressImage,
 					Command: []string{"/bin/sh"},
 					Args:    []string{"-c", "(ls /testdatatmp/testdata.csv.gz >/dev/null 2>&1 && cat /testdatatmp/testdata.csv.gz |base64 -d|zcat > /testdata/testdata.csv) || echo \"no testdata.csv.gz file\""},
 					VolumeMounts: []coreV1.VolumeMount{
@@ -326,7 +326,7 @@ func (b *Backend) NewPod(loadTest loadTestV1.LoadTest, i int, configMap *coreV1.
 		pod.Spec.InitContainers = []coreV1.Container{
 			{
 				Name:    "get-data",
-				Image:   "rclone/rclone:latest",
+				Image:   b.config.RemoteCustomDataImage,
 				Command: []string{"/bin/sh"},
 				Args:    []string{"-c", "/usr/local/bin/rclone sync remotecustomdata:$(JMETER_WORKER_REMOTE_CUSTOM_DATA_BUCKET) /customdata || echo \"rsync failed\""},
 				VolumeMounts: []coreV1.VolumeMount{

--- a/pkg/backends/jmeter/resources_test.go
+++ b/pkg/backends/jmeter/resources_test.go
@@ -133,6 +133,7 @@ func TestPodResourceConfiguration(t *testing.T) {
 			MemoryLimits:   "300Mi",
 			MemoryRequests: "400Mi",
 		},
+		config: &Config{},
 	}
 
 	masterJob := c.NewJMeterMasterJob(lt, "http://kangal-proxy.local/load-test/loadtest-name/report", map[string]string{"": ""})

--- a/pkg/backends/k6/backend.go
+++ b/pkg/backends/k6/backend.go
@@ -22,11 +22,6 @@ var (
 	ErrRequireTestFile = errors.New("LoadTest TestFile is required")
 )
 
-const (
-	defaultImageName = "grafana/k6"
-	defaultImageTag  = "latest"
-)
-
 func init() {
 	backends.Register(&Backend{})
 }
@@ -58,10 +53,6 @@ func (b *Backend) GetEnvConfig() interface{} {
 
 // SetDefaults must set default values
 func (b *Backend) SetDefaults() {
-	if b.config.ImageName == "" || b.config.ImageTag == "" {
-		b.config.ImageName = defaultImageName
-		b.config.ImageTag = defaultImageTag
-	}
 	b.image = loadTestV1.ImageDetails{
 		Image: b.config.ImageName,
 		Tag:   b.config.ImageTag,

--- a/pkg/backends/k6/config.go
+++ b/pkg/backends/k6/config.go
@@ -2,9 +2,8 @@ package k6
 
 // Config specific to k6 backend
 type Config struct {
-	Image          string `envconfig:"K6_IMAGE"`
-	ImageName      string `envconfig:"K6_IMAGE_NAME"`
-	ImageTag       string `envconfig:"K6_IMAGE_TAG"`
+	ImageName      string `envconfig:"K6_IMAGE_NAME" default:"grafana/k6"`
+	ImageTag       string `envconfig:"K6_IMAGE_TAG" default:"latest"`
 	CPULimits      string `envconfig:"K6_CPU_LIMITS"`
 	CPURequests    string `envconfig:"K6_CPU_REQUESTS"`
 	MemoryLimits   string `envconfig:"K6_MEMORY_LIMITS"`

--- a/pkg/backends/locust/backend.go
+++ b/pkg/backends/locust/backend.go
@@ -16,11 +16,6 @@ import (
 )
 
 var (
-	defaultImageName = "locustio/locust"
-	defaultImageTag  = "latest"
-)
-
-var (
 	// ErrRequireMinOneDistributedPod spec requires 1 or more DistributedPods
 	ErrRequireMinOneDistributedPod = errors.New("LoadTest must specify 1 or more DistributedPods")
 	// ErrRequireTestFile the TestFile filed is required to not be an empty string
@@ -60,13 +55,8 @@ func (b *Backend) GetEnvConfig() interface{} {
 // SetDefaults must set default values
 func (b *Backend) SetDefaults() {
 	// this ensure backward compatibility
-	if b.config.ImageName == "" && b.config.Image != "" {
+	if b.config.Image != "" {
 		b.config.ImageName = b.config.Image
-	}
-
-	if b.config.ImageName == "" || b.config.ImageTag == "" {
-		b.config.ImageName = defaultImageName
-		b.config.ImageTag = defaultImageTag
 	}
 
 	b.image = loadTestV1.ImageDetails{

--- a/pkg/backends/locust/backend_test.go
+++ b/pkg/backends/locust/backend_test.go
@@ -305,7 +305,7 @@ func TestTransformLoadTestSpec(t *testing.T) {
 				TestFile:        []byte("something in the file"),
 				EnvVars:         map[string]string{"my-key": "my-value"},
 				TargetURL:       "http://my-app.my-domain.com",
-				MasterConfig:    loadTestV1.ImageDetails{Image: defaultImageName, Tag: defaultImageTag},
+				MasterConfig:    loadTestV1.ImageDetails{Image: "locustio/locust", Tag: "latest"},
 			},
 			wantErr: false,
 		},

--- a/pkg/backends/locust/backend_test.go
+++ b/pkg/backends/locust/backend_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kelseyhightower/envconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
@@ -338,8 +339,10 @@ func TestTransformLoadTestSpec(t *testing.T) {
 				Duration:        tt.args.duration,
 			}
 
+			cfg := Config{}
+			envconfig.MustProcess("", &cfg)
 			b := Backend{
-				config: &Config{},
+				config: &cfg,
 			}
 			b.SetDefaults()
 

--- a/pkg/backends/locust/config.go
+++ b/pkg/backends/locust/config.go
@@ -3,8 +3,8 @@ package locust
 // Config specific to Locust backend
 type Config struct {
 	Image                string `envconfig:"LOCUST_IMAGE"`
-	ImageName            string `envconfig:"LOCUST_IMAGE_NAME"`
-	ImageTag             string `envconfig:"LOCUST_IMAGE_TAG"`
+	ImageName            string `envconfig:"LOCUST_IMAGE_NAME" default:"locustio/locust"`
+	ImageTag             string `envconfig:"LOCUST_IMAGE_TAG" default:"latest"`
 	MasterCPULimits      string `envconfig:"LOCUST_MASTER_CPU_LIMITS"`
 	MasterCPURequests    string `envconfig:"LOCUST_MASTER_CPU_REQUESTS"`
 	MasterMemoryLimits   string `envconfig:"LOCUST_MASTER_MEMORY_LIMITS"`


### PR DESCRIPTION
Use `envconfig` to set defaults and ensure all images used can be defined with environment variables