### PR TITLE
Typo in docs for CPU limit

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -30,7 +30,7 @@
 |----------------------------------------------------|--------------------------------------------------------------------------|-----------------------------------|
 | `JMETER_MASTER_IMAGE_NAME`                         | JMeter master image name/repository                                      | `hellofresh/kangal-jmeter-master` |
 | `JMETER_MASTER_IMAGE_TAG`                          | Tag of the JMeter master image above                                     | `latest`                          |
-| `JMETER_MASTER_CPU_LIMIT`                          | Master CPU limit                                                         |                                   |
+| `JMETER_MASTER_CPU_LIMITS`                         | Master CPU limits                                                         |                                   |
 | `JMETER_MASTER_CPU_REQUESTS`                       | Master CPU requests                                                      |                                   |
 | `JMETER_MASTER_MEMORY_LIMITS`                      | Master memory limits                                                     |                                   |
 | `JMETER_MASTER_MEMORY_REQUESTS`                    | Master memory requests                                                   |                                   |


### PR DESCRIPTION
Just got bitten by this. Here is a PR for fixing a typo in the docs. The variable name in `pkg/backends/jmeter/config.go`  is named `JMETER_MASTER_CPU_LIMITS`, not `JMETER_MASTER_CPU_LIMIT`.