### PR TITLE
E2E test (temporary): Sonar Integration Gate on a dormant, unintegrated repo

### DIFF
--- a/.github/workflows/e2e-sonar-integration-gate-test.yml
+++ b/.github/workflows/e2e-sonar-integration-gate-test.yml
@@ -1,0 +1,14 @@
+# Temporary — validates hellofresh/sonarqube-automation#212's staleness fix
+# against a genuinely dormant repo that isn't Sonar-integrated at all. Safe
+# to delete; not meant to be merged.
+name: "E2E test (temporary): Sonar Integration Gate on a dormant repo"
+
+on:
+  pull_request:
+
+jobs:
+  sonar-integration-gate:
+    uses: hellofresh/sonarqube-automation/.github/workflows/reusable.yml@RES-1145-sonarqube-api-detection
+    with:
+      mode: informative
+    secrets: inherit


### PR DESCRIPTION
Temporary — validates hellofresh/sonarqube-automation#212's staleness-detection fix against this repo, which is genuinely dormant (master last touched 2026-01-28) and has no SonarQube integration. Expect `integrated=false`, `error=false`, informative comment, no crash. Draft PR, not for merging — will be closed and the branch deleted once observed.