### PR TITLE
feat: Modify registry from DockerHub to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Setup Golang
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6
         with:
           go-version: '^1.17'
 
@@ -33,7 +33,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v6
         if: success() && startsWith(github.ref, 'refs/tags/')
         with:
           version: v1.2.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,13 @@ on:
     types:
       - created
 
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+
 jobs:
   goreleaser:
     name: Build binary and Docker image
@@ -18,13 +25,12 @@ jobs:
         with:
           go-version: '^1.17'
 
-      - name: Docker Login
-        if: success() && startsWith(github.ref, 'refs/tags/')
-        env:
-          DOCKER_USERNAME: hellofreshtech
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: |
-          echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,8 +19,8 @@ dockers:
   - goos: linux
     goarch: amd64
     image_templates:
-      - "hellofresh/kangal:latest"
-      - "hellofresh/kangal:{{.Tag}}"
+      - "{{.Env.REGISTRY}}/hellofresh/kangal:latest"
+      - "{{.Env.REGISTRY}}/hellofresh/kangal:{{.Tag}}"
     dockerfile: Dockerfile
     extra_files:
       - openapi.json

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,8 +19,8 @@ dockers:
   - goos: linux
     goarch: amd64
     image_templates:
-      - "{{.Env.REGISTRY}}/hellofresh/kangal:latest"
-      - "{{.Env.REGISTRY}}/hellofresh/kangal:{{.Tag}}"
+      - "ghcr.io/hellofresh/kangal:latest"
+      - "ghcr.io/hellofresh/kangal:{{.Tag}}"
     dockerfile: Dockerfile
     extra_files:
       - openapi.json

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ ___
 
 > [!WARNING]
 > Kangal's upload to DockerHub has been removed
-> We apologize for the disruption, but you can get the image from `ghcr.io/hellofresh/kangal` from January 31st
+> We apologize for the disruption, but you can get the image from `ghcr.io/hellofresh/kangal` from January 31st 2026
 >
 > The registry in DockerHub will not be available from February-onwards
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 Run performance tests in Kubernetes cluster with Kangal.
 ___
 
+> [!WARNING]
+> Kangal's upload to DockerHub has been removed
+> We apologize for the disruption, but you can get the image from `ghcr.io/hellofresh/kangal` from January 31st
+>
+> The registry in DockerHub will not be available from February-onwards
+
 ## Table of content
 - [Why Kangal?](#why-kangal)
 - [Key features](#key-features)

--- a/charts/kangal/Chart.yaml
+++ b/charts/kangal/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - performance tests
   - tests runner
 name: kangal
-version: 2.3.0
+version: 2.3.1
 home: https://github.com/hellofresh/kangal
 icon: https://raw.githubusercontent.com/hellofresh/kangal/master/logo.svg
 maintainers:

--- a/charts/kangal/values.yaml
+++ b/charts/kangal/values.yaml
@@ -11,7 +11,7 @@ proxy:
   replicaCount: 2
 
   image:
-    repository: hellofresh/kangal
+    repository: ghcr.io/hellofresh/kangal
     tag: latest
     pullPolicy: Always
 

--- a/charts/kangal/values.yaml
+++ b/charts/kangal/values.yaml
@@ -33,7 +33,8 @@ proxy:
     hosts:
       http: kangal-proxy.example.com
 
-  resources: {}
+  resources:
+    {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -107,7 +108,8 @@ controller:
   containerPorts:
     http: 8080
 
-  resources: {}
+  resources:
+    {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -187,11 +189,11 @@ configMap:
   AWS_ENDPOINT_URL: s3.us-east-1.amazonaws.com
   AWS_BUCKET_NAME: my-bucket
   AWS_USE_HTTPS: "false"
-  GHZ_IMAGE_NAME: hellofresh/kangal-ghz
+  GHZ_IMAGE_NAME: ghcr.io/hellofresh/kangal-ghz
   GHZ_IMAGE_TAG: latest
-  JMETER_MASTER_IMAGE_NAME: hellofresh/kangal-jmeter-master
+  JMETER_MASTER_IMAGE_NAME: ghcr.io/hellofresh/kangal-jmeter-master
   JMETER_MASTER_IMAGE_TAG: latest
-  JMETER_WORKER_IMAGE_NAME: hellofresh/kangal-jmeter-worker
+  JMETER_WORKER_IMAGE_NAME: ghcr.io/hellofresh/kangal-jmeter-worker
   JMETER_WORKER_IMAGE_TAG: latest
   LOCUST_IMAGE_NAME: locustio/locust
   LOCUST_IMAGE_TAG: "1.3.0"

--- a/charts/kangal/values.yaml
+++ b/charts/kangal/values.yaml
@@ -191,9 +191,9 @@ configMap:
   AWS_USE_HTTPS: "false"
   GHZ_IMAGE_NAME: ghcr.io/hellofresh/kangal-ghz
   GHZ_IMAGE_TAG: latest
-  JMETER_MASTER_IMAGE_NAME: ghcr.io/hellofresh/kangal-jmeter-master
+  JMETER_MASTER_IMAGE_NAME: ghcr.io/hellofresh/kangal-jmeter/master
   JMETER_MASTER_IMAGE_TAG: latest
-  JMETER_WORKER_IMAGE_NAME: ghcr.io/hellofresh/kangal-jmeter-worker
+  JMETER_WORKER_IMAGE_NAME: ghcr.io/hellofresh/kangal-jmeter/worker
   JMETER_WORKER_IMAGE_TAG: latest
   LOCUST_IMAGE_NAME: locustio/locust
   LOCUST_IMAGE_TAG: "1.3.0"

--- a/charts/kangal/values.yaml
+++ b/charts/kangal/values.yaml
@@ -89,7 +89,7 @@ controller:
   replicaCount: 1
 
   image:
-    repository: hellofresh/kangal
+    repository: ghcr.io/hellofresh/kangal
     tag: latest
     pullPolicy: Always
 


### PR DESCRIPTION
Modify registry from DockerHub to GHCR

DockerHub images will stop working in February, so we must upload to GHCR instead