### PR TITLE
Don't allow different image tags for JMeter master and worker Docker images

### DIFF
--- a/charts/kangal/Chart.yaml
+++ b/charts/kangal/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - performance tests
   - tests runner
 name: kangal
-version: 2.3.0
+version: 2.4.0
 home: https://github.com/hellofresh/kangal
 icon: https://raw.githubusercontent.com/hellofresh/kangal/master/logo.svg
 maintainers:

--- a/charts/kangal/README.md
+++ b/charts/kangal/README.md
@@ -80,12 +80,11 @@ The following table lists the common configurable parameters for `Kangal` chart:
 | `configMap.GHZ_IMAGE_NAME`           | Default ghz docker image name/repository if none is provided when creating a new loadtest           | `hellofresh/kangal-ghz`           |
 | `configMap.GHZ_IMAGE_TAG`            | Tag of the ghz docker image                                                                         | `latest`                          |
 | `configMap.JMETER_MASTER_IMAGE_NAME` | Default JMeter master docker image name/repository if none is provided when creating a new loadtest | `hellofresh/kangal-jmeter-master` |
-| `configMap.JMETER_MASTER_IMAGE_TAG`  | Tag of the JMeter master docker image                                                               | `latest`                          |
 | `configMap.JMETER_WORKER_IMAGE_NAME` | Default JMeter worker docker image name/repository if none is provided when creating a new loadtest | `hellofresh/kangal-jmeter-worker` |
-| `configMap.JMETER_WORKER_IMAGE_TAG`  | Tag of the JMeter worker docker image                                                               | `latest`                          |
+| `configMap.JMETER_IMAGE_TAG`         | Tag of the JMeter docker images                                                                     | `latest`                          |
 | `configMap.LOCUST_IMAGE_NAME`        | Default Locust docker image name/repository if none is provided when creating a new loadtest        | `locustio/locust`                 |
 | `configMap.LOCUST_IMAGE_TAG`         | Tag of the Locust docker image                                                                      | `1.3.0`                           |
-| `configMap.K6_IMAGE_NAME`            | Default k6 docker image name/repository if none is provided when creating a new loadtest            | `grafana/k6`                   |
+| `configMap.K6_IMAGE_NAME`            | Default k6 docker image name/repository if none is provided when creating a new loadtest            | `grafana/k6`                      |
 | `configMap.K6_IMAGE_TAG`             | Tag of the k6 docker image above                                                                    | `latest`                          |
 
 Deployment specific configurations:

--- a/charts/kangal/values.yaml
+++ b/charts/kangal/values.yaml
@@ -190,9 +190,8 @@ configMap:
   GHZ_IMAGE_NAME: hellofresh/kangal-ghz
   GHZ_IMAGE_TAG: latest
   JMETER_MASTER_IMAGE_NAME: hellofresh/kangal-jmeter-master
-  JMETER_MASTER_IMAGE_TAG: latest
   JMETER_WORKER_IMAGE_NAME: hellofresh/kangal-jmeter-worker
-  JMETER_WORKER_IMAGE_TAG: latest
+  JMETER_IMAGE_TAG: latest
   LOCUST_IMAGE_NAME: locustio/locust
   LOCUST_IMAGE_TAG: "1.3.0"
 

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -28,14 +28,13 @@
 ### JMeter
 | Parameter                                          | Description                                                              | Default                           |
 |----------------------------------------------------|--------------------------------------------------------------------------|-----------------------------------|
+| `JMETER_IMAGE_TAG`                                 | Tag of the JMeter images                                                 | `latest`                          |
 | `JMETER_MASTER_IMAGE_NAME`                         | JMeter master image name/repository                                      | `hellofresh/kangal-jmeter-master` |
-| `JMETER_MASTER_IMAGE_TAG`                          | Tag of the JMeter master image above                                     | `latest`                          |
 | `JMETER_MASTER_CPU_LIMIT`                          | Master CPU limit                                                         |                                   |
 | `JMETER_MASTER_CPU_REQUESTS`                       | Master CPU requests                                                      |                                   |
 | `JMETER_MASTER_MEMORY_LIMITS`                      | Master memory limits                                                     |                                   |
 | `JMETER_MASTER_MEMORY_REQUESTS`                    | Master memory requests                                                   |                                   |
 | `JMETER_WORKER_IMAGE_NAME`                         | JMeter worker image name/repository                                      | `hellofresh/kangal-jmeter-worker` |
