### PR TITLE
Exposes expected number of workers to JMeter master

### DIFF
--- a/pkg/backends/jmeter/resources.go
+++ b/pkg/backends/jmeter/resources.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 
 	"go.uber.org/zap"
@@ -374,6 +375,10 @@ func (b *Backend) NewJMeterMasterJob(loadTest loadTestV1.LoadTest, reportURL str
 		{
 			Name:  "WORKER_SVC_NAME",
 			Value: loadTestWorkerServiceName,
+		},
+		{
+			Name:  "WORKER_TOTAL",
+			Value: strconv.Itoa(int(*loadTest.Spec.DistributedPods)),
 		},
 		{
 			Name:  "USE_WORKERS",

--- a/pkg/backends/jmeter/resources_test.go
+++ b/pkg/backends/jmeter/resources_test.go
@@ -106,6 +106,7 @@ func TestGetNamespaceFromInvalidName(t *testing.T) {
 }
 
 func TestPodResourceConfiguration(t *testing.T) {
+	var two int32 = 2
 	lt := loadTestV1.LoadTest{
 		Spec: loadTestV1.LoadTestSpec{
 			MasterConfig: loadTestV1.ImageDetails{
@@ -116,6 +117,7 @@ func TestPodResourceConfiguration(t *testing.T) {
 				Image: defaultWorkerImageName,
 				Tag:   defaultWorkerImageTag,
 			},
+			DistributedPods: &two,
 		},
 	}
 


### PR DESCRIPTION
This is part of a fix for #332. It injects the number of expected workers into the JMeter master job so that the launcher script knows for how many to wait for before starting JMeter itself.

There is a potential problem with dereferencing the pointer `*loadTest.Spec.DistributedPods` without checking for nil, but I've assumed it'll be set because `NewTestdataConfigMap` is called prior to this function and it already seems to use it without checking.