-| `JMETER_WORKER_IMAGE_TAG`                          | Tag of the JMeter worker image above                                     | `latest`                          |
 | `JMETER_WORKER_CPU_LIMITS`                         | Worker container CPU limits                                              |                                   |
 | `JMETER_WORKER_CPU_REQUESTS`                       | Worker CPU requests                                                      |                                   |
 | `JMETER_WORKER_MEMORY_LIMITS`                      | Worker memory limits                                                     |                                   |
@@ -43,7 +42,7 @@
 | `JMETER_WORKER_REMOTE_CUSTOM_DATA_ENABLED`         | Enable remote custom data                                                | `false`                           |
 | `JMETER_WORKER_REMOTE_CUSTOM_DATA_BUCKET`          | The name of the bucket where remote data is                              |                                   |
 | `JMETER_WORKER_REMOTE_CUSTOM_DATA_VOLUME_SIZE`     | Volume size used by download remote data                                 | `1Gi`                             |
-| `JMETER_WORKER_REMOTE_CUSTOM_DATA_STORAGECLASS`    | StorageClass used for remote data PVC (ReadWriteMany required)       | kubernetes environment default |
+| `JMETER_WORKER_REMOTE_CUSTOM_DATA_STORAGECLASS`    | StorageClass used for remote data PVC (ReadWriteMany required)           | kubernetes environment default    |
 | `RCLONE_CONFIG_REMOTECUSTOMDATA_TYPE`              | [Rclone](https://rclone.org/) environment variable for type              |                                   |
 | `RCLONE_CONFIG_REMOTECUSTOMDATA_ACCESS_KEY_ID`     | [Rclone](https://rclone.org/) environment variable for access key ID     |                                   |
 | `RCLONE_CONFIG_REMOTECUSTOMDATA_SECRET_ACCESS_KEY` | [Rclone](https://rclone.org/) environment variable for secret access key |                                   |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -29,11 +29,12 @@ If you want to use a custom docker image for your load tests, as describe here, 
 - you have `ALLOWED_CUSTOM_IMAGES=true` environment variable set for your Kangal Proxy deployment. If not - no custom images are allowed
 
 The default images and tags are specified as constants in `/pkg/backends/your_backend_name/backend.go` files. You can find
-an example of K6 [here](https://github.com/hellofresh/kangal/blob/master/pkg/backends/k6/backend.go#L26).
+an example of K6 [here](https://github.com/hellofresh/kangal/blob/master/pkg/backends/k6/config.go#L5).
 
 If you want to redefine the default images and tags - use deployment [environment variables](https://github.com/hellofresh/kangal/blob/master/docs/env-vars.md#backend-specific-configuration) for Proxy and Controller.
 
-- `JMETER_MASTER_IMAGE_NAME` and `JMETER_MASTER_IMAGE_TAG` for JMeter master pods and `JMETER_WORKER_IMAGE_NAME` and `JMETER_WORKER_IMAGE_TAG` for JMeter worker pods
+- `JMETER_MASTER_IMAGE_NAME` for JMeter master pods and `JMETER_WORKER_IMAGE_NAME` for JMeter worker pods
+- `JMETER_IMAGE_TAG` for the Docker image tag for JMeter. The tag is the same for master and worker pods, to avoid incompatibility of different JMeter version.
 - `LOCUST_IMAGE_NAME` and `LOCUST_IMAGE_TAG` for Locust
 - `GHZ_IMAGE_NAME` and `GHZ_IMAGE_TAG` for Ghz
 - `K6_IMAGE_NAME` and `K6_IMAGE_TAG` for K6

--- a/pkg/backends/jmeter/backend_test.go
+++ b/pkg/backends/jmeter/backend_test.go
@@ -140,11 +140,11 @@ func TestSync(t *testing.T) {
 			DistributedPods: &distributedPodsNum,
 			MasterConfig: loadTestV1.ImageDetails{
 				Image: defaultMasterImageName,
-				Tag:   defaultMasterImageTag,
+				Tag:   defaultImageTag,
 			},
 			WorkerConfig: loadTestV1.ImageDetails{
 				Image: defaultWorkerImageName,
-				Tag:   defaultWorkerImageTag,
+				Tag:   defaultImageTag,
 			},
 		},
 		Status: loadTestV1.LoadTestStatus{
@@ -215,7 +215,7 @@ func TestTransformLoadTestSpec(t *testing.T) {
 		assert.Equal(t, spec.MasterConfig.Image, "master-image")
 		assert.Equal(t, spec.MasterConfig.Tag, "master-tag")
 		assert.Equal(t, spec.WorkerConfig.Image, "worker-image")
-		assert.Equal(t, spec.WorkerConfig.Tag, "worker-tag")
+		assert.Equal(t, spec.MasterConfig.Tag, spec.WorkerConfig.Tag)
 	})
 }
 
@@ -224,17 +224,16 @@ func TestSetDefaults(t *testing.T) {
 		jmeter := &Backend{
 			config: &Config{
 				MasterImageName: "my-master-image-name",
-				MasterImageTag:  "my-master-image-tag",
 				WorkerImageName: "my-worker-image-name",
-				WorkerImageTag:  "my-worker-image-tag",
+				ImageTag:        "my-image-tag",
 			},
 		}
 		jmeter.SetDefaults()
 
 		assert.Equal(t, jmeter.workerConfig.Image, "my-worker-image-name")
-		assert.Equal(t, jmeter.workerConfig.Tag, "my-worker-image-tag")
+		assert.Equal(t, jmeter.workerConfig.Tag, "my-image-tag")
 		assert.Equal(t, jmeter.masterConfig.Image, "my-master-image-name")
-		assert.Equal(t, jmeter.masterConfig.Tag, "my-master-image-tag")
+		assert.Equal(t, jmeter.masterConfig.Tag, "my-image-tag")
 	})
 
 	t.Run("No default", func(t *testing.T) {
@@ -246,8 +245,8 @@ func TestSetDefaults(t *testing.T) {
 		jmeter.SetDefaults()
 
 		assert.Equal(t, jmeter.masterConfig.Image, defaultMasterImageName)
-		assert.Equal(t, jmeter.masterConfig.Tag, defaultMasterImageTag)
+		assert.Equal(t, jmeter.masterConfig.Tag, defaultImageTag)
 		assert.Equal(t, jmeter.workerConfig.Image, defaultWorkerImageName)
-		assert.Equal(t, jmeter.workerConfig.Tag, defaultWorkerImageTag)
+		assert.Equal(t, jmeter.workerConfig.Tag, defaultImageTag)
 	})
 }

--- a/pkg/backends/jmeter/config.go
+++ b/pkg/backends/jmeter/config.go
@@ -7,17 +7,16 @@ import (
 // Config specific to JMeter backend
 type Config struct {
 	MasterImageName         string        `envconfig:"JMETER_MASTER_IMAGE_NAME" default:"hellofresh/kangal-jmeter-master"`
-	MasterImageTag          string        `envconfig:"JMETER_MASTER_IMAGE_TAG" default:"latest"`
 	MasterCPULimits         string        `envconfig:"JMETER_MASTER_CPU_LIMITS"`
 	MasterCPURequests       string        `envconfig:"JMETER_MASTER_CPU_REQUESTS"`
 	MasterMemoryLimits      string        `envconfig:"JMETER_MASTER_MEMORY_LIMITS"`
 	MasterMemoryRequests    string        `envconfig:"JMETER_MASTER_MEMORY_REQUESTS"`
 	WorkerImageName         string        `envconfig:"JMETER_WORKER_IMAGE_NAME" default:"hellofresh/kangal-jmeter-worker"`
-	WorkerImageTag          string        `envconfig:"JMETER_WORKER_IMAGE_TAG" default:"latest"`
 	WorkerCPULimits         string        `envconfig:"JMETER_WORKER_CPU_LIMITS"`
 	WorkerCPURequests       string        `envconfig:"JMETER_WORKER_CPU_REQUESTS"`
 	WorkerMemoryLimits      string        `envconfig:"JMETER_WORKER_MEMORY_LIMITS"`
 	WorkerMemoryRequests    string        `envconfig:"JMETER_WORKER_MEMORY_REQUESTS"`
+	ImageTag                string        `envconfig:"JMETER_IMAGE_TAG" default:"latest"`
 	TestDataDecompressImage string        `envconfig:"JMETER_TESTDATA_DECOMPRESS_IMAGE" default:"alpine:latest"`
 	RemoteCustomDataImage   string        `envconfig:"JMETER_WORKER_REMOTE_CUSTOM_DATA_IMAGE" default:"rclone/rclone:latest"`
 	WaitForResourceTimeout  time.Duration `envconfig:"WAIT_FOR_RESOURCE_TIMEOUT" default:"30s"`

--- a/pkg/backends/jmeter/resources.go
+++ b/pkg/backends/jmeter/resources.go
@@ -206,7 +206,7 @@ func (b *Backend) NewPod(loadTest loadTestV1.LoadTest, i int, configMap *coreV1.
 	imageRef := fmt.Sprintf("%s:%s", loadTest.Spec.WorkerConfig.Image, loadTest.Spec.WorkerConfig.Tag)
 	if loadTest.Spec.WorkerConfig.Image == "" || loadTest.Spec.WorkerConfig.Tag == "" {
 		imageRef = fmt.Sprintf("%s:%s", b.workerConfig.Image, b.workerConfig.Tag)
-		logger.Debug("Loadtest.Spec.WorkerConfig is empty; using worker image from config", zap.String("imageRef", imageRef))
+		logger.Debug("Loadtest.Spec.WorkerConfig is empty; using default worker image from config", zap.String("imageRef", imageRef))
 	}
 
 	pod := &coreV1.Pod{
@@ -367,7 +367,7 @@ func (b *Backend) NewJMeterMasterJob(loadTest loadTestV1.LoadTest, reportURL str
 	imageRef := fmt.Sprintf("%s:%s", loadTest.Spec.MasterConfig.Image, loadTest.Spec.MasterConfig.Tag)
 	if loadTest.Spec.MasterConfig.Image == "" || loadTest.Spec.MasterConfig.Tag == "" {
 		imageRef = fmt.Sprintf("%s:%s", b.masterConfig.Image, b.masterConfig.Tag)
-		logger.Debug("Loadtest.Spec.MasterConfig is empty; using master image from config", zap.String("imageRef", imageRef))
+		logger.Debug("Loadtest.Spec.MasterConfig is empty; using default master image from config", zap.String("imageRef", imageRef))
 	}
 
 	jMeterEnvVars := []coreV1.EnvVar{

--- a/pkg/backends/jmeter/resources_test.go
+++ b/pkg/backends/jmeter/resources_test.go
@@ -110,11 +110,11 @@ func TestPodResourceConfiguration(t *testing.T) {
 		Spec: loadTestV1.LoadTestSpec{
 			MasterConfig: loadTestV1.ImageDetails{
 				Image: defaultMasterImageName,
-				Tag:   defaultMasterImageTag,
+				Tag:   defaultImageTag,
 			},
 			WorkerConfig: loadTestV1.ImageDetails{
 				Image: defaultWorkerImageName,
-				Tag:   defaultWorkerImageTag,
+				Tag:   defaultImageTag,
 			},
 		},
 	}


### PR DESCRIPTION
**Current behaviour:** 
Kangal allows to use custom docker images when creating a loadtest object. For JMeter backend docker images for master and worker pods are defined separately. But they should still have the same tag to avoid inconsistency when running master and worker with different JMeter versions.

**Solution:**
This PR removes the usage of separate `MasterImageTag` and `WorkerImageTag` in code. Now the same tag will be used for both master and worker pods.